### PR TITLE
hotfix: #269 초대 페이지에서 로그인 성공한 케이스 처리

### DIFF
--- a/src/component/space/join/JoinSpace.tsx
+++ b/src/component/space/join/JoinSpace.tsx
@@ -51,7 +51,7 @@ export function JoinSpace() {
             onClick={() =>
               mutate(Number(spaceId), {
                 onSuccess: () => {
-                  toast.success(`스페이스에 초대 되었어요!`);
+                  toast.success(`스페이스에 초대되었어요!`);
                   navigate(PATHS.spaceDetail(spaceId));
                 },
                 onError: (error) => {

--- a/src/hooks/api/login/usePostAppleToken.ts
+++ b/src/hooks/api/login/usePostAppleToken.ts
@@ -72,12 +72,14 @@ export const usePostAppleLogin = () => {
 
         mutate(parseInt(saveSpaceIdPhase), {
           onSuccess: () => {
-            toast.success("첫 스페이스에 오신 걸 환영해요!");
+            toast.success("스페이스에 초대되었어요!");
             moveNextPhase();
           },
-          onError: () => {
-            toast.success("이미 참여한 스페이스로 이동했어요!");
-            moveNextPhase();
+          onError: (error) => {
+            if (error.status === 400) {
+              toast.success("이미 참여한 스페이스로 이동했어요!");
+              moveNextPhase();
+            }
           },
         });
       } else {

--- a/src/hooks/api/login/usePostSignIn.ts
+++ b/src/hooks/api/login/usePostSignIn.ts
@@ -59,6 +59,10 @@ export const usePostSignIn = () => {
       const saveSpaceIdPhase = Cookies.get(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);
       if (saveSpaceIdPhase) {
         mutate(parseInt(saveSpaceIdPhase), {
+          onSuccess: (_, spaceId) => {
+            toast.success(`스페이스에 초대되었어요!`);
+            navigate(PATHS.spaceDetail(spaceId.toString()));
+          },
           onError: (error) => {
             if (error.status === 400) {
               toast.success("이미 참여한 스페이스로 이동했어요!");

--- a/src/hooks/api/login/usePostSignIn.ts
+++ b/src/hooks/api/login/usePostSignIn.ts
@@ -58,16 +58,20 @@ export const usePostSignIn = () => {
 
       const saveSpaceIdPhase = Cookies.get(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);
       if (saveSpaceIdPhase) {
+        const moveNextPhase = () => {
+          navigate(PATHS.spaceDetail(saveSpaceIdPhase));
+          Cookies.remove(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);
+        };
+
         mutate(parseInt(saveSpaceIdPhase), {
-          onSuccess: (_, spaceId) => {
+          onSuccess: () => {
             toast.success(`스페이스에 초대되었어요!`);
-            navigate(PATHS.spaceDetail(spaceId.toString()));
+            moveNextPhase();
           },
           onError: (error) => {
             if (error.status === 400) {
               toast.success("이미 참여한 스페이스로 이동했어요!");
-              navigate(PATHS.spaceDetail(saveSpaceIdPhase));
-              Cookies.remove(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);
+              moveNextPhase();
             }
           },
         });

--- a/src/hooks/api/login/usePostSignUp.ts
+++ b/src/hooks/api/login/usePostSignUp.ts
@@ -50,7 +50,6 @@ export const usePostSignUp = () => {
 
       const saveSpaceIdPhase = Cookies.get(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);
       if (saveSpaceIdPhase) {
-        console.log(saveSpaceIdPhase);
         mutate(parseInt(saveSpaceIdPhase), {
           onSuccess: () => {
             toast.success("첫 스페이스에 오신 걸 환영해요!");


### PR DESCRIPTION
> ### 초대 페이지에서 로그인 성공한 케이스 처리
---

### 🏄🏼‍♂️‍ Summary (요약)

- 초대 페이지에서 로그인 성공한 케이스 처리
- 애플 로그인해서 초대 수락된 경우 멘트 수정 ('첫 스페이스~' → '스페이스에 초대되었어요')
- 처리 후 space id 쿠키 삭제

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

- #269 
### 📚 Reference (참조)

-
