### PR TITLE
SDK를 적용한 카카오톡 앱 내 로그인 적용

### DIFF
--- a/src/hooks/api/login/usePostKakaoToken.ts
+++ b/src/hooks/api/login/usePostKakaoToken.ts
@@ -6,12 +6,12 @@ import { useNavigate } from "react-router-dom";
 import { KakaoLoginResponse } from "@/types/loginType";
 
 const getKakaoLoginResponse = async (code: string): Promise<KakaoLoginResponse> => {
-  const REST_API_KEY = import.meta.env.VITE_KAKAO_KEY as string;
+  const KAKAO_JAVASCRIPT_KEY = import.meta.env.VITE_KAKAO_KEY as string;
   const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI as string;
 
   const data = {
     grant_type: "authorization_code",
-    client_id: REST_API_KEY,
+    client_id: KAKAO_JAVASCRIPT_KEY,
     redirect_uri: REDIRECT_URI,
     code: code,
   };


### PR DESCRIPTION
> ### SDK를 적용한 카카오톡 앱 내 로그인 적용
---

### 🏄🏼‍♂️‍ Summary (요약)

- SDK를 적용해서 카카오 브라우저로 이동하는게 아닌 앱으로 로그인할 수 있도록 변경했어요. 
- 다음과 같은 요구사항으로 시작되었어요.
=> 카카오톡 앱에서 로그인 시에 뒤로가기가 없어서 로그인하고 안하고 싶다면 앱을 꺼야돼요! + 그리고 앱으로 로그인하는 것도 있던데, 아이디 치는게 번거로워요.
- 구현방식
---
- 뒤로가기 삽입
뒤로 가기 삽입의 경우, 카카오톡 자체 웹 사이트이므로 삽입이 불가능하고, 넣고 싶다면 iframe태그를 써서 하는 방식 밖에 없었어요. 하지만 이는 보완에 좋지 못하다고 해요. 이에 따라 뒤로가기 이전에 그냥 앱 자체로 로그인할 수 있도록 하여 이 문제를 자연스럽게 해결하고자 했어요.
---
- 앱 내 로그인 방식
1. 카카오톡이 깔려있는 모바일 => SDK를 활용하여 앱 내 로그인이 될 수 있게 했어요.
2. 카카오톡이 깔려있지 않은 모바일 + 데스크톱 웹 => 기존과 동일하게 아이디, 비밀번호를 입력하게 하였어요. 
3. 사파리 웹 : 사파리의 경우 카카오톡이 깔려있어도 앱 내 로그인이 불가능했어요. 이는 SDK를 적용할 수 있는 변수인 `throughTalk` 를 호환하지 못해 에러가 발생했어요. 이에 따라서 사파리와 같이 `throughTalk`를 호환하지 못해 에러가 발생하는 경우 기존 방식을 적용했어요.
정리: 앱으로 로그인할 수 있을땐 앱 내 로그인을 하고 그렇지 않은 경우는 기존 방식 유지 
---

### 🫨 Describe your Change (변경사항)

- 커멋 사항 참조

### 🧐 Issue number and link (참고)

- #319 
### 📚 Reference (참조)

- Safari에서 호환하지 못하는 원인
=> 원인 분석을 검색해보니.. 다음 원인이 가장 클것으로 예상됩니다. 
1.	Safari의 보안 정책:
Safari는 보안 및 프라이버시 정책이 엄격하여, 외부 애플리케이션(카카오톡 등)과의 통신이나 리디렉션을 제한할 수 있습니다. 특히, Safari는 써드파티 쿠키 차단과 리디렉션에 대한 보안 정책이 강화되어 있어, 이러한 방식의 로그인 요청이 실패할 가능성이 높습니다.
2.	Kakao SDK의 호환성:
카카오 SDK에서는 throughTalk 옵션을 통해, 사용자의 카카오톡 앱을 통해 로그인을 유도합니다. 그러나 Safari의 특정 버전이나 설정에 따라 이 과정에서 카카오톡 앱으로의 전환이 원활하지 않거나 실패할 수 있습니다.
