### PR TITLE
액션 아이템 리스트 추가 패칭 작업 및 셔플 로직 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@egjs/react-flicking": "^4.11.3",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@hello-pangea/dnd": "^16.6.0",
     "@popperjs/core": "^2.11.8",
     "@tanstack/react-query": "^5.49.2",
     "@tanstack/react-query-devtools": "^5.49.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@emotion/styled':
     specifier: ^11.11.5
     version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.2)(react@18.3.1)
+  '@hello-pangea/dnd':
+    specifier: ^16.6.0
+    version: 16.6.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react-native@0.75.1)(react@18.3.1)
   '@popperjs/core':
     specifier: ^2.11.8
     version: 2.11.8
@@ -2354,6 +2357,27 @@ packages:
       '@hapi/hoek': 9.3.0
     dev: false
 
+  /@hello-pangea/dnd@16.6.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react-native@0.75.1)(react@18.3.1):
+    resolution: {integrity: sha512-vfZ4GydqbtUPXSLfAvKvXQ6xwRzIjUSjVU0Sx+70VOhc2xx6CdmJXJ8YhH70RpbTUGjxctslQTHul9sIOxCfFQ==}
+    peerDependencies:
+      react: ^16.8.5 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.24.7
+      css-box-model: 1.2.1
+      memoize-one: 6.0.0
+      raf-schd: 4.0.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-redux: 8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react-native@0.75.1)(react@18.3.1)(redux@4.2.1)
+      redux: 4.2.1
+      use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-native
+    dev: false
+
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -3508,7 +3532,6 @@ packages:
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
     dependencies:
       '@types/react': 18.3.2
-    dev: true
 
   /@types/react-redux@7.1.33:
     resolution: {integrity: sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==}
@@ -3533,6 +3556,10 @@ packages:
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+    dev: false
+
+  /@types/use-sync-external-store@0.0.3:
+    resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
     dev: false
 
   /@types/yargs-parser@21.0.3:
@@ -6368,6 +6395,10 @@ packages:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
     dev: false
 
+  /memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+    dev: false
+
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
     dev: false
@@ -7387,6 +7418,41 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 17.0.2
       react-native: 0.75.1(@babel/core@7.24.5)(@babel/preset-env@7.25.3)(@types/react@18.3.2)(react@18.3.1)(typescript@5.4.5)
+    dev: false
+
+  /react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1)(react-native@0.75.1)(react@18.3.1)(redux@4.2.1):
+    resolution: {integrity: sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==}
+    peerDependencies:
+      '@types/react': ^16.8 || ^17.0 || ^18.0
+      '@types/react-dom': ^16.8 || ^17.0 || ^18.0
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+      react-native: '>=0.59'
+      redux: ^4 || ^5.0.0-beta.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      redux:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@types/hoist-non-react-statics': 3.3.5
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+      '@types/use-sync-external-store': 0.0.3
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-native: 0.75.1(@babel/core@7.24.5)(@babel/preset-env@7.25.3)(@types/react@18.3.2)(react@18.3.1)(typescript@5.4.5)
+      redux: 4.2.1
+      use-sync-external-store: 1.2.2(react@18.3.1)
     dev: false
 
   /react-refresh@0.14.2:

--- a/src/app/actionItem/ActionItemEditPage.tsx
+++ b/src/app/actionItem/ActionItemEditPage.tsx
@@ -47,12 +47,6 @@ export function ActionItemEditPage() {
   const [data, setData] = useState(actionItems);
   const isLimit = data.length >= 6;
 
-  useEffect(() => {
-    const inputNodeSet = document.querySelectorAll("input");
-    const lastInputNode = inputNodeSet[inputNodeSet.length - 1];
-    lastInputNode.focus();
-  }, [data]);
-
   const handleDelete = (id: number) => {
     open({
       title: "실행 목표 삭제",

--- a/src/app/actionItem/ActionItemEditPage.tsx
+++ b/src/app/actionItem/ActionItemEditPage.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { DragDropContext, Draggable, Droppable, DropResult } from "@hello-pangea/dnd";
 import { AxiosResponse } from "axios";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { ActionItemModifyBox } from "@/component/actionItem/ActionItemModifyBox.tsx";

--- a/src/component/actionItem/ActionItemBox.tsx
+++ b/src/component/actionItem/ActionItemBox.tsx
@@ -14,7 +14,6 @@ import { PATHS } from "@/config/paths.ts";
 import { useCreateActionItem } from "@/hooks/api/actionItem/useCreateActionItem.ts";
 import { useBottomSheet } from "@/hooks/useBottomSheet.ts";
 import { useInput } from "@/hooks/useInput.ts";
-import { useModal } from "@/hooks/useModal.ts";
 import { useToast } from "@/hooks/useToast.ts";
 import { ANIMATION } from "@/style/common/animation.ts";
 import { DESIGN_TOKEN_COLOR, DESIGN_TOKEN_TEXT } from "@/style/designTokens.ts";
@@ -63,7 +62,6 @@ export default function ActionItemBox({
   const { mutate, isPending } = useCreateActionItem();
   const { toast } = useToast();
   const navigate = useNavigate();
-  const { open } = useModal();
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -298,13 +296,6 @@ export default function ActionItemBox({
                     navigate(PATHS.goalsEdit(), {
                       state: {
                         data: retrospectInfo,
-                      },
-                    });
-                    open({
-                      title: "현재 해당 기능은 준비중이에요",
-                      contents: "빠르게 개발을 진행하고 있으니, 잠시만 기다려주세요!",
-                      options: {
-                        type: "alert",
                       },
                     });
                   }}

--- a/src/component/actionItem/ActionItemModifyBox.tsx
+++ b/src/component/actionItem/ActionItemModifyBox.tsx
@@ -2,8 +2,7 @@ import { css } from "@emotion/react";
 import { HTMLAttributes } from "react";
 
 import { Icon } from "@/component/common/Icon";
-import { DESIGN_TOKEN_COLOR } from "@/style/designTokens.ts";
-import { DESIGN_SYSTEM_COLOR } from "@/style/variable.ts";
+import { DESIGN_TOKEN_COLOR, DESIGN_TOKEN_TEXT } from "@/style/designTokens.ts";
 
 type ActionItemModifyBoxProps = {
   contents: string;
@@ -32,15 +31,8 @@ export function ActionItemModifyBox({ actionItemId, handleChange, contents, dele
         value={contents}
         onChange={handleChange}
         css={css`
+          ${DESIGN_TOKEN_TEXT.body14Medium};
           flex-grow: 1;
-        `}
-      />
-      <Icon
-        icon="ic_handle"
-        color={DESIGN_SYSTEM_COLOR.lightGrey3}
-        size={"1.8rem"}
-        css={css`
-          margin-left: auto;
         `}
       />
     </div>


### PR DESCRIPTION
> ### 액션 아이템 리스트 추가 패칭 작업 및 셔플 로직 추가
---

### 🏄🏼‍♂️‍ Summary (요약)
- 액션 아이템 리스트 추가 패칭 작업 및 셔플 로직 추가

### 🫨 Describe your Change (변경사항)
- 커밋 내용 참조

### 🧐 Issue number and link (참고)
- #35 
-
### 📚 Reference (참조)
- `react-beautiful-dnd`를 이용한 리스트 셔플 기능을 사용하게 되면 개발 환경에서는 `StrictMode`를 제거해야 테스트를 할 수 있어요, 이에 따라 해당 코드를 지우거나 배포 환경에서 테스트가 가능한데 `@hello-pangea/dnd` 라이브러리로 대체를 하게 되면 개발 환경에서도 테스트가 가능할 뿐만 아니라 컴포넌트 사용 방법도 동일해요!

https://github.com/user-attachments/assets/59266d02-7514-461a-8b4e-2f5e4b113ad2


