### PR TITLE
사용자가 설정한 목표 달성 범위가 정상 출력되지 않습니다.

### DIFF
--- a/src/component/write/phase/Write.tsx
+++ b/src/component/write/phase/Write.tsx
@@ -81,7 +81,7 @@ export function Write() {
       );
       setIsTempData(true);
     }
-  }, [temporaryDataLoading, temporaryDataSuccess]);
+  }, [temporaryDataLoading, temporaryDataSuccess, temporaryData]);
 
   useEffect(() => {
     if (answerDataSuccess && answerData) {
@@ -101,6 +101,10 @@ export function Write() {
     setIsAnswerFilled(allFilled);
   }, [answers]);
 
+  /**
+   * NOTE: questionId는 작성 화면에서의 phase를 의미합니다.
+   * 구조화된 데이터의 index와 현재의 phase를 비교하여 답변을 업데이트하여 상태 값을 관리합니다.
+   * */
   const updateAnswer = (questionId: number, newValue: string) => {
     setAnswers((prevAnswers) => {
       const updatedAnswers = prevAnswers.map((answer, index) => (index === questionId ? { ...answer, answerContent: newValue } : answer));

--- a/src/component/write/template/complete/Achievement.tsx
+++ b/src/component/write/template/complete/Achievement.tsx
@@ -6,7 +6,7 @@ import { DESIGN_TOKEN_COLOR, DESIGN_TOKEN_TEXT } from "@/style/designTokens.ts";
 
 type ProgressBarProps = { name: string; question?: never; index: number } | { question: string; name?: never; index: number };
 
-export function CAchievementTemplate({ name, question, index: AchivementIdx = 0 }: ProgressBarProps) {
+export function CAchievementTemplate({ name, question, index: AchivementIdx = -1 }: ProgressBarProps) {
   const segments = Array.from({ length: 5 }, (_, i) => i < AchivementIdx + 1);
   const defaultBorderStyle = css`
     border-radius: 0;

--- a/src/component/write/template/write/write.const.ts
+++ b/src/component/write/template/write/write.const.ts
@@ -1,0 +1,1 @@
+export const ACHIVEMENT_PERCENT = ["20", "40", "60", "80", "100"];

--- a/src/hooks/api/retrospect/analysis/useGetAnalysisAnswer.ts
+++ b/src/hooks/api/retrospect/analysis/useGetAnalysisAnswer.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
+import { ACHIVEMENT_PERCENT } from "@/component/write/template/write/write.const.ts";
 
 type getAnalysisAnswer = {
   spaceId: string;
@@ -27,9 +28,37 @@ export type getAnalysisResponse = {
   }[];
 };
 
+const scaledAchievement = (data: getAnalysisResponse) => {
+  const transformedIndividuals = data.individuals.map((individual) => ({
+    ...individual,
+    answers: individual.answers.map((answer) => ({
+      ...answer,
+      answerContent:
+        answer.questionType === "range" ? `${parseInt(answer.answerContent) / parseInt(ACHIVEMENT_PERCENT[0]) - 1}` ?? "-1" : answer.answerContent,
+    })),
+  }));
+
+  const transformedQuestions = data.questions.map((question) => ({
+    ...question,
+    answers: question.answers.map((answer) => ({
+      ...answer,
+      answerContent:
+        question.questionType === "range" ? `${parseInt(answer.answerContent) / parseInt(ACHIVEMENT_PERCENT[0]) - 1}` ?? "-1" : answer.answerContent,
+    })),
+  }));
+
+  return {
+    ...data,
+    individuals: transformedIndividuals,
+    questions: transformedQuestions,
+  };
+};
+
 export const useGetAnalysisAnswer = ({ spaceId, retrospectId }: getAnalysisAnswer) => {
   const getAnalysisAnswer = () => {
-    const res = api.get<getAnalysisResponse>(`/space/${spaceId}/retrospect/${retrospectId}/answer/analyze`).then((res) => res.data);
+    const res = api
+      .get<getAnalysisResponse>(`/space/${spaceId}/retrospect/${retrospectId}/answer/analyze`)
+      .then((res) => scaledAchievement(res.data));
     return res;
   };
   return useQuery({

--- a/src/hooks/api/write/useGetAnswers.ts
+++ b/src/hooks/api/write/useGetAnswers.ts
@@ -1,14 +1,28 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
+import { ACHIVEMENT_PERCENT } from "@/component/write/template/write/write.const.ts";
 
-type AnswerResponseType = {
+export type AnswerResponseType = {
   answers: {
     questionId: number;
     questionType: string;
     answerContent: string;
   }[];
 };
+
+export const scaledAchievement = (data: AnswerResponseType) => {
+  const answers = data.answers.map((item) =>
+    item.questionType === "range"
+      ? {
+          ...item,
+          answerContent: `${parseInt(item.answerContent) / parseInt(ACHIVEMENT_PERCENT[0]) - 1}` ?? "-1",
+        }
+      : item,
+  );
+  return { answers: answers };
+};
+
 export const useGetAnswers = ({ spaceId, retrospectId }: { spaceId: number; retrospectId: number }) => {
   const getQuestions = () => {
     const res = api
@@ -16,7 +30,7 @@ export const useGetAnswers = ({ spaceId, retrospectId }: { spaceId: number; retr
         `/space/${spaceId}/retrospect/${retrospectId}/answer/written
 `,
       )
-      .then((res) => res.data);
+      .then((res) => scaledAchievement(res.data));
     return res;
   };
 

--- a/src/hooks/api/write/useGetTemporaryQuestions.ts
+++ b/src/hooks/api/write/useGetTemporaryQuestions.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
+import { scaledAchievement } from "@/hooks/api/write/useGetAnswers.ts";
 
 type QuestionResponseType = {
   answers: {
@@ -12,7 +13,9 @@ type QuestionResponseType = {
 
 export const useGetTemporaryQuestions = ({ spaceId, retrospectId }: { spaceId: number; retrospectId: number }) => {
   const getTemporaryQuestions = () => {
-    const res = api.get<QuestionResponseType>(`/space/${spaceId}/retrospect/${retrospectId}/answer/temp`).then((res) => res.data);
+    const res = api.get<QuestionResponseType>(`/space/${spaceId}/retrospect/${retrospectId}/answer/temp`).then((res) => {
+      return scaledAchievement(res.data);
+    });
     return res;
   };
 

--- a/src/hooks/api/write/useWriteQuestions.ts
+++ b/src/hooks/api/write/useWriteQuestions.ts
@@ -18,7 +18,6 @@ export const useWriteQuestions = () => {
     /**
      * NOTE: 분석을 위한 Range 값을 실제 퍼센트로 변환하는 작업을 진행합니다.
      * index 형태를 통해 게이지를 채우기 때문에 index는 0으로 시작하는 형태를 지니고 있습니다,
-     * 그렇기 때문에 퍼센테이저로 변환하는 수식을 (index + 1) * 20로 설정을 합니다.
      *
      * Achievement Percent
      * - 0 : 20

--- a/src/hooks/api/write/useWriteQuestions.ts
+++ b/src/hooks/api/write/useWriteQuestions.ts
@@ -2,6 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import { api } from "@/api";
 import { Answer } from "@/component/write/phase/Write.tsx";
+import { ACHIVEMENT_PERCENT } from "@/component/write/template/write/write.const.ts";
 
 type writeQuestionsProps = {
   data: Answer[];
@@ -14,10 +15,22 @@ type writeQuestionsProps = {
 export const useWriteQuestions = () => {
   const writeQuestions = ({ data, isTemporarySave = false, spaceId, retrospectId, method = "POST" }: writeQuestionsProps) => {
     const url = `/space/${spaceId}/retrospect/${retrospectId}/answer`;
-    const fixedData = data.map((curData) =>
-      curData.questionType === "range" ? { ...curData, answerContent: parseInt(curData.answerContent) * 20 + 20 } : curData,
+    /**
+     * NOTE: 분석을 위한 Range 값을 실제 퍼센트로 변환하는 작업을 진행합니다.
+     * index 형태를 통해 게이지를 채우기 때문에 index는 0으로 시작하는 형태를 지니고 있습니다,
+     * 그렇기 때문에 퍼센테이저로 변환하는 수식을 (index + 1) * 20로 설정을 합니다.
+     *
+     * Achievement Percent
+     * - 0 : 20
+     * - 1 : 40
+     * - 2 : 60
+     * - 3 : 80
+     * - 4 : 100
+     * */
+    const scaledAchievement = data.map((curData) =>
+      curData.questionType === "range" ? { ...curData, answerContent: ACHIVEMENT_PERCENT[parseInt(curData.answerContent)] ?? "-1" } : curData,
     );
-    const payload = { requests: fixedData, ...(method === "POST" && { isTemporarySave }) };
+    const payload = { requests: scaledAchievement, ...(method === "POST" && { isTemporarySave }) };
 
     if (method === "POST") {
       return api.post(url, payload);


### PR DESCRIPTION
> ### 사용자가 설정한 목표 달성 범위가 정상 출력되지 않습니다.
---

### 🏄🏼‍♂️‍ Summary (요약)
- 사용자가 설정한 목표 달성 범위가 정상 출력되지 않아 관련 로직을 추가 및 수정 진행하였어요

### 🫨 Describe your Change (변경사항)
- 커밋 내용을 참고해주세요

### 🧐 Issue number and link (참고)
- #307 

### 📚 Reference (참조)
- 컴포넌트 내부적으로는 목표 달성 범위에 대한 Range 관리를 index로 진행하고, 서버 측에서 데이터를 전송하거나 받아올 때의 경우에는 실제 퍼센테이지로 관리가 되어야하기 때문에 스케일 처리를 진행하도록 로직을 추가하였습니다!
- 서버 전송 시 : 퍼센테이지로 변환
- 서버에서 응답 값으로 받았을 때 : 퍼센테이지에서 인덱스로 변환

#### 퍼센테이지로 변환해야하는 이유
기존에는 index 형태로 넘기 받으면서 범위 처리를 진행하고 있었으나, 분석 기능 추가로 인해 퍼센테이지로 전송을 해야 서버에서 해당 값을 받아 분석 데이터에 사용하기 때문에