### PR TITLE
회고, 템플릿 수정 및 삭제 낙관적 업데이트

### DIFF
--- a/src/hooks/api/retrospect/useApiDeleteRetrospect.ts
+++ b/src/hooks/api/retrospect/useApiDeleteRetrospect.ts
@@ -1,6 +1,7 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
+import { RestrospectResponse } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
 import { useToast } from "@/hooks/useToast";
 
 export const useApiDeleteRetrospect = () => {
@@ -11,14 +12,31 @@ export const useApiDeleteRetrospect = () => {
     return response;
   };
 
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ spaceId, retrospectId }: { spaceId: string | undefined; retrospectId: string | undefined }) =>
       retrospectDelete(spaceId, retrospectId),
-    onSuccess: () => {
-      toast.success("회고록 삭제에 성공하였습니다.");
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey: ["getRetrospects", variables.spaceId] });
+      const prevList = queryClient.getQueryData(["getRetrospects", variables.spaceId]);
+      queryClient.setQueryData(["getRetrospects", variables.spaceId], (old: RestrospectResponse) => {
+        return {
+          ...old,
+          retrospects: old.retrospects.filter((item) => item.retrospectId !== Number(variables.retrospectId)),
+        };
+      });
+      return { prevList };
     },
-    onError: (error) => {
-      toast.error(error.message);
+    onError: (error, variables, context) => {
+      toast.error("다시 시도해주세요");
+      console.error("mutate error with", error);
+      queryClient.setQueryData(["getRetrospects", variables.spaceId], context?.prevList);
+    },
+    onSettled: async (_, __, variables) => {
+      await queryClient.invalidateQueries({ queryKey: ["getRetrospects", variables.spaceId] });
+    },
+    onSuccess: () => {
+      toast.success("회고 삭제에 성공하였습니다.");
     },
   });
 };

--- a/src/hooks/api/retrospect/useApiOptionsGetRetrospects.ts
+++ b/src/hooks/api/retrospect/useApiOptionsGetRetrospects.ts
@@ -3,7 +3,7 @@ import { UseQueryOptions } from "@tanstack/react-query";
 import { api } from "@/api";
 import { Retrospect } from "@/types/retrospect";
 
-type RestrospectResponse = {
+export type RestrospectResponse = {
   layerCount: number;
   retrospects: Retrospect[];
 };
@@ -14,7 +14,7 @@ const spaceRestrospectFetch = async (spaceId: string | undefined) => {
 };
 
 export const useApiOptionsGetRetrospects = (spaceId?: string): UseQueryOptions<RestrospectResponse, Error, RestrospectResponse["retrospects"]> => ({
-  queryKey: ["getRetrospects", spaceId!],
+  queryKey: ["getRetrospects", spaceId!], //FIXME - query key 상수화
   queryFn: () => spaceRestrospectFetch(spaceId),
   select(data) {
     return data.retrospects;

--- a/src/hooks/api/template/usePatchTemplateTitle.ts
+++ b/src/hooks/api/template/usePatchTemplateTitle.ts
@@ -1,23 +1,41 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
+import { CustomTemplateListRes } from "@/types/template";
 
 type PatchTemplateTitle = { formTitle: string; formId: number };
 
 export const usePatchTemplateTitle = (spaceId: number) => {
   const patchTemplateTitle = async ({ formTitle, formId }: PatchTemplateTitle) => {
-    const { data } = await api.patch<PatchTemplateTitle>(`/form/${formId}/title`, { formTitle });
-    return data;
+    const res = await api.patch(`/form/${formId}/title`, { formTitle });
+    return res;
   };
 
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: patchTemplateTitle,
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ["getCustomTemplateList", spaceId], //FIXME - query key 상수화
+    onMutate: async (newTemplate) => {
+      await queryClient.cancelQueries({ queryKey: ["getCustomTemplateList", spaceId] });
+      const prevList = queryClient.getQueryData(["getCustomTemplateList", spaceId]);
+      queryClient.setQueryData(["getCustomTemplateList", spaceId], (old: InfiniteData<CustomTemplateListRes["customTemplateList"]>) => {
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            content: page.content.map((item) => (item.id === newTemplate.formId ? { ...item, title: newTemplate.formTitle } : item)),
+          })),
+        };
       });
+      console.log("mutate called with", newTemplate);
+      return { prevList, newTemplate };
+    },
+    onError: (error, _, context) => {
+      console.error("mutate error with", error);
+      queryClient.setQueryData(["getCustomTemplateList", spaceId], context?.prevList);
+    },
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["getCustomTemplateList", spaceId] });
     },
   });
 };


### PR DESCRIPTION
> ### 회고, 템플릿 수정 및 삭제 낙관적 업데이트
---

### 🏄🏼‍♂️‍ Summary (요약)

- 템플릿 이름 수정 낙관적 업데이트
- 템플릿 삭제 낙관적 업데이트
- 회고 삭제 낙관적 업데이트

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

- #193 
### 📚 Reference (참조)

- 현재 쿼리 키를 상수처리하지 않고 그대로 사용하고 있어요. 외부에서 제어하고 있는 쿼리 키는 `FIXME` 주석을 달아두긴 했는데, 추후 상수로 리팩토링 해야 쿼리 키 수정으로 인해 생기는 버그를 방지할 수 있을 것 같아요!
