### PR TITLE
hotfix: 회고 작성 시 range 데이터 0~100 단위로 수정

### DIFF
--- a/src/hooks/api/write/useWriteQuestions.ts
+++ b/src/hooks/api/write/useWriteQuestions.ts
@@ -14,7 +14,10 @@ type writeQuestionsProps = {
 export const useWriteQuestions = () => {
   const writeQuestions = ({ data, isTemporarySave = false, spaceId, retrospectId, method = "POST" }: writeQuestionsProps) => {
     const url = `/space/${spaceId}/retrospect/${retrospectId}/answer`;
-    const payload = { requests: data, ...(method === "POST" && { isTemporarySave }) };
+    const fixedData = data.map((curData) =>
+      curData.questionType === "range" ? { ...curData, answerContent: parseInt(curData.answerContent) * 20 + 20 } : curData,
+    );
+    const payload = { requests: fixedData, ...(method === "POST" && { isTemporarySave }) };
 
     if (method === "POST") {
       return api.post(url, payload);


### PR DESCRIPTION
> ### 회고 작성 시 range 데이터 0~100 단위로 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 분석 응답 데이터를 0부터 100까지 퍼센티지로 반환하고 있는데, 회고 작성 시 0부터 4까지 인덱스값으로 POST해서 분석 데이터가 부정확하게 나오는 문제
→ 작성 시 0부터 100까지 20 단위로 POST
@klmhyeonwoo 

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

-
### 📚 Reference (참조)

-
