### PR TITLE
사용자가 작성을 완료 후, 임시 저장 시 오류 방지를 위한 로직 설계

### DIFF
--- a/src/component/write/phase/Write.tsx
+++ b/src/component/write/phase/Write.tsx
@@ -135,6 +135,7 @@ export function Write() {
       )}
       {isTemporarySaveModalOpen && (
         <Portal id="modal-root">
+          {/* FIXME: 디자인 팀에 모달 문구 전달 후, 수정 예정 */}
           <TemporarySaveModal
             title={"회고 작성을 멈출까요?"}
             content={modalMode.current === "TEMP_SAVED" ? "작성중인 회고는 임시저장 되어요" : "중요한 정보라면 변경 사항을 저장해주세요"}
@@ -145,11 +146,11 @@ export function Write() {
                     {
                       onSuccess: () => {
                         handleModalClose("temporary-save");
-                        navigate("/");
                       },
                     },
                   )
                 : handleModalClose("temporary-save");
+              navigate("/");
             }}
             quit={() => {
               handleModalClose("temporary-save");

--- a/src/component/write/phase/Write.tsx
+++ b/src/component/write/phase/Write.tsx
@@ -27,19 +27,21 @@ export type Answer = {
   answerContent: string;
 };
 
+type ModalModeType = "TEMP_SAVED" | "ALREADY_SAVED";
+type EditModeType = "EDIT" | "POST";
+
 export function Write() {
   /** Util */
   const navigate = useNavigate();
 
   /** Write Local State */
   const { data, incrementPhase, decrementPhase, phase, movePhase, spaceId, retrospectId } = useContext(PhaseContext);
-  // const [satisfyIdx, setSatistfyIdx] = useState(-1);
-  // const [archievementIdx, setArchievementIdx] = useState(-1);
   const [isEntireModalOpen, setEntireModalOpen] = useState(false);
   const [isTemporarySaveModalOpen, setTemporarySaveModalOpen] = useState(false);
   const [isAnswerFilled, setIsAnswerFilled] = useState(false);
   const isComplete = data?.questions.length === phase;
-  const editMode = useRef("POST");
+  const editMode = useRef<EditModeType>("POST");
+  const modalMode = useRef<ModalModeType>("TEMP_SAVED");
   const [answers, setAnswers] = useState<Answer[]>(
     data.questions.map((question) => ({
       questionId: question.questionId,
@@ -77,6 +79,7 @@ export function Write() {
   useEffect(() => {
     if (answerDataSuccess && answerData) {
       editMode.current = "EDIT";
+      modalMode.current = "ALREADY_SAVED";
       setAnswers(
         answerData.answers.map((question) => ({
           questionId: question.questionId,
@@ -134,17 +137,19 @@ export function Write() {
         <Portal id="modal-root">
           <TemporarySaveModal
             title={"회고 작성을 멈출까요?"}
-            content={"작성중인 회고는 임시저장 되어요"}
+            content={modalMode.current === "TEMP_SAVED" ? "작성중인 회고는 임시저장 되어요" : "중요한 정보라면 변경 사항을 저장해주세요"}
             confirm={() => {
-              mutate(
-                { data: answers, isTemporarySave: true, spaceId: spaceId, retrospectId: retrospectId },
-                {
-                  onSuccess: () => {
-                    handleModalClose("temporary-save");
-                    navigate("/");
-                  },
-                },
-              );
+              modalMode.current === "TEMP_SAVED"
+                ? mutate(
+                    { data: answers, isTemporarySave: true, spaceId: spaceId, retrospectId: retrospectId },
+                    {
+                      onSuccess: () => {
+                        handleModalClose("temporary-save");
+                        navigate("/");
+                      },
+                    },
+                  )
+                : handleModalClose("temporary-save");
             }}
             quit={() => {
               handleModalClose("temporary-save");

--- a/src/component/write/phase/Write.tsx
+++ b/src/component/write/phase/Write.tsx
@@ -146,11 +146,11 @@ export function Write() {
                     {
                       onSuccess: () => {
                         handleModalClose("temporary-save");
+                        navigate("/");
                       },
                     },
                   )
-                : handleModalClose("temporary-save");
-              navigate("/");
+                : (handleModalClose("temporary-save"), navigate("/"));
             }}
             quit={() => {
               handleModalClose("temporary-save");


### PR DESCRIPTION
> ### 사용자가 작성을 완료 후, 임시 저장 시 오류 방지를 위한 로직 설계
---

### 🏄🏼‍♂️‍ Summary (요약)
- 사용자가 작성을 완료 후, 임시 저장 시 오류 방지를 위한 로직 설계를 했어요.
- 기존에는 작성을 완료 한 사용자가 좌측 상단의 취소 버튼을 누르게 되면, 임시 저장 모달이 뜨게되는데 해당 버튼을 누르면 오류(400)가 발생했어요.
- 이 문제를 해결하기 위해 사용자가 만약 답한 데이터가 있을 경우, 임시 저장 API를 호출하는 것이 아닌 경고 문구만을 띄어주게 설계했어요

### 🫨 Describe your Change (변경사항)
- src/component/write/phase/Write.tsx

### 🧐 Issue number and link (참고)
- #73 

### 📚 Reference (참조)
- 이미 사용자가 등록해놓은 데이터가 있는 경우
<img width="293" alt="스크린샷 2024-08-07 오전 1 59 18" src="https://github.com/user-attachments/assets/d947a3e0-24f0-4bf1-ad33-e3bce5d2f940">

- 사용자가 임시 저장 또는 새로 글을 등록하는 경우
<img width="293" alt="스크린샷 2024-08-07 오전 2 00 53" src="https://github.com/user-attachments/assets/8efdc08a-ee9e-4440-bca0-f0ec663a5604">
