### PR TITLE
회고 생성 시 필수 질문 자동 삽입, 홈 라우터 수정

### DIFF
--- a/src/app/retrospectCreate/RetrospectCreate.tsx
+++ b/src/app/retrospectCreate/RetrospectCreate.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@/component/common/Icon";
 import { ProgressBar } from "@/component/common/ProgressBar";
 import { Spacing } from "@/component/common/Spacing";
 import { DueDate, MainInfo, CustomTemplate, Start } from "@/component/retrospectCreate";
+import { REQUIRED_QUESTIONS } from "@/component/retrospectCreate/customTemplate/questions.const";
 import { usePostRetrospectCreate } from "@/hooks/api/retrospect/create/usePostRetrospectCreate";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
 import { DefaultLayout } from "@/layout/DefaultLayout";
@@ -51,9 +52,10 @@ export function RetrospectCreate() {
   const steps = ["start", "mainInfo", "customTemplate", "dueDate"] as const;
 
   const handleSubmit = () => {
+    const questionsWithRequired = retroCreateData.questions.concat(REQUIRED_QUESTIONS);
     postRetrospectCreate.mutate({
       spaceId,
-      body: { ...retroCreateData },
+      body: { ...retroCreateData, questions: questionsWithRequired },
     });
   };
 

--- a/src/component/home/NavigaionBar.tsx
+++ b/src/component/home/NavigaionBar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
+import { PATHS } from "@/config/paths";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
 
 export function NavigationBar() {
@@ -28,7 +29,7 @@ export function NavigationBar() {
         `}
       >
         <Link
-          to="retrospect"
+          to={PATHS.home()}
           css={css`
             width: 33%;
             display: flex;
@@ -38,14 +39,14 @@ export function NavigationBar() {
             text-decoration: none;
           `}
         >
-          <Icon icon="ic_home" size="2.4rem" color={getSelectedColor("/home/retrospect")} />
-          <Typography variant="OVERLINE" color={getSelectedColor("/home/retrospect")}>
+          <Icon icon="ic_home" size="2.4rem" color={getSelectedColor(PATHS.home())} />
+          <Typography variant="OVERLINE" color={getSelectedColor(PATHS.home())}>
             회고
           </Typography>
         </Link>
 
         <Link
-          to="goals"
+          to={PATHS.goals()}
           css={css`
             width: 33%;
             display: flex;
@@ -55,14 +56,14 @@ export function NavigationBar() {
             text-decoration: none;
           `}
         >
-          <Icon icon="ic_chart" size="2.4rem" color={getSelectedColor("/home/goals")} />
-          <Typography variant="OVERLINE" color={getSelectedColor("/home/goals")}>
+          <Icon icon="ic_chart" size="2.4rem" color={getSelectedColor(PATHS.goals())} />
+          <Typography variant="OVERLINE" color={getSelectedColor(PATHS.goals())}>
             실행 목표
           </Typography>
         </Link>
 
         <Link
-          to="analysis"
+          to={PATHS.analysis()}
           css={css`
             width: 33%;
             display: flex;
@@ -72,8 +73,8 @@ export function NavigationBar() {
             text-decoration: none;
           `}
         >
-          <Icon icon="ic_barChart" size="2.4rem" color={getSelectedColor("/home/analysis")} />
-          <Typography variant="OVERLINE" color={getSelectedColor("/home/analysis")}>
+          <Icon icon="ic_barChart" size="2.4rem" color={getSelectedColor(PATHS.analysis())} />
+          <Typography variant="OVERLINE" color={getSelectedColor(PATHS.analysis())}>
             분석
           </Typography>
         </Link>

--- a/src/component/retrospectCreate/customTemplate/ConfirmDefaultTemplate.tsx
+++ b/src/component/retrospectCreate/customTemplate/ConfirmDefaultTemplate.tsx
@@ -9,8 +9,8 @@ import { QuestionList, QuestionListItem } from "@/component/common/list";
 import { Spacing } from "@/component/common/Spacing";
 import { Tag } from "@/component/common/tag";
 import { Typography } from "@/component/common/typography";
+import { TemplateContext } from "@/component/retrospectCreate/steps/CustomTemplate";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
-import { TemplateContext } from "../steps/CustomTemplate";
 
 type ConfirmDefaultTemplateProps = {
   title: string;

--- a/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
+++ b/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import { useAtom } from "jotai";
 import { useContext, useRef, useState } from "react";
 
+import { RetrospectCreateContext } from "@/app/retrospectCreate/RetrospectCreate";
 import { AppBar } from "@/component/common/appBar";
 import { ButtonProvider } from "@/component/common/button";
 import { Card } from "@/component/common/Card";
@@ -15,7 +16,6 @@ import { useInput } from "@/hooks/useInput";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
 import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
-import { RetrospectCreateContext } from "@/app/retrospectCreate/RetrospectCreate";
 
 type QuestionsListProps = {
   goNext: ReturnType<typeof useMultiStepForm>["goNext"];

--- a/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
+++ b/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
@@ -100,8 +100,8 @@ export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
           필수 질문
         </Typography>
         <QuestionList>
-          {REQUIRED_QUESTIONS.map((question, index) => (
-            <QuestionListItem key={index} content={question} />
+          {REQUIRED_QUESTIONS.map(({ questionContent }, index) => (
+            <QuestionListItem key={index} content={questionContent} />
           ))}
         </QuestionList>
       </div>

--- a/src/component/retrospectCreate/customTemplate/questions.const.ts
+++ b/src/component/retrospectCreate/customTemplate/questions.const.ts
@@ -1,4 +1,16 @@
-export const REQUIRED_QUESTIONS = ["진행상황에 대해 얼마나 만족하나요?", "목표했던 부분에 얼마나 달성했나요?"] as const;
+import { Questions } from "@/types/retrospectCreate";
+
+// export const REQUIRED_QUESTIONS = ["진행상황에 대해 얼마나 만족하나요?", "목표했던 부분에 얼마나 달성했나요?"] as const;
+export const REQUIRED_QUESTIONS: Questions = [
+  {
+    questionType: "number",
+    questionContent: "진행상황에 대해 얼마나 만족하나요?",
+  },
+  {
+    questionType: "range",
+    questionContent: "목표했던 부분에 얼마나 달성했나요?",
+  },
+];
 
 export const QUESTION_TYPES = ["팀워크", "의사소통", "문제해결", "시간관리", "목표설정", "자기계발", "목표달성"] as const;
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,4 +1,7 @@
 export const PATHS = {
+  home: () => `/`,
+  goals: () => `/goals`,
+  analysis: () => `/analysis`,
   retrospectCreate: () => `/retrospect/new`,
   completeRetrospectCreate: () => `/retrospect/complete`,
 };

--- a/src/layout/HomeLayout.tsx
+++ b/src/layout/HomeLayout.tsx
@@ -1,0 +1,12 @@
+import { Outlet } from "react-router-dom";
+
+import { NavigationBar } from "@/component/home";
+
+export function HomeLayout() {
+  return (
+    <div>
+      <Outlet />
+      <NavigationBar />
+    </div>
+  );
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,12 +3,10 @@ import { createBrowserRouter, RouterProvider, RouteObject } from "react-router-d
 
 import { AnalysisViewPage } from "@/app/home/AnalysisViewPage";
 import { GoalViewPage } from "@/app/home/GoalViewPage";
-import { HomePage } from "@/app/home/HomePage";
 import { RetrospectViewPage } from "@/app/home/RetrospectViewPage";
 import { KaKaoRedirection } from "@/app/login/KakaoLoginRedirection";
 import { LoginPage } from "@/app/login/LoginPage";
 import { SetNickNamePage } from "@/app/login/SetNicknamePage";
-import MainPage from "@/app/MainPage.tsx"; /* FIXME - 실제 메인 페이지 작성 후 대체해주세요. */
 import { RetrospectCreate } from "@/app/retrospectCreate/RetrospectCreate";
 import { RetrospectCreateComplete } from "@/app/retrospectCreate/RetrospectCreateComplete";
 import { CreateDonePage } from "@/app/space/CreateDonePage";
@@ -17,6 +15,7 @@ import Staging from "@/app/test/Staging.tsx";
 import { RetrospectWriteCompletePage } from "@/app/write/RetrospectWriteCompletePage.tsx";
 import { RetrospectWritePage } from "@/app/write/RetrospectWritePage.tsx";
 import GlobalLayout from "@/layout/GlobalLayout.tsx";
+import { HomeLayout } from "@/layout/HomeLayout";
 import { RequireLoginLayout } from "@/layout/RequireLoginLayout";
 
 type RouteChildren = {
@@ -26,8 +25,22 @@ type RouteChildren = {
 const routerChildren: RouteChildren[] = [
   {
     path: "/",
-    element: <MainPage />,
-    auth: false,
+    element: <HomeLayout />,
+    children: [
+      {
+        path: "",
+        element: <RetrospectViewPage />,
+      },
+      {
+        path: "analysis",
+        element: <AnalysisViewPage />,
+      },
+      {
+        path: "goals",
+        element: <GoalViewPage />,
+      },
+    ],
+    auth: true,
   },
   {
     path: "/write",
@@ -63,25 +76,6 @@ const routerChildren: RouteChildren[] = [
     path: "/space/create/done",
     element: <CreateDonePage />,
     auth: true,
-  },
-  {
-    path: "/home",
-    element: <HomePage />,
-    auth: true,
-    children: [
-      {
-        path: "analysis",
-        element: <AnalysisViewPage />,
-      },
-      {
-        path: "goals",
-        element: <GoalViewPage />,
-      },
-      {
-        path: "retrospect",
-        element: <RetrospectViewPage />,
-      },
-    ],
   },
   { path: "/api/auth/oauth2/kakao", element: <KaKaoRedirection />, auth: false },
   {


### PR DESCRIPTION
> ### 회고 생성 시 필수 질문 자동 삽입, 홈 라우터 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 회고 생성 시 템플릿 질문 리스트에 필수 질문 삽입
- 홈 라우터 수정 (/home 제거, 루트로 지정)

### 🫨 Describe your Change (변경사항)

- src/app/retrospectCreate/RetrospectCreate.tsx
- src/router/index.tsx
- src/component/home/NavigaionBar.tsx

### 🧐 Issue number and link (참고)

- #35 
### 📚 Reference (참조)

- 라우터에서 path를 지정하지 않으면 (index: true인 경우) `browserRouter`에서 path가 없다고 판단해서 빈 화면을 띄우더라구요!
- 그래서 임시로 path: '' 로 작성해두었습니다. (정상 작동)
