### PR TITLE
앱바 높이 변수 처리에 따른 수정 + DualToneLayout 버그 수정

### DIFF
--- a/src/app/space/SpaceViewPage.tsx
+++ b/src/app/space/SpaceViewPage.tsx
@@ -71,7 +71,6 @@ export function SpaceViewPage() {
   return (
     <DefaultLayout
       theme="dark"
-      height="6.4rem"
       title={spaceInfo?.name}
       RightComp={
         <SpaceAppBarRightComp

--- a/src/component/common/appBar/AppBar.tsx
+++ b/src/component/common/appBar/AppBar.tsx
@@ -31,7 +31,7 @@ function Back({ theme }: { theme: "dark" | "gray" | "default" | "transparent" })
 
 //FIXME : 디자인 토큰에 따라 색깔 변경, 폰트 수정
 export const AppBar = forwardRef<HTMLDivElement, AppBarProps>(function (
-  { style, title, theme = "default", height = "5.8rem", LeftComp = <Back theme={theme} />, RightComp = <div></div> },
+  { style, title, theme = "default", height, LeftComp = <Back theme={theme} />, RightComp = <div></div> },
   ref,
 ) {
   return (
@@ -41,7 +41,7 @@ export const AppBar = forwardRef<HTMLDivElement, AppBarProps>(function (
           css`
             width: 100%;
             max-width: 48rem;
-            height: ${height};
+            height: ${height ?? "var(--app-bar-height)"};
             padding: 1.1rem 2rem;
             background-color: ${DESIGN_TOKEN_COLOR.themeBackground[theme]};
             display: flex;
@@ -55,7 +55,7 @@ export const AppBar = forwardRef<HTMLDivElement, AppBarProps>(function (
           `,
           style,
         ]}
-        ref = {ref}
+        ref={ref}
       >
         {LeftComp}
         <div
@@ -77,12 +77,6 @@ export const AppBar = forwardRef<HTMLDivElement, AppBarProps>(function (
         </div>
         {RightComp}
       </div>
-      <div
-        css={css`
-          width: 100%;
-          height: ${height};
-        `}
-      />
     </>
   );
 });

--- a/src/layout/DefaultLayout.tsx
+++ b/src/layout/DefaultLayout.tsx
@@ -26,8 +26,8 @@ export function DefaultLayout({ children, title, theme = "default", height, appB
           flex: 1 1 0;
           display: flex;
           flex-direction: column;
-          padding: 0 2rem;
-          height: calc(100dvh - ${height ?? `5.8rem`});
+          height: 100dvh;
+          padding: ${height ?? "var(--app-bar-height)"} 2rem 0 2rem;
         `}
       >
         {children}

--- a/src/layout/DualToneLayout.tsx
+++ b/src/layout/DualToneLayout.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 
 import { AppBar, AppBarProps } from "@/component/common/appBar";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
@@ -21,25 +21,38 @@ export function DualToneLayout({
   RightComp,
   TopComp,
 }: DualToneLayoutProps) {
+  const topCompRef = useRef<HTMLDivElement>(null);
+  const [topCompHeight, setTopCompHeight] = useState("0px");
+
+  useEffect(() => {
+    if (topCompRef.current) {
+      setTopCompHeight(getComputedStyle(topCompRef.current).height);
+    }
+  }, [TopComp]);
   return (
     <div>
       <div
         css={css`
           --parent-bg-color: ${DESIGN_SYSTEM_COLOR.themeBackground[topTheme]};
           background-color: var(--parent-bg-color);
-          position: sticky;
+          position: fixed;
           top: 0;
+          width: 100%;
           z-index: 999;
         `}
       >
         <AppBar title={title} theme={topTheme} height={height} LeftComp={LeftComp} RightComp={RightComp} />
-        <div
-          css={css`
-            padding: 0 2rem;
-          `}
-        >
-          {TopComp}
-        </div>
+        {TopComp && (
+          <div
+            ref={topCompRef}
+            css={css`
+              padding: 0 2rem;
+              margin-top: ${height ?? "var(--app-bar-height)"};
+            `}
+          >
+            {TopComp}
+          </div>
+        )}
       </div>
       <main
         css={css`
@@ -47,8 +60,8 @@ export function DualToneLayout({
           flex: 1 1 0;
           display: flex;
           flex-direction: column;
-          padding: 0 2rem;
-          min-height: calc(100dvh - ${height ?? `6.4rem`});
+          height: 100dvh;
+          padding: calc(${height ?? "var(--app-bar-height)"} + ${topCompHeight}) 2rem 0 2rem;
           background-color: ${DESIGN_SYSTEM_COLOR.themeBackground[bottomTheme]};
         `}
       >

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -22,6 +22,7 @@
 
 :root {
   --parent-bg-color: inherit;
+  --app-bar-height: 5.8rem;
 }
 
 html {


### PR DESCRIPTION
> ### 앱바 높이 변수 처리에 따른 수정 + DualToneLayout 버그 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 앱바 높이 변수 처리에 따른 수정
- 앱바 높이만큼의 self closing div 삭제, main 영역에 padding-top 처리 + height 100dvh
- DualToneLayout 버그 수정 (#109 해당 이슈는 자식인 AppBar가 fixed인 반면 이를 감싸는 부모가 sticky 속성이라 제대로 동작이 안됐던 것 같습니다. → sticky를 fixed로 수정했습니다)

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

- #109 
### 📚 Reference (참조)

-
