### PR TITLE
[QA] 템플릿 버튼 ReadOnly 로직 수정

### DIFF
--- a/src/app/retrospect/template/list/TemplateListPage.tsx
+++ b/src/app/retrospect/template/list/TemplateListPage.tsx
@@ -20,13 +20,17 @@ export const TemplateListPageContext = createContext<{ isCreateRetrospect: boole
 export function TemplateListPage() {
   const { toast } = useToast();
   const navigate = useNavigate();
-  const locationState = useLocation().state as { createRetrospect?: boolean };
+  const locationState = useLocation().state as { createRetrospect?: boolean; readOnly?: boolean };
   const isCreateRetrospect = useRef(false);
-  if (locationState && locationState.createRetrospect) {
-    isCreateRetrospect.current = true;
+  const isReadOnly = useRef(false);
+  if (locationState) {
+    if (locationState.createRetrospect) isCreateRetrospect.current = true;
+    if (locationState.readOnly) isReadOnly.current = true;
   }
+
   const { data: templates } = useGetDefaultTemplateList();
   const { spaceId } = useRequiredParams<{ spaceId: string }>();
+
   const { tabs, curTab, selectTab } = useTabs(["기본", "커스텀"] as const);
   const TemplateListTabs = (
     <Tabs
@@ -91,11 +95,12 @@ export function TemplateListPage() {
                       title={template.title}
                       tag={template.templateName}
                       imageUrl={template.imageUrl}
+                      readOnly={isReadOnly.current}
                     />
                   ))}
                 </>
               ),
-              커스텀: <CustomTemplateList />,
+              커스텀: <CustomTemplateList readOnly={isReadOnly.current} />,
             }[curTab]
           }
         </ul>

