### PR TITLE
회고 생성 템플릿 리스트의 경우 옵션 버튼 제거

### DIFF
--- a/src/app/retrospect/template/list/TemplateListPage.tsx
+++ b/src/app/retrospect/template/list/TemplateListPage.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { useEffect, useRef } from "react";
+import { createContext, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { Icon } from "@/component/common/Icon";
@@ -8,13 +8,14 @@ import { Tabs } from "@/component/common/tabs/Tabs";
 import { Typography } from "@/component/common/typography";
 import { DefaultTemplateListItem } from "@/component/retrospect/template/list";
 import { CustomTemplateList } from "@/component/retrospect/template/list/CustomTemplateList";
-import { PATHS } from "@/config/paths";
 import { useGetDefaultTemplateList } from "@/hooks/api/template/useGetDefaultTemplateList";
 import { useRequiredParams } from "@/hooks/useRequiredParams";
 import { useTabs } from "@/hooks/useTabs";
 import { useToast } from "@/hooks/useToast";
 import { DualToneLayout } from "@/layout/DualToneLayout";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
+
+export const TemplateListPageContext = createContext<{ isCreateRetrospect: boolean; spaceId: string }>({ isCreateRetrospect: false, spaceId: "" });
 
 export function TemplateListPage() {
   const { toast } = useToast();
@@ -65,43 +66,38 @@ export function TemplateListPage() {
   }, [spaceId]);
 
   return (
-    <DualToneLayout TopComp={TemplateListTabs} title="회고 템플릿 리스트">
-      {Info}
-      <ul
-        css={css`
-          display: flex;
-          flex-direction: column;
-          gap: 2rem;
-          margin-top: 2rem;
-          padding-bottom: 2rem;
-        `}
-      >
-        {
+    <TemplateListPageContext.Provider value={{ isCreateRetrospect: isCreateRetrospect.current, spaceId }}>
+      <DualToneLayout TopComp={TemplateListTabs} title="회고 템플릿 리스트">
+        {Info}
+        <ul
+          css={css`
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+            margin-top: 2rem;
+            padding-bottom: 2rem;
+          `}
+        >
           {
-            기본: (
-              <>
-                {templates.map((template) => (
-                  <DefaultTemplateListItem
-                    key={template.id}
-                    title={template.title}
-                    tag={template.templateName}
-                    imageUrl={template.imageUrl}
-                    createRetrospect={
-                      isCreateRetrospect.current
-                        ? () =>
-                            navigate(PATHS.retrospectCreate(), {
-                              state: { spaceId, templateId: template.id },
-                            })
-                        : undefined
-                    }
-                  />
-                ))}
-              </>
-            ),
-            커스텀: <CustomTemplateList spaceId={parseInt(spaceId)} isCreateRetrospect={isCreateRetrospect.current} />,
-          }[curTab]
-        }
-      </ul>
-    </DualToneLayout>
+            {
+              기본: (
+                <>
+                  {templates.map((template) => (
+                    <DefaultTemplateListItem
+                      key={template.id}
+                      id={template.id}
+                      title={template.title}
+                      tag={template.templateName}
+                      imageUrl={template.imageUrl}
+                    />
+                  ))}
+                </>
+              ),
+              커스텀: <CustomTemplateList />,
+            }[curTab]
+          }
+        </ul>
+      </DualToneLayout>
+    </TemplateListPageContext.Provider>
   );
 }

--- a/src/component/retrospect/template/list/CustomTemplateList.tsx
+++ b/src/component/retrospect/template/list/CustomTemplateList.tsx
@@ -1,22 +1,16 @@
-import { useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useContext, useMemo } from "react";
 
 import { CustomTemplateListItem } from "./CustomTemplateListItem";
 
+import { TemplateListPageContext } from "@/app/retrospect/template/list/TemplateListPage";
 import { SkeletonCard } from "@/component/common/skeleton/SkeletonCard";
-import { PATHS } from "@/config/paths";
 import { useGetCustomTemplateList } from "@/hooks/api/template/useGetCustomTemplateList";
 import { useIntersectionObserve } from "@/hooks/useIntersectionObserve";
 import { formatDateToString } from "@/utils/formatDate";
 
