### PR TITLE
hotfix: 분석 페이지 제목, 이름 수정

### DIFF
--- a/src/app/retrospect/analysis/RetrospectAnalysisPage.tsx
+++ b/src/app/retrospect/analysis/RetrospectAnalysisPage.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from "react";
+import { useLocation } from "react-router-dom";
 
 import { LoadingModal } from "@/component/common/Modal/LoadingModal.tsx";
 import { TabButton } from "@/component/common/tabs/TabButton";
@@ -11,6 +12,8 @@ import { useTabs } from "@/hooks/useTabs";
 import { DualToneLayout } from "@/layout/DualToneLayout";
 
 export const RetrospectAnalysisPage = () => {
+  const { title } = useLocation().state as { title: string };
+
   const tabMappings = {
     질문: "QUESTIONS",
     개별: "INDIVIDUAL_ANALYSIS",
@@ -27,7 +30,7 @@ export const RetrospectAnalysisPage = () => {
   return (
     <DualToneLayout
       bottomTheme="gray"
-      title={"중간 발표 회고"}
+      title={title}
       TopComp={
         <Fragment>
           <Tabs tabs={tabs} curTab={curTab} selectTab={selectTab} TabComp={TabButton} fullWidth={false} />

--- a/src/component/retrospect/analysis/InsightsBoxSection.tsx
+++ b/src/component/retrospect/analysis/InsightsBoxSection.tsx
@@ -1,8 +1,10 @@
 import { css } from "@emotion/react";
+import { useAtomValue } from "jotai";
 
 import { Icon } from "@/component/common/Icon";
 import { Spacing } from "@/component/common/Spacing";
 import { Typography } from "@/component/common/typography";
+import { authAtom } from "@/store/auth/authAtom";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { analysisType, Insight } from "@/types/analysis";
 
@@ -13,6 +15,7 @@ type InsightsBoxProps = {
 };
 
 export function InsightsBoxSection({ isTeam, type, insightArr }: InsightsBoxProps) {
+  const user = useAtomValue(authAtom);
   if (insightArr === null) return;
   const oneInsight = insightArr[0].content;
   return (
@@ -31,7 +34,7 @@ export function InsightsBoxSection({ isTeam, type, insightArr }: InsightsBoxProp
           line-height: 3.2rem;
         `}
       >
-        우리팀은{" "}
+        {`${isTeam ? "우리팀" : user.name}`}은{" "}
         {type === "goodPoints" && (
           <>
             <Typography

--- a/src/component/space/view/RetrospectBox.tsx
+++ b/src/component/space/view/RetrospectBox.tsx
@@ -235,6 +235,7 @@ export function RetrospectBox({
           <RetrospectButton
             status={retrospectStatus === "PROCEEDING" && isWrite ? "HAS_WRITING" : retrospectStatus}
             retrospectId={retrospectId}
+            title={title}
             spaceId={spaceId}
           />
         </div>

--- a/src/component/space/view/RetrospectButton.tsx
+++ b/src/component/space/view/RetrospectButton.tsx
@@ -9,16 +9,17 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 type RetrospectButtonProps = {
   status: "PROCEEDING" | "DONE" | "HAS_WRITING";
   retrospectId?: number;
+  title?: string;
   spaceId?: string;
 };
 
-export function RetrospectButton({ status, retrospectId, spaceId }: RetrospectButtonProps) {
+export function RetrospectButton({ status, retrospectId, title, spaceId }: RetrospectButtonProps) {
   const navigate = useNavigate();
   const { color, route, text } = useMemo<{ text: string; route: readonly [string, NavigateOptions]; color: string }>(() => {
     return {
       DONE: {
         text: "분석 확인",
-        route: [PATHS.retrospectAnalysis(spaceId!, retrospectId!), {}] as const,
+        route: [PATHS.retrospectAnalysis(spaceId!, retrospectId!), { state: { title } }] as const,
         color: DESIGN_TOKEN_COLOR.gray900,
       },
       HAS_WRITING: {


### PR DESCRIPTION
> ### hotfix: 분석 페이지 제목, 이름 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 분석 페이지 제목 반영
- 개인 분석의 경우 '우리팀' -> 유저 이름으로 수정

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

-
### 📚 Reference (참조)

-
![image](https://github.com/user-attachments/assets/00257421-9eb2-4437-92c6-fc25c847511b)

