### PR TITLE
DateTimePicker 반환값 timezone offset 제거

### DIFF
--- a/src/hooks/useDateTimePicker.ts
+++ b/src/hooks/useDateTimePicker.ts
@@ -12,7 +12,7 @@ export const useDateTimePicker = (defaultDate?: Value, defaultTime?: string) => 
   const { isChecked: isTimeChecked, onChange: onTimeChange, selectedValue: selectedTime } = useRadioButton(defaultTime);
 
   const dateString = useMemo(() => {
-    return selectedDate instanceof Date ? formatISO(selectedDate) : undefined;
+    return selectedDate instanceof Date ? formatISO(selectedDate).split("+")[0] : undefined;
   }, [selectedDate]);
 
   const dateTimeString = useMemo(() => {


### PR DESCRIPTION
> ### DateTimePicker 반환값 timezone offset 제거
---

### 🏄🏼‍♂️‍ Summary (요약)

- 일관성을 위해 ISO string의 timezone offset 부분을 제거했습니다.
- 이슈 참고

### 🫨 Describe your Change (변경사항)

- 

### 🧐 Issue number and link (참고)

- #191
### 📚 Reference (참조)

-