-type CustomTemplateListProps = {
-  spaceId: number;
-  isCreateRetrospect?: boolean;
-};
-
-export function CustomTemplateList({ spaceId, isCreateRetrospect }: CustomTemplateListProps) {
-  const navigate = useNavigate();
-  const { data, fetchNextPage, hasNextPage } = useGetCustomTemplateList(spaceId);
+export function CustomTemplateList() {
+  const { spaceId } = useContext(TemplateListPageContext);
+  const { data, fetchNextPage, hasNextPage } = useGetCustomTemplateList(+spaceId);
   const targetDivRef = useIntersectionObserve({
     options: { threshold: 0.5 },
     onIntersect: async () => {
@@ -32,19 +26,9 @@ export function CustomTemplateList({ spaceId, isCreateRetrospect }: CustomTempla
         <CustomTemplateListItem
           key={template.id}
           id={template.id}
-          spaceId={spaceId}
           title={template.title}
           tag={template.formTag}
           date={formatDateToString(new Date(template.createdAt), ". ")}
-          createRetrospect={
-            isCreateRetrospect
-              ? () => {
-                  navigate(PATHS.retrospectCreate(), {
-                    state: { spaceId, templateId: template.id },
-                  });
-                }
-              : undefined
-          }
         />
       ))}
       {hasNextPage && <SkeletonCard ref={targetDivRef} />}

--- a/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
+++ b/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
@@ -1,18 +1,25 @@
 import { css } from "@emotion/react";
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
 
+import { TemplateListPageContext } from "@/app/retrospect/template/list/TemplateListPage";
 import { Button } from "@/component/common/button";
 import { Card } from "@/component/common/Card";
 import { Tag } from "@/component/common/tag";
 import { Typography } from "@/component/common/typography";
+import { PATHS } from "@/config/paths";
 
 type DefaultTemplateListItemProps = {
+  id: number;
   title: string;
   tag: string;
   imageUrl?: string;
   date?: string;
-  createRetrospect?: () => void;
 };
-export function DefaultTemplateListItem({ title, tag, imageUrl, createRetrospect }: DefaultTemplateListItemProps) {
+
+export function DefaultTemplateListItem({ id, title, tag, imageUrl }: DefaultTemplateListItemProps) {
+  const { spaceId, isCreateRetrospect } = useContext(TemplateListPageContext);
+  const navigate = useNavigate();
   return (
     <li>
       <Card rounded={"md"}>
@@ -33,8 +40,15 @@ export function DefaultTemplateListItem({ title, tag, imageUrl, createRetrospect
             <img src={imageUrl} width={180} height={180} />
           </div>
         )}
-        {createRetrospect ? (
-          <Button colorSchema={"outline"} onClick={createRetrospect}>
+        {isCreateRetrospect ? (
+          <Button
+            colorSchema={"outline"}
+            onClick={() => {
+              navigate(PATHS.retrospectCreate(), {
+                state: { spaceId, templateId: id },
+              });
+            }}
+          >
             선택하기
           </Button>
         ) : (

--- a/src/component/retrospect/template/list/index.ts
+++ b/src/component/retrospect/template/list/index.ts
@@ -1,2 +1,3 @@
 export { CustomTemplateList } from "./CustomTemplateList";
 export { DefaultTemplateListItem } from "./DefaultTemplateListItem";
+export { CustomTemplateListItem } from "./CustomTemplateListItem";


### PR DESCRIPTION
> ### 회고 생성 템플릿 리스트의 경우 옵션 버튼 제거
---

### 🏄🏼‍♂️‍ Summary (요약)

- 회고 생성 템플릿 리스트의 경우 옵션 버튼 제거
- spaceId를 포함해서 회고 생성에 해당하는 리스트인지에 대한 상태를 `TemplateListPage`에서 Context로 provide

### 🫨 Describe your Change (변경사항)

- 

### 🧐 Issue number and link (참고)

- #151
### 📚 Reference (참조)

-
