### PR TITLE
중복선택 버튼 컴포넌트 (체크박스) 작성

### DIFF
--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -7,14 +7,19 @@ import CheckBoxGroup from "@/component/common/CheckBox/CheckBoxGroup";
 import Radio from "@/component/common/RadioButton/Radio";
 import RadioButtonGroup from "@/component/common/RadioButton/RadioButtonGroup";
 import { useCheckBox } from "@/hooks/useCheckBox";
+import { useRadioButton } from "@/hooks/useRadioButton";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 
 export default function Staging() {
-  const [selectedValue, setSelectedValue] = useState<string>();
-  const { isChecked, toggle, selectedValues } = useCheckBox();
+  const [isRadioChecked, onChange, selectedValue] = useRadioButton();
+  const [isCheckBoxChecked, toggle, selectedValues] = useCheckBox();
 
   useEffect(() => {
-    console.log("selectedValues", selectedValues);
+    console.log("라디오 버튼 선택 value:", selectedValue);
+  }, [selectedValue]);
+
+  useEffect(() => {
+    console.log("체크박스 선택 values:", selectedValues);
   }, [selectedValues]);
 
   return (
@@ -26,7 +31,7 @@ export default function Staging() {
 
       <br />
       <h3>라디오버튼</h3>
-      <RadioButtonGroup radioName={"프로젝트 주기"} selectedValue={selectedValue} onChange={setSelectedValue}>
+      <RadioButtonGroup isChecked={isRadioChecked} onChange={onChange} radioName={"프로젝트 주기"}>
         <Radio value={"0"}>주 1회</Radio>
         <Radio value={"1"}>월 1회</Radio>
         <Radio value={"2"}>분기별</Radio>
@@ -35,7 +40,7 @@ export default function Staging() {
 
       <br />
       <h3>체크박스</h3>
-      <CheckBoxGroup isChecked={isChecked} onChange={toggle}>
+      <CheckBoxGroup isChecked={isCheckBoxChecked} onChange={toggle}>
         <CheckBox value={"00"}>주 1회</CheckBox>
         <CheckBox value={"10"}>월 1회</CheckBox>
         <CheckBox value={"20"}>분기별</CheckBox>

--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -1,14 +1,26 @@
+import { useState } from "react";
+
 import Button from "@/component/Button/Button.tsx";
 import { ButtonProvider } from "@/component/Button/ButtonProvider.tsx";
+import Radio from "@/component/common/RadioButton/Radio";
+import RadioButtonGroup from "@/component/common/RadioButton/RadioButtonGroup";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 
 export default function Staging() {
+  const [selectedValue, setSelectedValue] = useState<string>();
   return (
     <DefaultLayout>
       <Button> 그냥 그저 그런 버튼 </Button>
       <Button colorSchema={"gray"}> 그냥 그저 그런 버튼 </Button>
       <Button colorSchema={"sky"}> 그냥 그저 그런 버튼 </Button>
       <Button colorSchema={"primary"}> 그냥 그저 그런 버튼 </Button>
+
+      <RadioButtonGroup radioName={"프로젝트 주기"} selectedValue={selectedValue} onChange={setSelectedValue}>
+        <Radio value={"0"}>주 1회</Radio>
+        <Radio value={"1"}>월 1회</Radio>
+        <Radio value={"2"}>분기별</Radio>
+        <Radio value={"3"}>프로젝트 끝난 후</Radio>
+      </RadioButtonGroup>
 
       <ButtonProvider>
         <ButtonProvider.Primary>기본 버튼</ButtonProvider.Primary>

--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import Button from "@/component/Button/Button.tsx";
 import { ButtonProvider } from "@/component/Button/ButtonProvider.tsx";

--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -1,13 +1,22 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import Button from "@/component/Button/Button.tsx";
 import { ButtonProvider } from "@/component/Button/ButtonProvider.tsx";
+import CheckBox from "@/component/common/CheckBox/CheckBox";
+import CheckBoxGroup from "@/component/common/CheckBox/CheckBoxGroup";
 import Radio from "@/component/common/RadioButton/Radio";
 import RadioButtonGroup from "@/component/common/RadioButton/RadioButtonGroup";
+import { useCheckBox } from "@/hooks/useCheckBox";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 
 export default function Staging() {
   const [selectedValue, setSelectedValue] = useState<string>();
+  const { isChecked, toggle, selectedValues } = useCheckBox();
+
+  useEffect(() => {
+    console.log("selectedValues", selectedValues);
+  }, [selectedValues]);
+
   return (
     <DefaultLayout>
       <Button> 그냥 그저 그런 버튼 </Button>
@@ -15,12 +24,23 @@ export default function Staging() {
       <Button colorSchema={"sky"}> 그냥 그저 그런 버튼 </Button>
       <Button colorSchema={"primary"}> 그냥 그저 그런 버튼 </Button>
 
+      <br />
+      <h3>라디오버튼</h3>
       <RadioButtonGroup radioName={"프로젝트 주기"} selectedValue={selectedValue} onChange={setSelectedValue}>
         <Radio value={"0"}>주 1회</Radio>
         <Radio value={"1"}>월 1회</Radio>
         <Radio value={"2"}>분기별</Radio>
         <Radio value={"3"}>프로젝트 끝난 후</Radio>
       </RadioButtonGroup>
+
+      <br />
+      <h3>체크박스</h3>
+      <CheckBoxGroup isChecked={isChecked} onChange={toggle}>
+        <CheckBox value={"00"}>주 1회</CheckBox>
+        <CheckBox value={"10"}>월 1회</CheckBox>
+        <CheckBox value={"20"}>분기별</CheckBox>
+        <CheckBox value={"30"}>프로젝트 끝난 후</CheckBox>
+      </CheckBoxGroup>
 
       <ButtonProvider>
         <ButtonProvider.Primary>기본 버튼</ButtonProvider.Primary>

--- a/src/component/common/CheckBox/CheckBox.tsx
+++ b/src/component/common/CheckBox/CheckBox.tsx
@@ -1,8 +1,9 @@
 import { css } from "@emotion/react";
 import { useContext } from "react";
 
+import { CheckBoxContext } from "./CheckBoxGroup";
+
 import ListItemCard from "@/component/common/Card/ListItemCard";
-import { CheckBoxContext } from "@/store/context/CheckBoxContext";
 
 type CheckBoxProps = {
   value: string;

--- a/src/component/common/CheckBox/CheckBox.tsx
+++ b/src/component/common/CheckBox/CheckBox.tsx
@@ -1,0 +1,45 @@
+import { css } from "@emotion/react";
+import { useContext } from "react";
+
+import ListItemCard from "@/component/common/Card/ListItemCard";
+import { CheckBoxContext } from "@/store/context/CheckBoxContext";
+
+type CheckBoxProps = {
+  value: string;
+  children: React.ReactNode;
+};
+
+const CheckBox = ({ value, children }: CheckBoxProps) => {
+  const checkboxContext = useContext(CheckBoxContext);
+  return (
+    <ListItemCard variant={checkboxContext?.isChecked(value) ? "theme" : "default"}>
+      <label
+        htmlFor={value}
+        css={css`
+          font-weight: 600;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          height: 100%;
+          width: 100%;
+          cursor: pointer;
+        `}
+      >
+        {children}
+      </label>
+      <input
+        type="checkbox"
+        id={value}
+        value={value}
+        onChange={(e) => {
+          checkboxContext?.onChange && checkboxContext.onChange(e.target.value);
+        }}
+        css={css`
+          display: none;
+        `}
+      />
+    </ListItemCard>
+  );
+};
+
+export default CheckBox;

--- a/src/component/common/CheckBox/CheckBoxGroup.tsx
+++ b/src/component/common/CheckBox/CheckBoxGroup.tsx
@@ -6,7 +6,7 @@ type CheckBoxGroupProps = {
   children: React.ReactNode;
 } & CheckBoxContextState;
 
-const CheckBoxGroup = ({ children, ...rest }: CheckBoxGroupProps) => {
+const CheckBoxGroup = ({ children, ...props }: CheckBoxGroupProps) => {
   return (
     <div
       css={css`
@@ -15,7 +15,7 @@ const CheckBoxGroup = ({ children, ...rest }: CheckBoxGroupProps) => {
         gap: 1rem;
       `}
     >
-      <CheckBoxContext.Provider value={rest}>{children}</CheckBoxContext.Provider>
+      <CheckBoxContext.Provider value={props}>{children}</CheckBoxContext.Provider>
     </div>
   );
 };

--- a/src/component/common/CheckBox/CheckBoxGroup.tsx
+++ b/src/component/common/CheckBox/CheckBoxGroup.tsx
@@ -1,6 +1,12 @@
 import { css } from "@emotion/react";
+import { createContext } from "react";
 
-import { CheckBoxContext, CheckBoxContextState } from "@/store/context/CheckBoxContext";
+export type CheckBoxContextState = {
+  isChecked: (value: string) => boolean;
+  onChange: (value: string) => void;
+};
+
+export const CheckBoxContext = createContext<CheckBoxContextState | undefined>(undefined);
 
 type CheckBoxGroupProps = {
   children: React.ReactNode;

--- a/src/component/common/CheckBox/CheckBoxGroup.tsx
+++ b/src/component/common/CheckBox/CheckBoxGroup.tsx
@@ -1,12 +1,10 @@
 import { css } from "@emotion/react";
 
-import { CheckBoxContext } from "@/store/context/CheckBoxContext";
+import { CheckBoxContext, CheckBoxContextState } from "@/store/context/CheckBoxContext";
 
 type CheckBoxGroupProps = {
   children: React.ReactNode;
-  isChecked: (value: string) => boolean;
-  onChange: (value: string) => void;
-};
+} & CheckBoxContextState;
 
 const CheckBoxGroup = ({ children, ...rest }: CheckBoxGroupProps) => {
   return (

--- a/src/component/common/CheckBox/CheckBoxGroup.tsx
+++ b/src/component/common/CheckBox/CheckBoxGroup.tsx
@@ -1,0 +1,25 @@
+import { css } from "@emotion/react";
+
+import { CheckBoxContext } from "@/store/context/CheckBoxContext";
+
+type CheckBoxGroupProps = {
+  children: React.ReactNode;
+  isChecked: (value: string) => boolean;
+  onChange: (value: string) => void;
+};
+
+const CheckBoxGroup = ({ children, ...rest }: CheckBoxGroupProps) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      `}
+    >
+      <CheckBoxContext.Provider value={rest}>{children}</CheckBoxContext.Provider>
+    </div>
+  );
+};
+
+export default CheckBoxGroup;

--- a/src/component/common/RadioButton/Radio.tsx
+++ b/src/component/common/RadioButton/Radio.tsx
@@ -1,8 +1,9 @@
 import { css } from "@emotion/react";
 import { useContext } from "react";
 
+import { RadioContext } from "./RadioButtonGroup";
+
 import ListItemCard from "@/component/common/Card/ListItemCard";
-import { RadioContext } from "@/store/context/RadioContext";
 
 type RadioProps = {
   value: string;

--- a/src/component/common/RadioButton/Radio.tsx
+++ b/src/component/common/RadioButton/Radio.tsx
@@ -12,7 +12,7 @@ type RadioProps = {
 const Radio = ({ value, children }: RadioProps) => {
   const radioContext = useContext(RadioContext);
   return (
-    <ListItemCard variant={radioContext?.selectedValue === value ? "theme" : "default"}>
+    <ListItemCard variant={radioContext?.isChecked(value) ? "theme" : "default"}>
       <label
         htmlFor={value}
         css={css`

--- a/src/component/common/RadioButton/Radio.tsx
+++ b/src/component/common/RadioButton/Radio.tsx
@@ -22,6 +22,7 @@ const Radio = ({ value, children }: RadioProps) => {
           align-items: center;
           height: 100%;
           width: 100%;
+          cursor: pointer;
         `}
       >
         {children}

--- a/src/component/common/RadioButton/RadioButtonGroup.tsx
+++ b/src/component/common/RadioButton/RadioButtonGroup.tsx
@@ -1,13 +1,10 @@
 import { css } from "@emotion/react";
 
-import { RadioContext } from "@/store/context/RadioContext";
+import { RadioContext, RadioContextState } from "@/store/context/RadioContext";
 
 type RadioButtonGroupProps = {
   children: React.ReactNode;
-  isChecked: (value: string) => boolean;
-  onChange: (value: string) => void;
-  radioName: string;
-};
+} & RadioContextState;
 
 const RadioButtonGroup = ({ children, ...rest }: RadioButtonGroupProps) => {
   return (

--- a/src/component/common/RadioButton/RadioButtonGroup.tsx
+++ b/src/component/common/RadioButton/RadioButtonGroup.tsx
@@ -1,6 +1,13 @@
 import { css } from "@emotion/react";
+import { createContext } from "react";
 
-import { RadioContext, RadioContextState } from "@/store/context/RadioContext";
+export type RadioContextState = {
+  radioName: string;
+  isChecked: (value: string) => boolean;
+  onChange: (value: string) => void;
+};
+
+export const RadioContext = createContext<RadioContextState | undefined>(undefined);
 
 type RadioButtonGroupProps = {
   children: React.ReactNode;

--- a/src/component/common/RadioButton/RadioButtonGroup.tsx
+++ b/src/component/common/RadioButton/RadioButtonGroup.tsx
@@ -6,7 +6,7 @@ type RadioButtonGroupProps = {
   children: React.ReactNode;
 } & RadioContextState;
 
-const RadioButtonGroup = ({ children, ...rest }: RadioButtonGroupProps) => {
+const RadioButtonGroup = ({ children, ...props }: RadioButtonGroupProps) => {
   return (
     <div
       css={css`
@@ -15,7 +15,7 @@ const RadioButtonGroup = ({ children, ...rest }: RadioButtonGroupProps) => {
         gap: 1rem;
       `}
     >
-      <RadioContext.Provider value={rest}>{children}</RadioContext.Provider>
+      <RadioContext.Provider value={props}>{children}</RadioContext.Provider>
     </div>
   );
 };

--- a/src/component/common/RadioButton/RadioButtonGroup.tsx
+++ b/src/component/common/RadioButton/RadioButtonGroup.tsx
@@ -4,8 +4,8 @@ import { RadioContext } from "@/store/context/RadioContext";
 
 type RadioButtonGroupProps = {
   children: React.ReactNode;
-  selectedValue: string | undefined;
-  onChange: React.Dispatch<React.SetStateAction<string | undefined>>;
+  isChecked: (value: string) => boolean;
+  onChange: (value: string) => void;
   radioName: string;
 };
 

--- a/src/hooks/useCheckBox.ts
+++ b/src/hooks/useCheckBox.ts
@@ -1,9 +1,11 @@
 import { useState } from "react";
 
-export const useCheckBox = () => {
+type UseCheckBoxReturn = [(value: string) => boolean, (value: string) => void, string[]];
+
+export const useCheckBox = (): UseCheckBoxReturn => {
   const [checkedStates, setCheckedStates] = useState<Record<string, boolean>>({});
   const isChecked = (value: string) => checkedStates[value];
   const toggle = (value: string) => setCheckedStates((prev) => ({ ...prev, [value]: !prev[value] }));
   const selectedValues = Object.keys(checkedStates).filter((key) => checkedStates[key]);
-  return { isChecked, toggle, selectedValues };
+  return [isChecked, toggle, selectedValues];
 };

--- a/src/hooks/useCheckBox.ts
+++ b/src/hooks/useCheckBox.ts
@@ -1,13 +1,10 @@
 import { useState } from "react";
 
-import { CheckBoxContextState } from "@/store/context/CheckBoxContext";
-
-type UseCheckBoxReturn = [CheckBoxContextState["isChecked"], CheckBoxContextState["onChange"], string[]];
-
-export const useCheckBox = (): UseCheckBoxReturn => {
+export const useCheckBox = () => {
   const [checkedStates, setCheckedStates] = useState<Record<string, boolean>>({});
   const isChecked = (value: string) => checkedStates[value];
   const toggle = (value: string) => setCheckedStates((prev) => ({ ...prev, [value]: !prev[value] }));
   const selectedValues = Object.keys(checkedStates).filter((key) => checkedStates[key]);
-  return [isChecked, toggle, selectedValues];
+
+  return [isChecked, toggle, selectedValues] as const;
 };

--- a/src/hooks/useCheckBox.ts
+++ b/src/hooks/useCheckBox.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
-type UseCheckBoxReturn = [(value: string) => boolean, (value: string) => void, string[]];
+import { CheckBoxContextState } from "@/store/context/CheckBoxContext";
+
+type UseCheckBoxReturn = [CheckBoxContextState["isChecked"], CheckBoxContextState["onChange"], string[]];
 
 export const useCheckBox = (): UseCheckBoxReturn => {
   const [checkedStates, setCheckedStates] = useState<Record<string, boolean>>({});

--- a/src/hooks/useCheckBox.ts
+++ b/src/hooks/useCheckBox.ts
@@ -1,0 +1,9 @@
+import { useState } from "react";
+
+export const useCheckBox = () => {
+  const [checkedStates, setCheckedStates] = useState<Record<string, boolean>>({});
+  const isChecked = (value: string) => checkedStates[value];
+  const toggle = (value: string) => setCheckedStates((prev) => ({ ...prev, [value]: !prev[value] }));
+  const selectedValues = Object.keys(checkedStates).filter((key) => checkedStates[key]);
+  return { isChecked, toggle, selectedValues };
+};

--- a/src/hooks/useRadioButton.ts
+++ b/src/hooks/useRadioButton.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
-type UseRadioButtonReturn = [(value: string) => boolean, (value: string) => void, string | undefined];
+import { RadioContextState } from "@/store/context/RadioContext";
+
+type UseRadioButtonReturn = [RadioContextState["isChecked"], RadioContextState["onChange"], string | undefined];
 
 export const useRadioButton = (): UseRadioButtonReturn => {
   const [selectedValue, setSelectedValue] = useState<string>();

--- a/src/hooks/useRadioButton.ts
+++ b/src/hooks/useRadioButton.ts
@@ -1,13 +1,9 @@
 import { useState } from "react";
 
-import { RadioContextState } from "@/store/context/RadioContext";
-
-type UseRadioButtonReturn = [RadioContextState["isChecked"], RadioContextState["onChange"], string | undefined];
-
-export const useRadioButton = (): UseRadioButtonReturn => {
+export const useRadioButton = () => {
   const [selectedValue, setSelectedValue] = useState<string>();
   const isChecked = (value: string) => selectedValue === value;
   const onChange = (value: string) => setSelectedValue(value);
 
-  return [isChecked, onChange, selectedValue];
+  return [isChecked, onChange, selectedValue] as const;
 };

--- a/src/hooks/useRadioButton.ts
+++ b/src/hooks/useRadioButton.ts
@@ -1,0 +1,11 @@
+import { useState } from "react";
+
+type UseRadioButtonReturn = [(value: string) => boolean, (value: string) => void, string | undefined];
+
+export const useRadioButton = (): UseRadioButtonReturn => {
+  const [selectedValue, setSelectedValue] = useState<string>();
+  const isChecked = (value: string) => selectedValue === value;
+  const onChange = (value: string) => setSelectedValue(value);
+
+  return [isChecked, onChange, selectedValue];
+};

--- a/src/layout/GlobalLayout.tsx
+++ b/src/layout/GlobalLayout.tsx
@@ -17,7 +17,7 @@ export default function GlobalLayout() {
 
         display: flex;
         flex-direction: column;
-        background-color: #f1f3f5;
+        background-color: #ffffff;
       `}
     >
       <Outlet />

--- a/src/store/context/CheckBoxContext.ts
+++ b/src/store/context/CheckBoxContext.ts
@@ -1,8 +1,8 @@
 import { createContext } from "react";
 
-type CheckBoxContext = {
+export type CheckBoxContextState = {
   isChecked: (value: string) => boolean;
   onChange: (value: string) => void;
 };
 
-export const CheckBoxContext = createContext<CheckBoxContext | undefined>(undefined);
+export const CheckBoxContext = createContext<CheckBoxContextState | undefined>(undefined);

--- a/src/store/context/CheckBoxContext.ts
+++ b/src/store/context/CheckBoxContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+
+type CheckBoxContext = {
+  isChecked: (value: string) => boolean;
+  onChange: (value: string) => void;
+};
+
+export const CheckBoxContext = createContext<CheckBoxContext | undefined>(undefined);

--- a/src/store/context/CheckBoxContext.ts
+++ b/src/store/context/CheckBoxContext.ts
@@ -1,8 +1,0 @@
-import { createContext } from "react";
-
-export type CheckBoxContextState = {
-  isChecked: (value: string) => boolean;
-  onChange: (value: string) => void;
-};
-
-export const CheckBoxContext = createContext<CheckBoxContextState | undefined>(undefined);

--- a/src/store/context/RadioContext.ts
+++ b/src/store/context/RadioContext.ts
@@ -1,9 +1,0 @@
-import { createContext } from "react";
-
-export type RadioContextState = {
-  radioName: string;
-  isChecked: (value: string) => boolean;
-  onChange: (value: string) => void;
-};
-
-export const RadioContext = createContext<RadioContextState | undefined>(undefined);

--- a/src/store/context/RadioContext.ts
+++ b/src/store/context/RadioContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-type RadioContextState = {
+export type RadioContextState = {
   radioName: string;
   isChecked: (value: string) => boolean;
   onChange: (value: string) => void;

--- a/src/store/context/RadioContext.ts
+++ b/src/store/context/RadioContext.ts
@@ -2,8 +2,8 @@ import { createContext } from "react";
 
 type RadioContextState = {
   radioName: string;
-  selectedValue?: string;
-  onChange?: (value: string) => void;
+  isChecked: (value: string) => boolean;
+  onChange: (value: string) => void;
 };
 
 export const RadioContext = createContext<RadioContextState | undefined>(undefined);


### PR DESCRIPTION
> ### 중복선택 버튼 컴포넌트 (체크박스) 작성
---

### 🏄🏼‍♂️‍ Summary (요약)

- 중복 선택이 가능한 버튼그룹 (체크박스) 컴포넌트 개발
- 중복 선택이 불가한 버튼그룹 (라디오버튼) 컴포넌트 리팩토링 (체크박스와 사용방식 통일)

### 🫨 Describe your Change (변경사항)

- `useRadioButton`, `useCheckBox` 훅 작성
  - 각각 `selectedValue`, `setSelectedValues` (튜플의 세 번째 값) 값이 선택된 value 정보를 담고 있습니다.
- 라디오버튼은 input의 name 속성에 들어가는 `radioName` props를 추가로 전달해야 한다는 점 외에는 **라디오버튼, 체크박스 사용 방법이 같습니다**.

### 🧐 Issue number and link (참고)

- #11 
### 📚 Reference (참조)

- `Staging.tsx`에 **사용 예시**를 참고해주세요!
