### PR TITLE
툴팁 꼬리 위치 고정 값으로 수정

### DIFF
--- a/src/component/common/tip/Tooltip.tsx
+++ b/src/component/common/tip/Tooltip.tsx
@@ -56,9 +56,10 @@ function Trigger({ children }: { children: React.ReactNode }) {
 type Content = {
   message: string;
   animate?: boolean;
-  placement?: Extract<VariationPlacement, "top-start" | "top-end" | "bottom-start" | "bottom-end">;
+  placement: Extract<VariationPlacement, "top-start" | "top-end" | "bottom-start" | "bottom-end">;
   modifiers?: Partial<OffsetModifier>[];
-  offset?: [number, number];
+  offsetX?: number;
+  offsetY?: number;
   hideOnClick?: boolean;
 };
 
@@ -69,7 +70,17 @@ type ContentProps =
     } & Content)
   | PropsWithChildren<{ asChild?: false } & Content>;
 
-function Content({ asChild, children, message, animate, placement = "top-end", offset = [8, 30], modifiers = [], hideOnClick = true }: ContentProps) {
+function Content({
+  asChild,
+  children,
+  message,
+  animate = true,
+  placement,
+  offsetX = 0,
+  offsetY = 30,
+  modifiers = [],
+  hideOnClick = true,
+}: ContentProps) {
   const context = useContext(TooltipContext);
 
   const [isVisible, setIsVisible] = useState(true);
@@ -95,7 +106,7 @@ function Content({ asChild, children, message, animate, placement = "top-end", o
       {
         name: "offset",
         options: {
-          offset,
+          offset: [offsetX, offsetY],
         },
       },
       ...modifiers,
@@ -103,29 +114,29 @@ function Content({ asChild, children, message, animate, placement = "top-end", o
   });
 
   const getArrowPosition = (placement: ContentProps["placement"]) => {
-    const offsetX = offset[0] + (context.referenceEl?.offsetWidth ? context.referenceEl?.offsetWidth / 2 : 0);
     const offsetY = -0.4;
+    const offsetX = 2;
     switch (placement) {
       case "top-start":
         return css`
           bottom: ${offsetY}rem;
-          left: ${offsetX}px;
+          left: ${offsetX}rem;
         `;
       case "top-end":
         return css`
           bottom: ${offsetY}rem;
-          right: ${offsetX}px;
+          right: ${offsetX}rem;
         `;
 
       case "bottom-start":
         return css`
           top: ${offsetY}rem;
-          left: ${offsetX}px;
+          left: ${offsetX}rem;
         `;
       case "bottom-end":
         return css`
           top: ${offsetY}rem;
-          right: ${offsetX}px;
+          right: ${offsetX}rem;
         `;
     }
   };

--- a/src/component/retrospect/template/recommend/RecommendDone.tsx
+++ b/src/component/retrospect/template/recommend/RecommendDone.tsx
@@ -6,12 +6,12 @@ import { Header } from "@/component/common/header";
 import { Icon } from "@/component/common/Icon";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { Spacing } from "@/component/common/Spacing";
+import { Tooltip } from "@/component/common/tip";
 import { TemplateCard } from "@/component/retrospect/template/card/TemplateCard";
 import { PATHS } from "@/config/paths";
 import { useApiRecommendTemplate } from "@/hooks/api/retrospect/recommend/useApiRecommendTemplate";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 import { RecommendTemplateType } from "@/types/retrospectCreate/recommend";
-import { Tooltip } from "@/component/common/tip";
 
 export function RecommendDone() {
   const locationState = useLocation().state as RecommendTemplateType & { spaceId: string };
@@ -52,7 +52,7 @@ export function RecommendDone() {
               onClick={() => navigate("/template", { state: { templateId: recommendData.formId } })}
             />
           </Tooltip.Trigger>
-          <Tooltip.Content message="커스텀된 템플릿의 이름을 수정할 수 있어요!" placement="top-start" hideOnClick animate />
+          <Tooltip.Content message="자세히 알고싶다면 카드를 클릭해보세요!" placement="top-start" offsetY={15} hideOnClick />
         </Tooltip>
       </div>
       <ButtonProvider>

--- a/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
+++ b/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
@@ -109,7 +109,7 @@ export function ConfirmEditTemplate({ goNext, goPrev }: QuestionsListProps) {
                     }}
                   />
                 </Tooltip.Trigger>
-                <Tooltip.Content message="커스텀된 템플릿의 이름을 수정할 수 있어요!" hideOnClick animate />
+                <Tooltip.Content message="커스텀된 템플릿의 이름을 수정할 수 있어요!" placement="top-end" offsetX={10} hideOnClick />
               </Tooltip>
             </div>
             <Tag>{tag}</Tag>


### PR DESCRIPTION
> ### 툴팁 꼬리 위치 고정 값으로 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 기존에는 툴팁 꼬리가 툴팁 기준이되는 컴포넌트의 중앙에 위치하게 하려는 의도로 기준 컴포넌트의 width를 가지고 위치를 계산했었는데, 툴팁꼬리가 툴팁 박스를 기준으로 움직이고, 툴팁 박스도 메시지에 따라 길이가 달라져서 어려울 것 같습니다.
- 툴팁 박스의 가장자리를 기준으로 2rem정도 안쪽으로 움직이도록 수정했습니다.
- x, y축 방향으로 이동시킬 거리를 튜플 형태에서 각각 number로 따로 받도록 수정했습니다.

### 🫨 Describe your Change (변경사항)

- #88

### 🧐 Issue number and link (참고)

-
### 📚 Reference (참조)

-
