### PR TITLE
스페이스 뷰 페이지 1차 변경 및 리팩토링

### DIFF
--- a/src/app/space/SpaceViewPage.tsx
+++ b/src/app/space/SpaceViewPage.tsx
@@ -121,7 +121,7 @@ export function SpaceViewPage() {
         css={css`
           width: calc(100% + 4rem);
           transform: translateX(-2rem);
-          min-height: calc(100vh - 20rem);
+          min-height: calc(100vh - 33rem);
           background-color: ${DESIGN_TOKEN_COLOR.gray00};
           padding: 2.2rem 2rem;
         `}

--- a/src/app/space/SpaceViewPage.tsx
+++ b/src/app/space/SpaceViewPage.tsx
@@ -18,10 +18,9 @@ import { useApiDeleteSpace } from "@/hooks/api/space/useApiDeleteSpace";
 import { useApiOptionsGetSpaceInfo } from "@/hooks/api/space/useApiOptionsGetSpaceInfo";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { useModal } from "@/hooks/useModal";
-import { DefaultLayout } from "@/layout/DefaultLayout";
+import { DualToneLayout } from "@/layout/DualToneLayout";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Retrospect } from "@/types/retrospect";
-import { DualToneLayout } from "@/layout/DualToneLayout";
 
 export function SpaceViewPage() {
   const navigate = useNavigate();
@@ -31,7 +30,6 @@ export function SpaceViewPage() {
   const SHEET_ID = "createSpaceSheet";
 
   const { mutate: deleteSpace } = useApiDeleteSpace();
-  const [isVisiableBottomSheet, setIsVisiableBottomSheet] = useState<boolean>(false);
 
   const [
     { data: restrospectArr, isLoading: isLoadingRestrospects },
@@ -71,7 +69,6 @@ export function SpaceViewPage() {
           buttonText: ["다시 하기", "진행하기"],
         },
         onClose: () => {
-          setIsVisiableBottomSheet(true);
           openBottomSheet({ id: SHEET_ID });
         },
         onConfirm: () => {
@@ -82,7 +79,6 @@ export function SpaceViewPage() {
       });
       return;
     }
-    setIsVisiableBottomSheet(true);
     openBottomSheet({ id: SHEET_ID });
   };
 
@@ -185,18 +181,15 @@ export function SpaceViewPage() {
           ))}
         </div>
       </div>
-      {isVisiableBottomSheet && (
-        <BottomSheet
-          id={SHEET_ID}
-          contents={
-            <Fragment>
-              <CreateRetrospectiveSheet spaceId={spaceId} teamName={spaceInfo?.name} />
-            </Fragment>
-          }
-          handler={true}
-        />
-      )}
-
+      <BottomSheet
+        id={SHEET_ID}
+        contents={
+          <Fragment>
+            <CreateRetrospectiveSheet spaceId={spaceId} teamName={spaceInfo?.name} />
+          </Fragment>
+        }
+        handler={true}
+      />
       <Toast />
     </DualToneLayout>
   );

