### PR TITLE
Typography children 타입 수정

### DIFF
--- a/src/component/common/typography/Typography.tsx
+++ b/src/component/common/typography/Typography.tsx
@@ -8,7 +8,7 @@ type TypographyProps = {
   as?: Extract<React.ElementType, TextTags>;
   variant?: keyof typeof DESIGN_SYSTEM_TEXT;
   color?: keyof typeof DESIGN_SYSTEM_COLOR;
-  children: React.ReactElement | string;
+  children: React.ReactNode;
 };
 
 // FIXME: 디자인 토큰에 따른 default 값 수정


### PR DESCRIPTION
> ### Typography children 타입 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- children 타입을 React.ReactNode로 수정했습니다.
- 띄어쓰기가 안되는 문제 해결

### 🫨 Describe your Change (변경사항)

- 

### 🧐 Issue number and link (참고)

- #11 
### 📚 Reference (참조)

-
