### PR TITLE
회고 작성 시 이전 데이터를 불러오는 현상 수정

### DIFF
--- a/src/component/write/phase/Write.tsx
+++ b/src/component/write/phase/Write.tsx
@@ -92,7 +92,7 @@ export function Write() {
         })),
       );
     }
-  }, [answerDataLoading, answerDataSuccess]);
+  }, [answerDataLoading, answerDataSuccess, answerData]);
 
   useEffect(() => {
     const allFilled = answers.every((answer) => answer.answerContent !== "");

--- a/src/hooks/api/write/useGetAnswers.ts
+++ b/src/hooks/api/write/useGetAnswers.ts
@@ -23,6 +23,7 @@ export const useGetAnswers = ({ spaceId, retrospectId }: { spaceId: number; retr
   return useQuery({
     queryKey: ["answers", spaceId, retrospectId],
     queryFn: () => getQuestions(),
+    refetchOnWindowFocus: false,
     retry: 1,
   });
 };

--- a/src/hooks/api/write/useGetTemporaryQuestions.ts
+++ b/src/hooks/api/write/useGetTemporaryQuestions.ts
@@ -19,6 +19,7 @@ export const useGetTemporaryQuestions = ({ spaceId, retrospectId }: { spaceId: n
   return useQuery({
     queryKey: ["temporaryQuestion", spaceId, retrospectId],
     queryFn: () => getTemporaryQuestions(),
+    refetchOnWindowFocus: false,
     retry: 1,
   });
 };


### PR DESCRIPTION
> ### 회고 작성 시 이전 데이터를 불러오는 현상 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 회고 작성 시 이전 데이터를 불러오는 현상 수정을 했어요
- 윈도우 창을 벗어났을 때 리패치를 하는 요소들을 제거했어요

### 🫨 Describe your Change (변경사항)
- src/component/write/phase/Write.tsx
- src/hooks/api/write/useGetAnswers.ts
- src/hooks/api/write/useGetTemporaryQuestions.ts

### 🧐 Issue number and link (참고)
- #133 

### 📚 Reference (참조)
-