--- a/src/app/space/SpaceViewPage.tsx
+++ b/src/app/space/SpaceViewPage.tsx
@@ -95,9 +95,9 @@ export function SpaceViewPage() {
       topTheme="dark"
       TopComp={
         <>
-          <ActionItemListView teamActionList={teamActionList?.teamActionItemList || []} />
+          <ActionItemListView retrospectId={100} teamActionList={teamActionList?.teamActionItemList || []} />
           <Spacing size={1.1} />
-          <SpaceCountView mainTemplate="" memberCount={spaceInfo?.memberCount} />
+          <SpaceCountView mainTemplate={spaceInfo?.fieldList[0]} memberCount={spaceInfo?.memberCount} />
           <Spacing size={2.4} />
         </>
       }

--- a/src/app/space/SpaceViewPage.tsx
+++ b/src/app/space/SpaceViewPage.tsx
@@ -21,6 +21,7 @@ import { useModal } from "@/hooks/useModal";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Retrospect } from "@/types/retrospect";
+import { DualToneLayout } from "@/layout/DualToneLayout";
 
 export function SpaceViewPage() {
   const navigate = useNavigate();
@@ -90,8 +91,16 @@ export function SpaceViewPage() {
   }
 
   return (
-    <DefaultLayout
-      theme="dark"
+    <DualToneLayout
+      topTheme="dark"
+      TopComp={
+        <>
+          <ActionItemListView teamActionList={teamActionList?.teamActionItemList || []} />
+          <Spacing size={1.1} />
+          <SpaceCountView mainTemplate="" memberCount={spaceInfo?.memberCount} />
+          <Spacing size={2.4} />
+        </>
+      }
       title={spaceInfo?.name}
       RightComp={
         <SpaceAppBarRightComp
@@ -108,10 +117,6 @@ export function SpaceViewPage() {
         />
       }
     >
-      <ActionItemListView teamActionList={teamActionList?.teamActionItemList || []} />
-      <Spacing size={1.1} />
-      <SpaceCountView mainTemplate="" memberCount={spaceInfo?.memberCount} />
-      <Spacing size={2.4} />
       <div
         css={css`
           width: calc(100% + 4rem);
@@ -193,6 +198,6 @@ export function SpaceViewPage() {
       )}
 
       <Toast />
-    </DefaultLayout>
+    </DualToneLayout>
   );
 }

--- a/src/component/home/TagBox.tsx
+++ b/src/component/home/TagBox.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
-import { categoryTagChange } from "@/utils/space/categoryTagChange";
+import { categoryTagKoreanChange } from "@/utils/space/categoryTagKoreanChange";
 
 type TagBoxProps = {
   tagName: string;
@@ -23,7 +23,7 @@ export function TagBox({ tagName }: TagBoxProps) {
       `}
     >
       <Typography variant="body12SemiBold" color="gray800">
-        {categoryTagChange(tagName)}
+        {categoryTagKoreanChange(tagName)}
       </Typography>
     </div>
   );

--- a/src/component/home/TagBox.tsx
+++ b/src/component/home/TagBox.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { categoryTagChange } from "@/utils/space/categoryTagChange";
 
 type TagBoxProps = {
   tagName: string;
@@ -22,7 +23,7 @@ export function TagBox({ tagName }: TagBoxProps) {
       `}
     >
       <Typography variant="body12SemiBold" color="gray800">
-        {tagName}
+        {categoryTagChange(tagName)}
       </Typography>
     </div>
   );

--- a/src/component/space/view/ActionItemListView.tsx
+++ b/src/component/space/view/ActionItemListView.tsx
@@ -14,6 +14,7 @@ import { ActionItemType } from "@/types/actionItem";
 
 type TeamGoalViewPros = {
   teamActionList: ActionItemType[];
+  retrospectId: number;
 };
 
 type ActionItemProps = {
@@ -25,7 +26,7 @@ type PostActionItemProps = {
   actionItemContent: string;
 };
 
-export function ActionItemListView({ teamActionList }: TeamGoalViewPros) {
+export function ActionItemListView({ retrospectId, teamActionList }: TeamGoalViewPros) {
   const [textValue, setTextValue] = useState("");
   const { mutate: postActionItem } = useApiPostActionItem();
   const { openBottomSheet } = useBottomSheet();
@@ -33,7 +34,7 @@ export function ActionItemListView({ teamActionList }: TeamGoalViewPros) {
     setTextValue(e.target.value);
   };
 
-  const handleAddActionItem = ({ retrospectId, actionItemContent }: PostActionItemProps) => {
+  const handleAddActionItem = ({ actionItemContent }: PostActionItemProps) => {
     if (textValue.trim() === "") {
       return;
     }

--- a/src/component/space/view/ActionItemListView.tsx
+++ b/src/component/space/view/ActionItemListView.tsx
@@ -22,7 +22,7 @@ type ActionItemProps = {
 };
 
 type PostActionItemProps = {
-  retrospectId: string;
+  retrospectId: number;
   actionItemContent: string;
 };
 
@@ -34,7 +34,7 @@ export function ActionItemListView({ retrospectId, teamActionList }: TeamGoalVie
     setTextValue(e.target.value);
   };
 
-  const handleAddActionItem = ({ actionItemContent }: PostActionItemProps) => {
+  const handleAddActionItem = ({ retrospectId, actionItemContent }: PostActionItemProps) => {
     if (textValue.trim() === "") {
       return;
     }
@@ -68,9 +68,6 @@ export function ActionItemListView({ retrospectId, teamActionList }: TeamGoalVie
         `}
       >
         <Typography variant="body14Medium">실행목표</Typography>
-        <Typography variant="body14Medium" color="gray500">
-          더보기
-        </Typography>
       </div>
 
       <Spacing size={1.0} />
@@ -89,7 +86,7 @@ export function ActionItemListView({ retrospectId, teamActionList }: TeamGoalVie
               align-items: center;
             `}
           >
-            <Icon icon="ic_plus" size="1.5rem" color="gray500" />
+            <Icon icon="ic_plus" size="1.5rem" color={DESIGN_TOKEN_COLOR.gray500} />
           </button>
           <Spacing size={1.6} />
           <Typography variant="body14Medium" color="gray600">
@@ -137,7 +134,7 @@ export function ActionItemListView({ retrospectId, teamActionList }: TeamGoalVie
               <Button
                 colorSchema="black"
                 onClick={() => {
-                  handleAddActionItem({ retrospectId: "100", actionItemContent: textValue });
+                  handleAddActionItem({ retrospectId: retrospectId, actionItemContent: textValue });
                 }}
               >
                 추가하기

--- a/src/component/space/view/SpaceAppBarRightComp.tsx
+++ b/src/component/space/view/SpaceAppBarRightComp.tsx
@@ -12,6 +12,7 @@ type RightCompProps = {
   onDeleteClick: () => void;
   isTooltipVisible: boolean;
   onClickPlus: () => void;
+  isLeader: boolean;
 };
 
 const slideUpDown = keyframes`
@@ -26,7 +27,7 @@ const slideUpDown = keyframes`
   }
 `;
 
-export function SpaceAppBarRightComp({ spaceId, onDeleteClick, isTooltipVisible, onClickPlus }: RightCompProps) {
+export function SpaceAppBarRightComp({ spaceId, onDeleteClick, isTooltipVisible, onClickPlus, isLeader }: RightCompProps) {
   const [isBoxVisible, setIsBoxVisible] = useState(false);
   const boxRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
@@ -152,7 +153,7 @@ export function SpaceAppBarRightComp({ spaceId, onDeleteClick, isTooltipVisible,
                 `}
               >
                 <Typography variant="subtitle14SemiBold" color="red500">
-                  스페이스 삭제
+                  {isLeader ? "스페이스 삭제" : "스페이스 떠나기"}
                 </Typography>
               </button>
             </motion.div>

--- a/src/component/space/view/SpaceCountView.tsx
+++ b/src/component/space/view/SpaceCountView.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
-import { categoryTagChange } from "@/utils/space/categoryTagChange";
+import { categoryTagKoreanChange } from "@/utils/space/categoryTagKoreanChange";
 
 type SpaceCountViewProps = {
   memberCount: number | undefined;
@@ -43,7 +43,7 @@ export function SpaceCountView({ mainTemplate, memberCount }: SpaceCountViewProp
           <Typography variant="body12Medium" color="gray800">
             대표 템플릿
           </Typography>
-          <Typography variant="subtitle14SemiBold">{mainTemplate ? categoryTagChange(mainTemplate) : "_"}</Typography>
+          <Typography variant="subtitle14SemiBold">{mainTemplate ? categoryTagKoreanChange(mainTemplate) : "_"}</Typography>
         </div>
       </div>
 

--- a/src/component/space/view/SpaceCountView.tsx
+++ b/src/component/space/view/SpaceCountView.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/react";
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { categoryTagChange } from "@/utils/space/categoryTagChange";
 
 type SpaceCountViewProps = {
   memberCount: number | undefined;
@@ -42,7 +43,7 @@ export function SpaceCountView({ mainTemplate, memberCount }: SpaceCountViewProp
           <Typography variant="body12Medium" color="gray800">
             대표 템플릿
           </Typography>
-          <Typography variant="subtitle14SemiBold">{mainTemplate ? mainTemplate : "_"}</Typography>
+          <Typography variant="subtitle14SemiBold">{mainTemplate ? categoryTagChange(mainTemplate) : "_"}</Typography>
         </div>
       </div>
 

--- a/src/hooks/api/actionItem/useApiPostActionItem.ts
+++ b/src/hooks/api/actionItem/useApiPostActionItem.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { api } from "@/api";
 
 type PostActioItemProps = {
-  retrospectId: string;
+  retrospectId: number;
   content: string;
 };
 

--- a/src/hooks/api/actionItem/useApiPostActionItem.ts
+++ b/src/hooks/api/actionItem/useApiPostActionItem.ts
@@ -2,12 +2,12 @@ import { useMutation } from "@tanstack/react-query";
 
 import { api } from "@/api";
 
-type PostActioItemProps = {
+type PostActionItemProps = {
   retrospectId: number;
   content: string;
 };
 
-const postActionItem = async ({ retrospectId, content }: PostActioItemProps) => {
+const postActionItem = async ({ retrospectId, content }: PostActionItemProps) => {
   const data = await api.post("api/action-item/create", { retrospectId: retrospectId, content: content });
   return data;
 };

--- a/src/layout/DualToneLayout.tsx
+++ b/src/layout/DualToneLayout.tsx
@@ -38,6 +38,7 @@ export function DualToneLayout({
           position: fixed;
           top: 0;
           width: 100%;
+          max-width: 48rem;
           z-index: 999;
         `}
       >

--- a/src/types/spaceType/index.ts
+++ b/src/types/spaceType/index.ts
@@ -7,4 +7,5 @@ export type Space = {
   formId: number;
   bannerUrl: string;
   memberCount: number;
+  leaderId: number;
 };

--- a/src/utils/space/categoryTagChange.ts
+++ b/src/utils/space/categoryTagChange.ts
@@ -1,0 +1,17 @@
+export const categoryTagChange = (category: string): string => {
+  const categoryMap: { [key: string]: string } = {
+    INDIVIDUAL: "개인",
+    TEAM: "팀",
+    PLANNER: "기획",
+    EDUCATION: "교육",
+    DEVELOPMENT: "개발",
+    DESIGN: "디자인",
+    MANAGEMENT: "운영 및 관리",
+    DATA_ANALYSIS: "데이터 분석",
+    MARKETING: "마케팅",
+    RESEARCH: "연구",
+    ETC: "기타",
+  };
+
+  return categoryMap[category] || "Unknown Category";
+};

--- a/src/utils/space/categoryTagKoreanChange.ts
+++ b/src/utils/space/categoryTagKoreanChange.ts
@@ -1,4 +1,4 @@
-export const categoryTagChange = (category: string): string => {
+export const categoryTagKoreanChange = (category: string): string => {
   const categoryMap: { [key: string]: string } = {
     INDIVIDUAL: "개인",
     TEAM: "팀",
@@ -13,5 +13,5 @@ export const categoryTagChange = (category: string): string => {
     ETC: "기타",
   };
 
-  return categoryMap[category] || "Unknown Category";
+  return categoryMap[category] || "-";
 };


### PR DESCRIPTION
> ### 스페이스 뷰 페이지 1차 변경 및 리팩토링
---

### 🏄🏼‍♂️‍ Summary (요약)

- 스페이스 뷰 페이지 1차 변경 및 리팩토링를 완료했어요!

### 🫨 Describe your Change (변경사항)

- 스페이스 뷰 페이지와 관련 컴포넌트, 함수를 수정했어요!
- 태그 별 한국말 변경 함수는 제가 만든 것을 사용하면 될 것 같아요!! => `src/utils/space/categoryTagChange.ts`

### 🧐 Issue number and link (참고)
- #118 

### 📚 Reference (참조)

- 아직 해결해야되는 부분
1. ActionItem 생성이 왜 회고 ID를 받는지? SpaceId를 받아서 진행하는게 맞지 않나? => 논의 후 적용 예정
2. 팀 떠나기 API 오류 => 이거는 백엔드 문제인것 같아서 코드는 완료해둠 => API 수정되면 확인 필요.
3. 회고가 날짜가 지나도 상태가 그대로 유지되던데 백엔드와 이야기 필요 => 자동으로 업데이트가 안되는 것 같음. 
4. 액션 아이템 생성 TextArea width 해결
