### PR TITLE
회고 생성 플로우 수정, 페이지 이탈 시 템플릿 임시저장

### DIFF
--- a/src/app/retrospectCreate/RetrospectCreate.tsx
+++ b/src/app/retrospectCreate/RetrospectCreate.tsx
@@ -27,7 +27,7 @@ type UseMultiStepFormContextState<T extends (typeof CUSTOM_TEMPLATE_STEPS)[numbe
   typeof useMultiStepForm<T>
 >;
 
-type RetrospectCreateContextState = UseMultiStepFormContextState<(typeof PAGE_STEPS)[number]>;
+type RetrospectCreateContextState = UseMultiStepFormContextState<(typeof PAGE_STEPS)[number]> & { confirmQuitPage: () => void };
 type CustomTemplateContextState = UseMultiStepFormContextState<(typeof CUSTOM_TEMPLATE_STEPS)[number]>;
 
 export const RetrospectCreateContext = createContext<RetrospectCreateContextState>({} as RetrospectCreateContextState);
@@ -87,12 +87,16 @@ export function RetrospectCreate() {
     [pageState.currentStep, retroCreateData.deadline],
   );
 
+  const confirmQuitPage = () => {
+    setIsTemporarySaveModalOpen(true);
+  };
+
   const conditionalGoPrev = useCallback(() => {
     const { currentStep: pageCurrentStep, goPrev: pageGoPrev } = pageState;
     const { currentStep: customCurrentStep, goPrev: customGoPrev } = customState;
 
     if (pageCurrentStep === "start") {
-      setIsTemporarySaveModalOpen(true);
+      confirmQuitPage();
       return;
     }
     if (pageCurrentStep === "customTemplate" && customCurrentStep === "confirmEditTemplate") {
@@ -123,7 +127,7 @@ export function RetrospectCreate() {
           <ProgressBar curPage={conditionalStepIndex} lastPage={pageState.totalStepsCnt - 1} />
         </div>
         <Spacing size={2.9} />
-        <RetrospectCreateContext.Provider value={pageState}>
+        <RetrospectCreateContext.Provider value={{ ...pageState, confirmQuitPage }}>
           <form
             css={css`
               flex: 1 1 0;
@@ -135,7 +139,7 @@ export function RetrospectCreate() {
               e.preventDefault();
             }}
           >
-            {pageState.currentStep === "start" && <Start onQuitPage={quitPage} />}
+            {pageState.currentStep === "start" && <Start />}
             {pageState.currentStep === "mainInfo" && <MainInfo />}
             {pageState.currentStep === "customTemplate" && (
               <CustomTemplateContext.Provider value={customState}>

--- a/src/app/retrospectCreate/RetrospectCreate.tsx
+++ b/src/app/retrospectCreate/RetrospectCreate.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtomValue } from "jotai";
 import { useResetAtom } from "jotai/utils";
 import { createContext, useCallback, useMemo, useState } from "react";
 import { Beforeunload } from "react-beforeunload";
@@ -14,10 +14,10 @@ import { REQUIRED_QUESTIONS } from "@/component/retrospectCreate/customTemplate/
 import { TemporarySaveModal } from "@/component/write/modal";
 import { PATHS } from "@/config/paths";
 import { usePostRetrospectCreate } from "@/hooks/api/retrospect/create/usePostRetrospectCreate";
+import { usePostRecentTemplateId } from "@/hooks/api/template/usePostRecentTemplateId";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
-import { temporaryTemplateAtom } from "@/store/templateAtom";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
 
 const PAGE_STEPS = ["start", "mainInfo", "customTemplate", "dueDate"] as const;
@@ -58,11 +58,11 @@ export function RetrospectCreate() {
   const locationState = useLocation().state as { spaceId: number; templateId: number };
   const { spaceId, templateId } = locationState;
   const [isTemporarySaveModalOpen, setIsTemporarySaveModalOpen] = useState(false);
-  const [, setTemporaryTemplateAtom] = useAtom(temporaryTemplateAtom);
 
   const retroCreateData = useAtomValue(retrospectCreateAtom);
   const resetRetroCreateData = useResetAtom(retrospectCreateAtom);
   const postRetrospectCreate = usePostRetrospectCreate(spaceId);
+  const postRecentTemplateId = usePostRecentTemplateId(spaceId);
 
   const handleSubmit = () => {
     const questionsWithRequired = REQUIRED_QUESTIONS.concat(retroCreateData.questions);
@@ -107,10 +107,10 @@ export function RetrospectCreate() {
   }, [pageState.currentStep, customState.currentStep]);
 
   const quitPage = useCallback(() => {
+    postRecentTemplateId.mutate({ formId: templateId, spaceId });
     setIsTemporarySaveModalOpen(false);
-    setTemporaryTemplateAtom((prev) => ({ ...prev, templateId }));
     resetRetroCreateData();
-    navigate(PATHS.spaceDetail(spaceId.toString()));
+    navigate(PATHS.spaceDetail(spaceId.toString()), { replace: true });
   }, []);
 
   return (

--- a/src/app/retrospectCreate/RetrospectCreate.tsx
+++ b/src/app/retrospectCreate/RetrospectCreate.tsx
@@ -55,8 +55,8 @@ export function RetrospectCreate() {
     },
   } as const;
 
-  const locationState = useLocation().state as { spaceId: number; templateId: string };
-  const { spaceId } = locationState;
+  const locationState = useLocation().state as { spaceId: number; templateId: number };
+  const { spaceId, templateId } = locationState;
   const [isTemporarySaveModalOpen, setIsTemporarySaveModalOpen] = useState(false);
   const [, setTemporaryTemplateAtom] = useAtom(temporaryTemplateAtom);
 
@@ -68,7 +68,7 @@ export function RetrospectCreate() {
     const questionsWithRequired = REQUIRED_QUESTIONS.concat(retroCreateData.questions);
     postRetrospectCreate.mutate({
       spaceId,
-      body: { ...retroCreateData, questions: questionsWithRequired, curFormId: 10001 },
+      body: { ...retroCreateData, questions: questionsWithRequired, curFormId: templateId },
     });
     resetRetroCreateData();
   };
@@ -104,8 +104,7 @@ export function RetrospectCreate() {
 
   const quitPage = useCallback(() => {
     setIsTemporarySaveModalOpen(false);
-    /**FIXME - dummy template id */
-    setTemporaryTemplateAtom((prev) => ({ ...prev, templateId: 10001 }));
+    setTemporaryTemplateAtom((prev) => ({ ...prev, templateId }));
     resetRetroCreateData();
     navigate(PATHS.spaceDetail(spaceId.toString()));
   }, []);

--- a/src/component/common/input/TextArea.tsx
+++ b/src/component/common/input/TextArea.tsx
@@ -46,7 +46,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(function 
           id={id || textareaContext?.id}
           css={css`
             ::placeholder {
-              color: ${DESIGN_TOKEN_COLOR.gray00};
+              color: ${DESIGN_TOKEN_COLOR["gray500"]};
             }
             flex-shrink: 0;
             flex-grow: 1;

--- a/src/component/retrospectCreate/customTemplate/AddQuestionsBottomSheet.tsx
+++ b/src/component/retrospectCreate/customTemplate/AddQuestionsBottomSheet.tsx
@@ -14,13 +14,16 @@ import { useCheckBox } from "@/hooks/useCheckBox";
 import { useEditQuestions } from "@/hooks/useEditQuestions";
 import { useInput } from "@/hooks/useInput";
 import { useTabs } from "@/hooks/useTabs";
+import { useToast } from "@/hooks/useToast";
 
 type AddQuestionsBottomSheetProps = {
   onClose: () => void;
   handleAddQuestions: ReturnType<typeof useEditQuestions>["handleAddQuestions"];
+  maxCount: number;
 };
 
-export function AddQuestionsBottomSheet({ onClose, handleAddQuestions }: AddQuestionsBottomSheetProps) {
+export function AddQuestionsBottomSheet({ onClose, handleAddQuestions, maxCount }: AddQuestionsBottomSheetProps) {
+  const { toast } = useToast();
   const { tabs, curTab, selectTab } = useTabs(["직접 작성", "추천 질문"] as const);
   const { value: customQuestion, handleInputChange: handleCustomChange, resetInput } = useInput();
   const { isChecked, toggle, selectedValues, resetChecked } = useCheckBox();
@@ -33,6 +36,10 @@ export function AddQuestionsBottomSheet({ onClose, handleAddQuestions }: AddQues
   };
 
   const handleRecommendedSave = () => {
+    if (selectedValues.length > maxCount) {
+      toast.error("추가 가능한 질문 개수를 초과했어요");
+      return;
+    }
     handleAddQuestions(selectedValues);
     resetChecked();
     onClose();
@@ -59,7 +66,9 @@ export function AddQuestionsBottomSheet({ onClose, handleAddQuestions }: AddQues
         >
           <Input placeholder="질문을 작성해주세요." value={customQuestion} onChange={handleCustomChange} maxLength={10} count />
           <ButtonProvider>
-            <ButtonProvider.Primary onClick={handleCustomSave}>추가하기</ButtonProvider.Primary>
+            <ButtonProvider.Primary onClick={handleCustomSave} disabled={!customQuestion}>
+              추가하기
+            </ButtonProvider.Primary>
           </ButtonProvider>
         </div>
       )}
@@ -105,6 +114,7 @@ export function AddQuestionsBottomSheet({ onClose, handleAddQuestions }: AddQues
           <ButtonProvider>
             <ButtonProvider.Primary
               onClick={handleRecommendedSave}
+              disabled={selectedValues.length === 0}
             >{`추가하기${selectedValues.length > 0 ? " " + selectedValues.length : ""}`}</ButtonProvider.Primary>
           </ButtonProvider>
         </div>

--- a/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
+++ b/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { useAtom } from "jotai";
-import { useContext, useRef, useState } from "react";
+import { useContext, useMemo, useRef, useState } from "react";
 
 import { ButtonProvider } from "@/component/common/button";
 import { Card } from "@/component/common/Card";
@@ -22,8 +22,18 @@ type QuestionsListProps = {
 };
 
 export function ConfirmEditTemplate({ goNext, goPrev }: QuestionsListProps) {
-  const { tag } = useContext(TemplateContext);
+  const { tag: originalTag, questions: originalQuestions } = useContext(TemplateContext);
   const [retroCreateData, setRetroCreateData] = useAtom(retrospectCreateAtom);
+  const tag = useMemo(() => {
+    if (
+      originalQuestions
+        .map(({ questionContent }) => questionContent)
+        .every((question) => retroCreateData.questions.map(({ questionContent }) => questionContent).includes(question))
+    ) {
+      return originalTag;
+    }
+    return "커스텀";
+  }, [originalTag, originalQuestions, retroCreateData.questions]);
   const { value: title, handleInputChange: handleTitleChange } = useInput(retroCreateData.formName);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const [showTooltip, setShowTooltip] = useState(true);

--- a/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
+++ b/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
@@ -21,6 +21,7 @@ import { TemporarySaveModal } from "@/component/write/modal";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { useEditQuestions } from "@/hooks/useEditQuestions";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
+import { useToast } from "@/hooks/useToast";
 import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
@@ -31,6 +32,7 @@ type EditQuestionsProps = Pick<ReturnType<typeof useMultiStepForm>, "goNext" | "
 
 export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
   const { openBottomSheet, closeBottomSheet } = useBottomSheet();
+  const { toast } = useToast();
 
   const {
     newQuestions,
@@ -63,6 +65,14 @@ export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
   const onNext = () => {
     saveData();
     goNext();
+  };
+
+  const handleAddButtonClick = () => {
+    if (newQuestions.length < MAX_QUESTIONS_COUNT) {
+      openBottomSheet();
+    } else {
+      toast.error("추가 가능한 질문 개수를 초과했어요");
+    }
   };
 
   return (
@@ -164,14 +174,23 @@ export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
             </QuestionList>
           </Drop>
         </DragDropContext>
-        {newQuestions.length < MAX_QUESTIONS_COUNT && <AddListItemButton onClick={openBottomSheet} />}
+        <AddListItemButton onClick={handleAddButtonClick} />
       </div>
 
       <ButtonProvider>
         <ButtonProvider.Primary onClick={onNext}>완료</ButtonProvider.Primary>
       </ButtonProvider>
 
-      <BottomSheet contents={<AddQuestionsBottomSheet onClose={closeBottomSheet} handleAddQuestions={handleAddQuestions} />} sheetHeight={590} />
+      <BottomSheet
+        contents={
+          <AddQuestionsBottomSheet
+            maxCount={MAX_QUESTIONS_COUNT - newQuestions.length}
+            onClose={closeBottomSheet}
+            handleAddQuestions={handleAddQuestions}
+          />
+        }
+        sheetHeight={590}
+      />
       {isTemporarySaveModalOpen && (
         <Portal id="modal-root">
           <TemporarySaveModal

--- a/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
+++ b/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
@@ -21,7 +21,7 @@ import { TemporarySaveModal } from "@/component/write/modal";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { useEditQuestions } from "@/hooks/useEditQuestions";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
-import { isQuestionEditedAtom, retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
+import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
 
@@ -49,7 +49,6 @@ export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
 
   const { questions: originalQuestions } = useContext(TemplateContext);
   const setRetroCreateData = useSetAtom(retrospectCreateAtom);
-  const setIsQuestionEdited = useSetAtom(isQuestionEditedAtom);
 
   const [isTemporarySaveModalOpen, setIsTemporarySaveModalOpen] = useState(false);
   const isEdited = useMemo(
@@ -58,7 +57,6 @@ export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
   );
 
   const saveData = () => {
-    setIsQuestionEdited(isEdited);
     setRetroCreateData((prev) => ({ ...prev, isNewForm: isEdited, questions: newQuestions, formName: `커스텀 템플릿` }));
   };
 

--- a/src/component/retrospectCreate/steps/CustomTemplate.tsx
+++ b/src/component/retrospectCreate/steps/CustomTemplate.tsx
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import { createContext, useContext, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
@@ -6,7 +6,7 @@ import { CustomTemplateContext, RetrospectCreateContext } from "@/app/retrospect
 import { FullModal } from "@/component/common/Modal/FullModal";
 import { ConfirmEditTemplate, EditQuestions, ConfirmDefaultTemplate } from "@/component/retrospectCreate";
 import { useGetCustomTemplate } from "@/hooks/api/template/useGetCustomTemplate";
-import { isQuestionEditedAtom, retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
+import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 import { CustomTemplateRes } from "@/types/template";
 
 export const TemplateContext = createContext<CustomTemplateRes>({
@@ -24,14 +24,7 @@ export function CustomTemplate() {
   const pageContext = useContext(RetrospectCreateContext);
   const customContext = useContext(CustomTemplateContext);
 
-  const isQuestionEdited = useAtomValue(isQuestionEditedAtom);
   const [retroCreateData, setRetroCreateData] = useAtom(retrospectCreateAtom);
-
-  useEffect(() => {
-    if (isQuestionEdited) {
-      customContext.goTo("confirmEditTemplate");
-    }
-  }, []);
 
   useEffect(() => {
     if (retroCreateData.questions.length > 0) return;

--- a/src/component/retrospectCreate/steps/CustomTemplate.tsx
+++ b/src/component/retrospectCreate/steps/CustomTemplate.tsx
@@ -43,16 +43,7 @@ export function CustomTemplate() {
       {customContext.currentStep === "confirmDefaultTemplate" && <ConfirmDefaultTemplate goEdit={customContext.goNext} />}
       {customContext.currentStep === "editQuestions" && (
         <FullModal>
-          <EditQuestions
-            goNext={customContext.goNext}
-            goPrev={() => {
-              if (!isQuestionEdited) {
-                customContext.goPrev();
-              } else {
-                customContext.goTo("confirmEditTemplate");
-              }
-            }}
-          />
+          <EditQuestions goNext={customContext.goNext} goPrev={customContext.goPrev} />
         </FullModal>
       )}
       {customContext.currentStep === "confirmEditTemplate" && <ConfirmEditTemplate goNext={pageContext.goNext} goPrev={customContext.goPrev} />}

--- a/src/component/retrospectCreate/steps/DueDate.tsx
+++ b/src/component/retrospectCreate/steps/DueDate.tsx
@@ -85,11 +85,11 @@ export function DueDate() {
             <Spacing size={2.2} />
             <DateTimePicker value={selectedDate} onChange={onSelectDate} radioControl={radioControl} />
             <ButtonProvider
-            // onlyContainerStyle={css`
-            //   div:nth-of-type(1) {
-            //     margin: 0;
-            //   }
-            // `}
+              onlyContainerStyle={css`
+                div:nth-of-type(1) {
+                  margin: 0;
+                }
+              `}
             >
               <ButtonProvider.Primary onClick={handleDateSave} disabled={!selectedDate}>
                 설정하기

--- a/src/component/retrospectCreate/steps/Start.tsx
+++ b/src/component/retrospectCreate/steps/Start.tsx
@@ -6,12 +6,8 @@ import { ButtonProvider } from "@/component/common/button";
 import { Header } from "@/component/common/header";
 import { Icon } from "@/component/common/Icon";
 
-type StartProps = {
-  onQuitPage: () => void;
-};
-
-export function Start({ onQuitPage }: StartProps) {
-  const { goNext } = useContext(RetrospectCreateContext);
+export function Start() {
+  const { goNext, confirmQuitPage } = useContext(RetrospectCreateContext);
   return (
     <>
       <Header title={"회고를 만들어볼까요"} contents={"회고를 진행하기 위한 공간이 필요해요"} theme="white" />
@@ -26,7 +22,7 @@ export function Start({ onQuitPage }: StartProps) {
       </div>
       <ButtonProvider>
         <ButtonProvider.White onClick={goNext}>시작하기</ButtonProvider.White>
-        <ButtonProvider.Primary onClick={onQuitPage}>나중에 하기</ButtonProvider.Primary>
+        <ButtonProvider.Primary onClick={confirmQuitPage}>나중에 하기</ButtonProvider.Primary>
       </ButtonProvider>
     </>
   );

--- a/src/hooks/api/template/usePostRecentTemplateId.ts
+++ b/src/hooks/api/template/usePostRecentTemplateId.ts
@@ -13,7 +13,6 @@ export const usePostRecentTemplateId = (spaceId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: ["postRecentTemplateId"],
     mutationFn: postRecentTemplateId,
     onSuccess: async () => {
       await queryClient.invalidateQueries({

--- a/src/hooks/api/template/usePostRecentTemplateId.ts
+++ b/src/hooks/api/template/usePostRecentTemplateId.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "@/api";
+
+type PostRecentTemplatIdReq = { formId: number; spaceId: number };
+
+export const usePostRecentTemplateId = (spaceId: number) => {
+  const postRecentTemplateId = async ({ formId, spaceId }: PostRecentTemplatIdReq) => {
+    const { data } = await api.post<PostRecentTemplatIdReq>(`/form/recommend`, { formId, spaceId });
+    return data;
+  };
+
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["postRecentTemplateId"],
+    mutationFn: postRecentTemplateId,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["getSpaceInfo", spaceId], //FIXME - query key 상수화
+      });
+    },
+  });
+};

--- a/src/store/retrospect/retrospectCreate.ts
+++ b/src/store/retrospect/retrospectCreate.ts
@@ -1,9 +1,6 @@
-import { atom } from "jotai";
 import { atomWithReset } from "jotai/utils";
 
 import { RetrospectCreateReq } from "@/types/retrospectCreate";
-
-export const isQuestionEditedAtom = atom<boolean>(false);
 
 export const retrospectCreateAtom = atomWithReset<RetrospectCreateReq>({
   title: "",

--- a/src/store/templateAtom.ts
+++ b/src/store/templateAtom.ts
@@ -1,5 +1,0 @@
-import { atomWithStorage } from "jotai/utils";
-
-export const temporaryTemplateAtom = atomWithStorage<{ templateId?: number }>("template", {
-  templateId: undefined,
-});


### PR DESCRIPTION
> ### 회고 생성 플로우 수정, 페이지 이탈 시 템플릿 임시저장
---

### 🏄🏼‍♂️‍ Summary (요약)

- 질문 수정 앞뒤로 이동하는 플로우 수정사항 반영
- 페이지 나갈 때 임시저장 API 연결
- 질문 개수 초과했을 때 에러 토스트

### 🫨 Describe your Change (변경사항)

- src/app/retrospectCreate/RetrospectCreate.tsx
- src/component/retrospectCreate/steps/Start.tsx
- src/component/retrospectCreate/customTemplate/EditQuestions.tsx
- src/component/retrospectCreate/customTemplate/AddQuestionsBottomSheet.tsx
- src/hooks/api/template/usePostRecentTemplateId.ts

### 🧐 Issue number and link (참고)

- #105 
### 📚 Reference (참조)

<img width="319" alt="스크린샷 2024-08-15 오전 1 58 17" src="https://github.com/user-attachments/assets/b172412a-4688-42c5-9f97-cad5abbbd1bc">  

- 현재 추천 질문 체크할 때 체크는 개수 제한 없이 가능하고, `추가하기` 버튼을 최종적으로 눌러야 개수 초과 여부를 판단해 토스트를 띄웁니다. 사실 사용자가 체크할 때마다 개수 초과 여부를 판단해서 초과할 때는 바로 에러 토스트를 띄우는 게 더 좋은 사용자 경험을 제공할 것 같다는 생각을 했어요. 근데 만들어놨던 체크박스 컴포넌트가 리팩토링이 꽤 들어가게 될 것 같아서 이건 좀 더 고려해보고 별도 PR로 올리도록 할게요!