### PR TITLE
Input, TextArea 글자 수 카운트 추가

### DIFF
--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -70,7 +70,7 @@ export default function Staging() {
       <br />
       <InputLabelContainer id={"retro"}>
         <Label order={1}>회고 이름</Label>
-        <Input onChange={handleChangeName} value={layerName} />
+        <Input onChange={handleChangeName} value={layerName} maxLength={10} wordCount />
       </InputLabelContainer>
 
       <InputLabelContainer id={"description"}>

--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -4,7 +4,7 @@ import { Fragment, useEffect, useState } from "react";
 import { BottomSheet } from "@/component/BottomSheet";
 import { Button, ButtonProvider } from "@/component/common/button";
 import { CheckBox, CheckBoxGroup } from "@/component/common/checkBox";
-import { Input, InputLabelContainer, Label } from "@/component/common/input";
+import { Input, InputLabelContainer, Label, TextArea } from "@/component/common/input";
 import { ProgressBar } from "@/component/common/ProgressBar";
 import { Radio, RadioButtonGroup } from "@/component/common/radioButton";
 import { useBottomSheet } from "@/hooks/useBottomSheet.ts";
@@ -19,6 +19,7 @@ export default function Staging() {
   const { openBottomSheet, bottomSheetState } = useBottomSheet();
   const [number, setNumber] = useState(0);
   const { value: layerName, handleInputChange: handleChangeName } = useInput();
+  const { value: description, handleInputChange: handleChangeDescription } = useInput();
 
   useEffect(() => {
     console.log("라디오 버튼 선택 value:", selectedValue);
@@ -70,6 +71,11 @@ export default function Staging() {
       <InputLabelContainer id={"retro"}>
         <Label order={1}>회고 이름</Label>
         <Input onChange={handleChangeName} value={layerName} />
+      </InputLabelContainer>
+
+      <InputLabelContainer id={"description"}>
+        <Label>한 줄 설명</Label>
+        <TextArea onChange={handleChangeDescription} value={description} maxLength={20} wordCount />
       </InputLabelContainer>
 
       <ButtonProvider>

--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -14,11 +14,11 @@ import { useRadioButton } from "@/hooks/useRadioButton";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 
 export default function Staging() {
-  const [isRadioChecked, onChange, selectedValue] = useRadioButton();
-  const [isCheckBoxChecked, toggle, selectedValues] = useCheckBox();
+  const { isChecked: isRadioChecked, onChange, selectedValue } = useRadioButton();
+  const { isChecked: isCheckBoxChecked, toggle, selectedValues } = useCheckBox();
   const { openBottomSheet, bottomSheetState } = useBottomSheet();
   const [number, setNumber] = useState(0);
-  const [layerName, handleChangeName] = useInput();
+  const { value: layerName, handleInputChange: handleChangeName } = useInput();
 
   useEffect(() => {
     console.log("라디오 버튼 선택 value:", selectedValue);

--- a/src/app/test/Staging.tsx
+++ b/src/app/test/Staging.tsx
@@ -70,12 +70,12 @@ export default function Staging() {
       <br />
       <InputLabelContainer id={"retro"}>
         <Label order={1}>회고 이름</Label>
-        <Input onChange={handleChangeName} value={layerName} maxLength={10} wordCount />
+        <Input onChange={handleChangeName} value={layerName} maxLength={10} count />
       </InputLabelContainer>
 
       <InputLabelContainer id={"description"}>
         <Label>한 줄 설명</Label>
-        <TextArea onChange={handleChangeDescription} value={description} maxLength={20} wordCount />
+        <TextArea onChange={handleChangeDescription} value={description} maxLength={20} count />
       </InputLabelContainer>
 
       <ButtonProvider>

--- a/src/component/common/input/Input.tsx
+++ b/src/component/common/input/Input.tsx
@@ -9,10 +9,10 @@ type InputProps = {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   width?: string;
-  wordCount?: boolean;
+  count?: boolean;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-export const Input = forwardRef(function ({ id, width = "100%", wordCount, ...props }: InputProps) {
+export const Input = forwardRef(function ({ id, width = "100%", count, ...props }: InputProps) {
   const { maxLength, value } = props;
   const inputContext = useContext(InputContext);
   return (
@@ -34,7 +34,7 @@ export const Input = forwardRef(function ({ id, width = "100%", wordCount, ...pr
           {...props}
         />
         {/* FIXME - typography 컬러 넣기 !! */}
-        {wordCount && maxLength && <Typography variant="CAPTION" color={"lightGrey"}>{`${value.length}/${maxLength}`}</Typography>}
+        {count && maxLength && <Typography variant="CAPTION" color={"lightGrey"}>{`${value.length}/${maxLength}`}</Typography>}
       </div>
     </div>
   );

--- a/src/component/common/input/Input.tsx
+++ b/src/component/common/input/Input.tsx
@@ -34,7 +34,7 @@ export const Input = forwardRef(function ({ id, width = "100%", wordCount, ...pr
           {...props}
         />
         {/* FIXME - typography 컬러 넣기 !! */}
-        {wordCount && maxLength && <Typography variant="CAPTION">{`${value.length}/${maxLength}`}</Typography>}
+        {wordCount && maxLength && <Typography variant="CAPTION" color={"lightGrey"}>{`${value.length}/${maxLength}`}</Typography>}
       </div>
     </div>
   );

--- a/src/component/common/input/Input.tsx
+++ b/src/component/common/input/Input.tsx
@@ -3,20 +3,27 @@ import { forwardRef, useContext } from "react";
 
 import { InputContext } from "./InputLabelContainer";
 
+import { Typography } from "@/component/common/typography";
+
 type InputProps = {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   width?: string;
+  wordCount?: boolean;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-export const Input = forwardRef(function ({ id, width = "100%", ...props }: InputProps) {
+export const Input = forwardRef(function ({ id, width = "100%", wordCount, ...props }: InputProps) {
+  const { maxLength, value } = props;
   const inputContext = useContext(InputContext);
   return (
     <div>
       <div
         css={css`
           width: ${width};
-          border: 1px solid #e3e6ea; // FIXME: 디자인 토큰 적용하기
+          border: 1px solid ${"#e3e6ea"}; // FIXME: 디자인 토큰 적용하기
           border-radius: 0.8rem;
           padding: 1.6rem;
+          display: flex;
         `}
       >
         <input
@@ -26,6 +33,8 @@ export const Input = forwardRef(function ({ id, width = "100%", ...props }: Inpu
           `}
           {...props}
         />
+        {/* FIXME - typography 컬러 넣기 !! */}
+        {wordCount && maxLength && <Typography variant="CAPTION">{`${value.length}/${maxLength}`}</Typography>}
       </div>
     </div>
   );

--- a/src/component/common/input/TextArea.tsx
+++ b/src/component/common/input/TextArea.tsx
@@ -1,0 +1,53 @@
+import { css } from "@emotion/react";
+import { forwardRef, useContext } from "react";
+
+import { InputContext } from "./InputLabelContainer";
+
+import { Typography } from "@/component/common/typography";
+
+type TextAreaProps = {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  width?: string;
+  height?: string;
+  wordCount?: boolean;
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const TextArea = forwardRef(function ({ id, width = "100%", height = "4.8rem", wordCount, ...props }: TextAreaProps) {
+  const { maxLength, value } = props;
+  const textareaContext = useContext(InputContext);
+  return (
+    <div>
+      <div
+        css={css`
+          width: ${width};
+          border: 1px solid ${"#e3e6ea"}; // FIXME: 디자인 토큰 적용하기
+          border-radius: 0.8rem;
+          padding: 1.6rem;
+          display: flex;
+          flex-direction: column;
+        `}
+      >
+        <textarea
+          id={id || textareaContext?.id}
+          css={css`
+            width: 100%;
+            height: ${height};
+          `}
+          {...props}
+        />
+        {wordCount && maxLength && (
+          <div
+            css={css`
+              align-self: flex-end;
+            `}
+          >
+            <Typography variant="CAPTION" color={"lightGrey"}>{`${value.length}/${maxLength}`}</Typography>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+
+TextArea.displayName = "TextArea";

--- a/src/component/common/input/TextArea.tsx
+++ b/src/component/common/input/TextArea.tsx
@@ -10,10 +10,10 @@ type TextAreaProps = {
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   width?: string;
   height?: string;
-  wordCount?: boolean;
+  count?: boolean;
 } & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-export const TextArea = forwardRef(function ({ id, width = "100%", height = "4.8rem", wordCount, ...props }: TextAreaProps) {
+export const TextArea = forwardRef(function ({ id, width = "100%", height = "4.8rem", count, ...props }: TextAreaProps) {
   const { maxLength, value } = props;
   const textareaContext = useContext(InputContext);
   return (
@@ -36,7 +36,7 @@ export const TextArea = forwardRef(function ({ id, width = "100%", height = "4.8
           `}
           {...props}
         />
-        {wordCount && maxLength && (
+        {count && maxLength && (
           <div
             css={css`
               align-self: flex-end;

--- a/src/component/common/input/TextArea.tsx
+++ b/src/component/common/input/TextArea.tsx
@@ -13,7 +13,7 @@ type TextAreaProps = {
   count?: boolean;
 } & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-export const TextArea = forwardRef(function ({ id, width = "100%", height = "4.8rem", count, ...props }: TextAreaProps) {
+export const TextArea = forwardRef(function ({ id, width = "100%", height = "8.4rem", count, ...props }: TextAreaProps) {
   const { maxLength, value } = props;
   const textareaContext = useContext(InputContext);
   return (
@@ -26,13 +26,14 @@ export const TextArea = forwardRef(function ({ id, width = "100%", height = "4.8
           padding: 1.6rem;
           display: flex;
           flex-direction: column;
+          height: ${height};
         `}
       >
         <textarea
           id={id || textareaContext?.id}
           css={css`
             width: 100%;
-            height: ${height};
+            height: 100%;
           `}
           {...props}
         />

--- a/src/component/common/input/index.ts
+++ b/src/component/common/input/index.ts
@@ -1,3 +1,4 @@
 export { Input } from "./Input";
 export { Label } from "./Label";
 export { InputLabelContainer } from "./InputLabelContainer";
+export { TextArea } from "./TextArea";

--- a/src/hooks/useCheckBox.ts
+++ b/src/hooks/useCheckBox.ts
@@ -6,5 +6,5 @@ export const useCheckBox = () => {
   const toggle = (value: string) => setCheckedStates((prev) => ({ ...prev, [value]: !prev[value] }));
   const selectedValues = Object.keys(checkedStates).filter((key) => checkedStates[key]);
 
-  return [isChecked, toggle, selectedValues] as const;
+  return { isChecked, toggle, selectedValues };
 };

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -7,5 +7,5 @@ export const useInput = (defaultValue?: string) => {
     setValue(e.target.value);
   }, []);
 
-  return [value, handleInputChange] as const;
+  return { value, handleInputChange };
 };

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,9 +1,9 @@
 import { useCallback, useState } from "react";
 
-export const useInput = (defaultValue?: string) => {
+export const useInput = <T extends HTMLInputElement | HTMLTextAreaElement>(defaultValue?: string) => {
   const [value, setValue] = useState(defaultValue || "");
 
-  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = useCallback((e: React.ChangeEvent<T>) => {
     setValue(e.target.value);
   }, []);
 

--- a/src/hooks/useRadioButton.ts
+++ b/src/hooks/useRadioButton.ts
@@ -5,5 +5,5 @@ export const useRadioButton = () => {
   const isChecked = (value: string) => selectedValue === value;
   const onChange = (value: string) => setSelectedValue(value);
 
-  return [isChecked, onChange, selectedValue] as const;
+  return { isChecked, onChange, selectedValue };
 };

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -45,3 +45,14 @@ textarea {
 textarea {
   resize: none;
 }
+
+::-webkit-scrollbar {
+  border: none;
+  width: 0.8rem;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgb(231, 231, 231);
+  border-radius: 0.8rem;
+  border: 0.4rem solid transparent;
+}

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -34,8 +34,14 @@ button {
   user-select: none;
 }
 
-input {
+input,
+textarea {
   border: none;
   background-color: inherit;
   outline: none;
+  padding: 0;
+}
+
+textarea {
+  resize: none;
 }

--- a/src/style/variable.ts
+++ b/src/style/variable.ts
@@ -115,6 +115,7 @@ export const DESIGN_SYSTEM_COLOR = {
   inverseGrey700: "#c3c3c6",
   inverseGrey800: "#e4e4e5",
   inverseGrey900: "#fff",
+  lightGrey: "#ced4da",
   background: "#fff",
   darkBackground: "#17171c",
   greyBackground: "#f2f4f6",


### PR DESCRIPTION
> ### Input, TextArea 글자 수 카운트 추가
---

### 🏄🏼‍♂️‍ Summary (요약)

- TextArea 컴포넌트 추가
  - Input과 동일하게 사용하시면 됩니다. (훅도 동일하게 `useInput` 사용)
- 글자 수 세는 기능 추가
  - maxLength, count 전달

### 🫨 Describe your Change (변경사항)

- src/component/common/input/Input.tsx
- src/component/common/input/TextArea.tsx
- src/hooks/useInput.ts

### 🧐 Issue number and link (참고)

- #11 
### 📚 Reference (참조)
<img width="456" alt="스크린샷 2024-07-17 오후 10 45 13" src="https://github.com/user-attachments/assets/6376199a-e10e-406a-afd5-1b724af62e13">

