### PR TITLE
스페이스 생성 완료 후 추천 페이지로 이동

### DIFF
--- a/src/app/space/CreateNextPage.tsx
+++ b/src/app/space/CreateNextPage.tsx
@@ -49,7 +49,7 @@ export function CreateNextPage() {
         />
       </div>
       <ButtonProvider>
-        <ButtonProvider.Primary onClick={() => navigate(PATHS.retrospectCreate(), { state: { spaceId, templateId: 10001 } })}>
+        <ButtonProvider.Primary onClick={() => navigate(PATHS.retrospectRecommend(), { state: { spaceId } })}>
           회고 템플릿 추천 받기
         </ButtonProvider.Primary>
         <div css={laterTextStyles}>다음에 하기</div>

--- a/src/app/space/SpaceViewPage.tsx
+++ b/src/app/space/SpaceViewPage.tsx
@@ -81,7 +81,7 @@ export function SpaceViewPage() {
         },
         onConfirm: () => {
           navigate(PATHS.retrospectCreate(), {
-            state: { spaceId, templateId: spaceInfo.formId, saveTemplateId: true },
+            state: { spaceId, templateId: spaceInfo.formId },
           });
         },
       });

--- a/src/component/retrospect/template/recommend/RecommendDone.tsx
+++ b/src/component/retrospect/template/recommend/RecommendDone.tsx
@@ -63,7 +63,13 @@ export function RecommendDone() {
           `}
         >
           <ButtonProvider.Gray onClick={() => navigate(PATHS.template(locationState.spaceId))}>템플릿 변경</ButtonProvider.Gray>
-          <ButtonProvider.Primary onClick={() => navigate(PATHS.retrospectCreate(), { state: { spaceId: locationState.spaceId } })}>
+          <ButtonProvider.Primary
+            onClick={() =>
+              navigate(PATHS.retrospectCreate(), {
+                state: { spaceId: locationState.spaceId, templateId: recommendData.formId, saveTemplateId: true },
+              })
+            }
+          >
             진행하기
           </ButtonProvider.Primary>
         </div>

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -19,6 +19,7 @@ import { GoogleLoginRedirection } from "@/app/login/GoogleLoginRedirection";
 import { KakaoLoginRedirection } from "@/app/login/KakaoLoginRedirection";
 import { LoginPage } from "@/app/login/LoginPage";
 import { SetNickNamePage } from "@/app/login/SetNicknamePage";
+import { RetrospectAnalysisPage } from "@/app/retrospect/analysis/RetrospectAnalysisPage";
 import { TemplateListPage } from "@/app/retrospect/template/list/TemplateListPage";
 import { RecommendDonePage } from "@/app/retrospect/template/recommend/RecommendDonePage";
 import { RecommendTemplatePage } from "@/app/retrospect/template/recommend/RecommendTemplatePage";
@@ -36,7 +37,6 @@ import { RetrospectWritePage } from "@/app/write/RetrospectWritePage.tsx";
 import GlobalLayout from "@/layout/GlobalLayout.tsx";
 import { HomeLayout } from "@/layout/HomeLayout";
 import { RequireLoginLayout } from "@/layout/RequireLoginLayout";
-import { RetrospectAnalysisPage } from "@/app/retrospect/analysis/RetrospectAnalysisPage";
 
 type RouteChildren = {
   auth: boolean;


### PR DESCRIPTION
> ### 스페이스 생성 완료 후 추천 페이지로 이동
---

### 🏄🏼‍♂️‍ Summary (요약)

- 임시로 회고 생성으로 넘어가게 작성했던 플로우를 제거했습니다.
- 템플릿 추천 완료 후, 회고 생성으로 바로 넘어갈 때 `templateId`, `saveTemplateId` state를 추가로 전달합니다.
- '전에 진행했던 템플릿이 있어요. 계속 진행하시겠어요?' 모달에서 '진행하기'를 클릭한 경우는 새로 템플릿 ID를 대표 템플릿으로 지정하지 않도록 수정했습니다. (불필요하게 API 호출하지 않도록) 

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

-
### 📚 Reference (참조)

-
