### PR TITLE
모바일 사파리 환경 fit-content 속성 버그 대응

### DIFF
--- a/src/component/write/modal/TemporarySaveModal.tsx
+++ b/src/component/write/modal/TemporarySaveModal.tsx
@@ -39,6 +39,8 @@ export function TemporarySaveModal({ confirm, quit, title = "회고 작성을 �
     >
       <div
         css={css`
+          display: table;
+          margin: auto;
           width: 100%;
           height: fit-content;
           max-width: 46rem;


### PR DESCRIPTION
> ### 모바일 사파리 환경 fit-content 속성 버그 대응
---

### 🏄🏼‍♂️‍ Summary (요약)
- 모바일 사파리 환경에서 modal의 fit-content 속성이 정상적으로 적용되지 않는 현상 대응

### 🫨 Describe your Change (변경사항)
- src/component/write/modal/TemporarySaveModal.tsx

### 🧐 Issue number and link (참고)
- #75 

### 📚 Reference (참조)
- https://stackoverflow.com/questions/60052794/css-widthfit-content-not-working-on-iphones
