### PR TITLE
대표템플릿 저장 및 불러오기 로직 반영

### DIFF
--- a/src/app/retrospectCreate/RetrospectCreate.tsx
+++ b/src/app/retrospectCreate/RetrospectCreate.tsx
@@ -106,6 +106,9 @@ export function RetrospectCreate() {
       title: "회고 진행을 중단하시겠어요?",
       contents: "선택한 템플릿은 임시저장되어요",
       onConfirm: quitPage,
+      options: {
+        buttonText: ["취소", "나가기"],
+      },
     });
   };
 

--- a/src/app/retrospectCreate/RetrospectCreateComplete.tsx
+++ b/src/app/retrospectCreate/RetrospectCreateComplete.tsx
@@ -5,6 +5,7 @@ import { ButtonProvider } from "@/component/common/button";
 import { Header } from "@/component/common/header";
 import { Icon } from "@/component/common/Icon";
 import { Spacing } from "@/component/common/Spacing";
+import { PATHS } from "@/config/paths";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 
 export function RetrospectCreateComplete() {
@@ -25,7 +26,7 @@ export function RetrospectCreateComplete() {
         <Icon icon={"ic_notebook_open"} size={27.8} />
       </div>
       <ButtonProvider sort="horizontal">
-        <ButtonProvider.Gray onClick={() => navigate(-1)}>끝내기</ButtonProvider.Gray>
+        <ButtonProvider.Gray onClick={() => navigate(PATHS.spaceDetail(spaceId.toString()))}>끝내기</ButtonProvider.Gray>
         <ButtonProvider.Primary
           onClick={() => {
             navigate("/write", {

--- a/src/app/space/SpaceViewPage.tsx
+++ b/src/app/space/SpaceViewPage.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { useQueries } from "@tanstack/react-query";
 import { Fragment, useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { BottomSheet } from "@/component/BottomSheet";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
@@ -11,6 +11,7 @@ import { Typography } from "@/component/common/typography";
 import { SpaceCountView, RetrospectBox, ActionItemListView, CreateRetrospectiveSheet } from "@/component/space";
 import { EmptyRetrospect } from "@/component/space/view/EmptyRetrospect";
 import { SpaceAppBarRightComp } from "@/component/space/view/SpaceAppBarRightComp";
+import { PATHS } from "@/config/paths";
 import { useApiOptionsGetTeamActionItemList } from "@/hooks/api/actionItem/useApiOptionsGetTeamActionItemList";
 import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
 import { useApiDeleteSpace } from "@/hooks/api/space/useApiDeleteSpace";
@@ -22,6 +23,7 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Retrospect } from "@/types/retrospect";
 
 export function SpaceViewPage() {
+  const navigate = useNavigate();
   const { spaceId } = useParams<{ spaceId: string }>();
   const { openBottomSheet } = useBottomSheet();
   const { open } = useModal();
@@ -42,7 +44,6 @@ export function SpaceViewPage() {
 
   useEffect(() => {
     if (restrospectArr) {
-      console.log(restrospectArr);
       setProceedingRetrospects(restrospectArr.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING"));
       setDoneRetrospects(restrospectArr.filter((retrospect) => retrospect.retrospectStatus === "DONE"));
     }
@@ -59,7 +60,26 @@ export function SpaceViewPage() {
     deleteSpace(spaceId as string);
   };
 
-  const handleOpenBottomSheet = () => {
+  const handleCreateSpace = () => {
+    if (spaceInfo?.formId) {
+      open({
+        title: "전에 진행했던 템플릿이 있어요!\n계속 진행하시겠어요?",
+        contents: "",
+        options: {
+          buttonText: ["다시 하기", "진행하기"],
+        },
+        onClose: () => {
+          setIsVisiableBottomSheet(true);
+          openBottomSheet();
+        },
+        onConfirm: () => {
+          navigate(PATHS.retrospectCreate(), {
+            state: { spaceId, templateId: spaceInfo.formId, saveTemplateId: true },
+          });
+        },
+      });
+      return;
+    }
     setIsVisiableBottomSheet(true);
     openBottomSheet();
   };
@@ -83,7 +103,7 @@ export function SpaceViewPage() {
             });
           }}
           isTooltipVisible={restrospectArr?.length === 0}
-          handleOpenBottomSheet={handleOpenBottomSheet}
+          onClickPlus={handleCreateSpace}
         />
       }
     >

--- a/src/component/space/CreateRetrospectiveSheet.tsx
+++ b/src/component/space/CreateRetrospectiveSheet.tsx
@@ -39,8 +39,9 @@ export function CreateRetrospectiveSheet({ teamName, spaceId }: Props) {
       >
         <button
           onClick={() => {
-            navigate("/retrospect/new", {
-              state: { spaceId: spaceId },
+            //FIXME - 추천 페이지로 변경하기
+            navigate(PATHS.retrospectCreate(), {
+              state: { spaceId: spaceId, templateId: 10000, saveTemplateId: true },
             });
           }}
           css={css`

--- a/src/component/space/view/SpaceAppBarRightComp.tsx
+++ b/src/component/space/view/SpaceAppBarRightComp.tsx
@@ -11,7 +11,7 @@ type RightCompProps = {
   spaceId: string | undefined;
   onDeleteClick: () => void;
   isTooltipVisible: boolean;
-  handleOpenBottomSheet: () => void;
+  onClickPlus: () => void;
 };
 
 const slideUpDown = keyframes`
@@ -26,7 +26,7 @@ const slideUpDown = keyframes`
   }
 `;
 
-export function SpaceAppBarRightComp({ spaceId, onDeleteClick, isTooltipVisible, handleOpenBottomSheet }: RightCompProps) {
+export function SpaceAppBarRightComp({ spaceId, onDeleteClick, isTooltipVisible, onClickPlus }: RightCompProps) {
   const [isBoxVisible, setIsBoxVisible] = useState(false);
   const boxRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
@@ -67,7 +67,7 @@ export function SpaceAppBarRightComp({ spaceId, onDeleteClick, isTooltipVisible,
         `}
       >
         <div css={{ position: "relative" }}>
-          <Icon icon="ic_plus" color={DESIGN_TOKEN_COLOR.gray00} size={1.8} onClick={handleOpenBottomSheet} />
+          <Icon icon="ic_plus" color={DESIGN_TOKEN_COLOR.gray00} size={1.8} onClick={onClickPlus} />
           {isTooltipVisible && (
             <motion.div
               initial={{ opacity: 0, y: 10 }}

--- a/src/hooks/useMultiStepForm.ts
+++ b/src/hooks/useMultiStepForm.ts
@@ -28,6 +28,7 @@ export const useMultiStepForm = <T extends string>({ steps, redirectPath, handle
 
   const goPrev = useCallback(() => {
     if (currentStepIndex === 0) {
+      navigate(-1);
       return;
     }
     setCurrentStepIndex((i) => i - 1);


### PR DESCRIPTION
> ### 대표템플릿 저장 및 불러오기 로직 반영
---

### 🏄🏼‍♂️‍ Summary (요약)

- 템플릿 추천받아 회고 생성 이탈하는 경우에**만** `템플릿 저장` 모달 띄우기
- 대표 템플릿이 있는 경우 회고 생성 버튼 클릭 시 `대표 템플릿 사용 여부 확인` 모달 띄우기

### 🫨 Describe your Change (변경사항)

- src/app/retrospectCreate/RetrospectCreate.tsx
- src/app/space/SpaceViewPage.tsx
- src/component/space/CreateRetrospectiveSheet.tsx
- src/component/space/view/SpaceAppBarRightComp.tsx
  - 회고 생성 버튼을 눌렀을 때 바텀시트가 바로 뜨지 않고 모달을 먼저 띄우기 때문에 변수명을 조금 수정했습니다! @sean2337 

### 🧐 Issue number and link (참고)

- #105
### 📚 Reference (참조)

- 
