### PR TITLE
기본 템플릿 수정여부 필드 반대로 된 문제 수정

### DIFF
--- a/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
+++ b/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
@@ -71,7 +71,7 @@ export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
     setRetroCreateData((prev) => ({
       ...prev,
       isNewForm: isEdited,
-      hasChangedOriginal: isDefaultExtended,
+      hasChangedOriginal: !isDefaultExtended,
       questions: newQuestions,
       formName: `커스텀 템플릿`,
     }));

--- a/src/types/retrospectCreate/index.ts
+++ b/src/types/retrospectCreate/index.ts
@@ -17,7 +17,7 @@ export type RetrospectCreateReq = {
    */
   isNewForm: boolean;
   /**
-   * 기본 템플릿 질문을 유지한 채로 새로 커스텀 질문을 추가만 한 경우 true
+   * 기본 템플릿 질문을 유지한 채로 새로 커스텀 질문을 추가만 한 경우 false
    */
   hasChangedOriginal: boolean;
   formName?: string;


### PR DESCRIPTION
> ### 기본 템플릿 수정여부 필드 반대로 된 문제 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- #239 해당 PR에서 boolean만 반대로입니다!

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

- #235 
### 📚 Reference (참조)

-
