### PR TITLE
템플릿 리스트 빈 화면 추가

### DIFF
--- a/src/app/retrospect/template/list/TemplateListPage.tsx
+++ b/src/app/retrospect/template/list/TemplateListPage.tsx
@@ -78,6 +78,7 @@ export function TemplateListPage() {
             display: flex;
             flex-direction: column;
             gap: 2rem;
+            min-height: 100%;
             margin-top: 2rem;
             padding-bottom: 2rem;
           `}
@@ -97,7 +98,7 @@ export function TemplateListPage() {
                   ))}
                 </>
               ),
-              커스텀: <CustomTemplateList readOnly={isReadOnly.current} />,
+              커스텀: <CustomTemplateList />,
             }[curTab]
           }
         </ul>

--- a/src/component/common/dropdownMenu/DropdownMenu.tsx
+++ b/src/component/common/dropdownMenu/DropdownMenu.tsx
@@ -87,7 +87,16 @@ export function DropdownMenu({ children, onValueChange, placement = "bottom-end"
 
 function Trigger({ asChild, children }: { asChild: true; children: React.ReactNode } | PropsWithChildren<{ asChild?: false }>) {
   const context = useContext(DropdownMenuContext);
-  return <button onClick={() => context?.toggle()}>{asChild ? children : <Icon icon={"ic_more"} color={DESIGN_TOKEN_COLOR.gray600} />}</button>;
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        context?.toggle();
+      }}
+    >
+      {asChild ? children : <Icon icon={"ic_more"} color={DESIGN_TOKEN_COLOR.gray600} />}
+    </button>
+  );
 }
 
 function Content({ children }: { children: React.ReactNode }) {

--- a/src/component/common/empty/EmptyList.tsx
+++ b/src/component/common/empty/EmptyList.tsx
@@ -1,0 +1,35 @@
+import { css } from "@emotion/react";
+
+import { Icon } from "@/component/common/Icon";
+import { Typography } from "@/component/common/typography";
+
+type EmptyListProps = {
+  message: React.ReactNode;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export function EmptyList({ message, ...props }: EmptyListProps) {
+  return (
+    <div
+      css={css`
+        display: flex;
+        height: 100%;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.8rem;
+      `}
+      {...props}
+    >
+      <Icon icon="ic_clock" size={7.2} />
+      <div
+        css={css`
+          text-align: center;
+        `}
+      >
+        <Typography variant="body16Medium" color="gray600">
+          {message}
+        </Typography>
+      </div>
+    </div>
+  );
+}

--- a/src/component/common/empty/index.ts
+++ b/src/component/common/empty/index.ts
@@ -1,0 +1,1 @@
+export { EmptyList } from "./EmptyList";

--- a/src/component/retrospect/template/list/CustomTemplateList.tsx
+++ b/src/component/retrospect/template/list/CustomTemplateList.tsx
@@ -1,21 +1,18 @@
+import { css } from "@emotion/react";
 import { useContext, useMemo } from "react";
 
 import { CustomTemplateListItem } from "./CustomTemplateListItem";
 
 import { TemplateListPageContext } from "@/app/retrospect/template/list/TemplateListPage";
+import { EmptyList } from "@/component/common/empty";
 import { SkeletonCard } from "@/component/common/skeleton/SkeletonCard";
 import { useGetCustomTemplateList } from "@/hooks/api/template/useGetCustomTemplateList";
 import { useIntersectionObserve } from "@/hooks/useIntersectionObserve";
 import { formatDateToString } from "@/utils/formatDate";
 
-export function CustomTemplateList({ readOnly }: { readOnly?: boolean }) {
+export function CustomTemplateList() {
   const { spaceId } = useContext(TemplateListPageContext);
-  /**
-   * NOTE: 리드미 Props는 아래의 의미를 가지고 있습니다.
-   * - ReadOnly: 버튼 유무 상태
-   * */
 
-  console.log(readOnly);
   const { data, fetchNextPage, hasNextPage } = useGetCustomTemplateList(+spaceId);
   const targetDivRef = useIntersectionObserve({
     options: { threshold: 0.5 },
@@ -28,16 +25,33 @@ export function CustomTemplateList({ readOnly }: { readOnly?: boolean }) {
   const templates = useMemo(() => data.pages.flatMap(({ content }) => content), [data.pages]);
   return (
     <>
-      {templates.map((template) => (
-        <CustomTemplateListItem
-          key={template.id}
-          id={template.id}
-          title={template.title}
-          tag={template.formTag}
-          date={formatDateToString(new Date(template.createdAt), ". ")}
+      {templates.length === 0 ? (
+        <EmptyList
+          message={
+            <>
+              생성한 커스텀 템플릿이
+              <br />
+              아직 없어요!
+            </>
+          }
+          css={css`
+            margin-top: -5rem;
+          `}
         />
-      ))}
-      {hasNextPage && <SkeletonCard ref={targetDivRef} />}
+      ) : (
+        <>
+          {templates.map((template) => (
+            <CustomTemplateListItem
+              key={template.id}
+              id={template.id}
+              title={template.title}
+              tag={template.formTag}
+              date={formatDateToString(new Date(template.createdAt), ". ")}
+            />
+          ))}
+          {hasNextPage && <SkeletonCard ref={targetDivRef} />}
+        </>
+      )}
     </>
   );
 }

--- a/src/component/retrospect/template/list/CustomTemplateListItem.tsx
+++ b/src/component/retrospect/template/list/CustomTemplateListItem.tsx
@@ -32,12 +32,13 @@ export function CustomTemplateListItem({ id, title, tag, date }: CustomTemplateL
   const { spaceId, readOnly } = useContext(TemplateListPageContext);
   const navigate = useNavigate();
   const { open } = useModal();
-  const { openBottomSheet } = useBottomSheet();
+  const { openBottomSheet, closeBottomSheet } = useBottomSheet();
   const { value: templateTitle, handleInputChange: handleChangeTitle } = useInput(title);
   const { mutate: patchTemplateTitle } = usePatchTemplateTitle(+spaceId);
   const { mutate: deleteCustomTemplate } = useDeleteCustomTemplate(+spaceId);
   const handleSubmitTitle = () => {
     patchTemplateTitle({ formId: id, formTitle: templateTitle });
+    closeBottomSheet();
   };
   const handleOptionSelect = (option: string) => {
     if (option === MENU_EDIT) {


### PR DESCRIPTION
> ### 템플릿 리스트 빈 화면 추가
---

### 🏄🏼‍♂️‍ Summary (요약)

- 템플릿 리스트 빈 화면 추가
- 템플릿 이름 수정 후 바텀시트 닫기
- 드롭다운 버튼 클릭 이벤트 버블링 차단 (템플릿 상세로 이동 차단)

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

- #151 
### 📚 Reference (참조)

-