--- a/src/app/template/TemplatePage.tsx
+++ b/src/app/template/TemplatePage.tsx
@@ -19,7 +19,7 @@ export function TemplatePage() {
   const [isColliding, setIsColliding] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
-  const { templateId, readOnly } = location?.state as { templateId: number; readOnly: boolean };
+  const { templateId, readOnly = true } = location?.state as { templateId: number; readOnly: boolean };
 
   /**
    * template
@@ -199,7 +199,7 @@ export function TemplatePage() {
               <ExampleButton> {data?.templateName ?? ""} 회고 예시 보기 </ExampleButton>
             </article>
           </section>
-          {readOnly && (
+          {!readOnly && (
             <ButtonProvider>
               <Button>선택하기</Button>
             </ButtonProvider>

--- a/src/component/retrospect/template/list/CustomTemplateList.tsx
+++ b/src/component/retrospect/template/list/CustomTemplateList.tsx
@@ -8,8 +8,14 @@ import { useGetCustomTemplateList } from "@/hooks/api/template/useGetCustomTempl
 import { useIntersectionObserve } from "@/hooks/useIntersectionObserve";
 import { formatDateToString } from "@/utils/formatDate";
 
-export function CustomTemplateList() {
+export function CustomTemplateList({ readOnly }: { readOnly?: boolean }) {
   const { spaceId } = useContext(TemplateListPageContext);
+  /**
+   * NOTE: 리드미 Props는 아래의 의미를 가지고 있습니다.
+   * - ReadOnly: 버튼 유무 상태
+   * */
+
+  console.log(readOnly);
   const { data, fetchNextPage, hasNextPage } = useGetCustomTemplateList(+spaceId);
   const targetDivRef = useIntersectionObserve({
     options: { threshold: 0.5 },

--- a/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
+++ b/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
@@ -15,9 +15,10 @@ type DefaultTemplateListItemProps = {
   tag: string;
   imageUrl?: string;
   date?: string;
+  readOnly?: boolean;
 };
 
-export function DefaultTemplateListItem({ id, title, tag, imageUrl }: DefaultTemplateListItemProps) {
+export function DefaultTemplateListItem({ id, title, tag, imageUrl, readOnly }: DefaultTemplateListItemProps) {
   const { spaceId, isCreateRetrospect } = useContext(TemplateListPageContext);
   const navigate = useNavigate();
   return (
@@ -58,6 +59,7 @@ export function DefaultTemplateListItem({ id, title, tag, imageUrl }: DefaultTem
               navigate(PATHS.viewDetailTemplate(), {
                 state: {
                   templateId: id,
+                  readOnly: readOnly,
                 },
               })
             }

--- a/src/component/retrospect/template/recommend/RecommendDone.tsx
+++ b/src/component/retrospect/template/recommend/RecommendDone.tsx
@@ -14,7 +14,7 @@ import { DefaultLayout } from "@/layout/DefaultLayout";
 import { RecommendTemplateType } from "@/types/retrospectCreate/recommend";
 
 export function RecommendDone() {
-  const locationState = useLocation().state as RecommendTemplateType & { spaceId: string; readOnly: boolean };
+  const locationState = useLocation().state as RecommendTemplateType & { spaceId: string; readOnly?: boolean };
   const navigate = useNavigate();
   const { data: recommendData, isLoading } = useApiRecommendTemplate(locationState);
 

--- a/src/component/retrospect/template/recommend/RecommendDone.tsx
+++ b/src/component/retrospect/template/recommend/RecommendDone.tsx
@@ -14,7 +14,7 @@ import { DefaultLayout } from "@/layout/DefaultLayout";
 import { RecommendTemplateType } from "@/types/retrospectCreate/recommend";
 
 export function RecommendDone() {
-  const locationState = useLocation().state as RecommendTemplateType & { spaceId: string };
+  const locationState = useLocation().state as RecommendTemplateType & { spaceId: string; readOnly: boolean };
   const navigate = useNavigate();
   const { data: recommendData, isLoading } = useApiRecommendTemplate(locationState);
 
@@ -49,7 +49,7 @@ export function RecommendDone() {
               name={recommendData.formName}
               tag={recommendData.tag}
               imgUrl={recommendData.formImageUrl}
-              onClick={() => navigate("/template", { state: { templateId: recommendData.formId, readOnly: true } })}
+              onClick={() => navigate("/template", { state: { templateId: recommendData.formId, readOnly: false } })}
             />
           </Tooltip.Trigger>
           <Tooltip.Content message="자세히 알고싶다면 카드를 클릭해보세요!" placement="top-start" offsetY={15} hideOnClick />
@@ -62,7 +62,17 @@ export function RecommendDone() {
             gap: 0.8rem;
           `}
         >
-          <ButtonProvider.Gray onClick={() => navigate(PATHS.template(locationState.spaceId))}>템플릿 변경</ButtonProvider.Gray>
+          <ButtonProvider.Gray
+            onClick={() =>
+              navigate(PATHS.template(locationState.spaceId), {
+                state: {
+                  readOnly: false,
+                },
+              })
+            }
+          >
+            템플릿 변경
+          </ButtonProvider.Gray>
           <ButtonProvider.Primary
             onClick={() =>
               navigate(PATHS.retrospectCreate(), {

--- a/src/component/space/view/SpaceCountView.tsx
+++ b/src/component/space/view/SpaceCountView.tsx
@@ -37,7 +37,13 @@ export function SpaceCountView({ mainTemplate, memberCount }: SpaceCountViewProp
           justify-content: space-between;
           flex-basis: 50%;
         `}
-        onClick={() => navigate(PATHS.template(spaceId))}
+        onClick={() =>
+          navigate(PATHS.template(spaceId), {
+            state: {
+              readOnly: true,
+            },
+          })
+        }
       >
         <div
           css={css`


### PR DESCRIPTION
> ### 템플릿 버튼 ReadOnly 로직 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 템플릿 버튼 ReadOnly 로직 수정을 진행했어요

### 🫨 Describe your Change (변경사항)
- 커밋 내용을 참고해주세요

### 🧐 Issue number and link (참고)
- #151 
-
### 📚 Reference (참조)
- @donghunee 요청대로 회고 생성 시에 템플릿 페이지를 조회하는 플로우에 대한 버튼 노출 로직을 설계했고, 
스페이스에서 확인할 수 있는 템플릿 페이지 조회 로직에는 버튼이 노출되지 않도록 설계했어요.

- 해당 PR을 올린 배경은 현재 템플릿 상세 조회 페이지로 이동하는 과정을 여러 곳에서 요청을 하고 있어요

1. 스페이스 뷰에서 `대표 템플릿` 란을 통해 단순 템플릿 내용을 조회하는 순간
2. 회고 생성 중 템플릿 조회 페이지로 이동하여 템플릿을 선택하는 순간

-  로직을 일부 수정하면서 느꼈는데 지금 템플릿 상세 조회 페이지로 이동하는 과정에서 상태 관리가 점점 복잡해진다고 생각했어요, 지금은 일일히 명시를 하여 구현을 진행했는데 더 좋은 방법이 있는지, 혹은 리팩토링을 어떤 방식으로 진행할 수 있는지 같이 이야기를 나눠보면 좋을 것 같아요!


<img width="479" alt="스크린샷 2024-08-25 오후 4 50 51" src="https://github.com/user-attachments/assets/1f6363a6-4961-495e-9e5b-6fa653c8a828">
