### PR TITLE
카카오 로그인 모바일 환경일 시 앱을 통한 로그인 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <!-- FIXME: 추후 디자인 팀 OG 로고 요청 후 수정 -->
-    <link rel="icon" type="image/svg+xml" href="/white_layer.svg"/>
-    <link rel="icon" type="image/svg+xml" href="/dark_layer.svg" media="(prefers-color-scheme: dark)"/>
-    <link rel="icon" type="image/svg+xml" href="/white_layer.svg" media="(prefers-color-scheme: white)"/>
+    <link rel="icon" type="image/svg+xml" href="/white_layer.svg" />
+    <link rel="icon" type="image/svg+xml" href="/dark_layer.svg" media="(prefers-color-scheme: dark)" />
+    <link rel="icon" type="image/svg+xml" href="/white_layer.svg" media="(prefers-color-scheme: white)" />
     <link
       rel="stylesheet"
       as="style"
@@ -25,6 +25,7 @@
     <meta name="description" content="편리한 회고 작성부터 AI 분석까지 Layer에서 함께해요!" />
 
     <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
     <script type="text/javascript" src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js"></script>
   </head>
   <body>

--- a/src/component/login/SocialLoginArea.tsx
+++ b/src/component/login/SocialLoginArea.tsx
@@ -1,6 +1,6 @@
 import { css, Interpolation, Theme } from "@emotion/react";
 import Cookies from "js-cookie";
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, useEffect } from "react";
 
 import { ButtonProvider } from "@/component/common/button";
 import { Icon } from "@/component/common/Icon";
@@ -8,6 +8,7 @@ import { Typography } from "@/component/common/typography";
 import { SocialLoginButton } from "@/component/login/SocialLoginButton.tsx";
 import { usePostAppleLogin } from "@/hooks/api/login/usePostAppleToken.ts";
 import { backgroundColors } from "@/types/loginType";
+import { isMobile } from "@/utils/etc";
 
 export function SocialLoginArea({
   onlyContainerStyle,
@@ -24,11 +25,36 @@ export function SocialLoginArea({
     usePopup: true,
   });
 
-  const kakaoLogin = () => {
+  useEffect(() => {
+    if (typeof window.Kakao !== "undefined" && !window.Kakao.isInitialized()) {
+      window.Kakao.init(import.meta.env.VITE_KAKAKO_JAVASCRIPT_KEY);
+    }
+  }, []);
+
+  const kakaoLoginRedirection = () => {
     const REST_API_KEY = import.meta.env.VITE_REST_API_KEY as string;
     const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI as string;
     const link = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}`;
     window.location.href = link;
+  };
+
+  // 카카오 로그인 함수
+  const kakaoLogin = () => {
+    const KAKAO_REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI as string;
+
+    if (window.Kakao) {
+      if (isMobile()) {
+        window.Kakao.Auth.authorize({
+          redirectUri: KAKAO_REDIRECT_URI,
+          fail: () => {
+            kakaoLoginRedirection();
+          },
+          throughTalk: true,
+        });
+      } else {
+        kakaoLoginRedirection();
+      }
+    }
   };
 
   const appleLogin = async () => {

--- a/src/utils/etc.ts
+++ b/src/utils/etc.ts
@@ -1,1 +1,5 @@
 export const getRandomID = () => String(new Date().getTime());
+
+export const isMobile = () => {
+  return /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+};


### PR DESCRIPTION
> ### 카카오 로그인 모바일 환경일 시 앱을 통한 로그인 구현
---

### 🏄🏼‍♂️‍ Summary (요약)

- 카카오 로그인 모바일 환경일 시 앱을 통해 로그인하였어요.
- 다만 문제가 사파리의 경우, 앱을 통한 로그인 변수인 `throughTalk`을 인지하지 못해, 사파리의 경우는 카카오 페이지 이동이 불가피하다고 해요! 
- 현재 구현 상태
1. 모바일 (사파리 제외) : 앱을 통해 로그인 ( 앱이 설치되어있을시)
2. 그 외: 이전 방법 ( 사파리 + 앱이 설치 안된 모바일 등)
=> 앱이 설치되어있는 모바일 환경이면 앱을 통한 로그인을 시도해요!

### 🫨 Describe your Change (변경사항)

- 커밋 참고

### 🧐 Issue number and link (참고)

- #319 
### 📚 Reference (참조)

- 현재 현우형이 알려준걸로 테스트 했는데 API 호출까진 가는거 확인, 근데 Redirection URL이 달라서 로그인 성공인지는 확인 못함. 
=> 스테이징에서 테스트 해볼 예정
