### PR TITLE
믹스패널 Provider 작성, 이벤트 추가

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,19 +9,23 @@ import { Routers } from "./router";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { Toast } from "@/component/common/Toast";
 import { BridgeProvider } from "@/lib/provider/bridge-provider";
+import { MixpanelProvider } from "@/lib/provider/mix-pannel-provider";
 import { queryClient } from "@/lib/tanstack-query/queryClient";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Suspense fallback={<LoadingModal purpose={"데이터를 가져오고 있어요"} />}>
-      <QueryClientProvider client={queryClient}>
-        {/* <ReactQueryDevtools initialIsOpen={false} /> */}
-        {/* <DevTools /> */}
-        <BridgeProvider>
-          <Routers />
-        </BridgeProvider>
-        <Toast />
-      </QueryClientProvider>
-    </Suspense>
+    <MixpanelProvider>
+      <Suspense fallback={<LoadingModal purpose={"데이터를 가져오고 있어요"} />}>
+        <QueryClientProvider client={queryClient}>
+          {/* <ReactQueryDevtools initialIsOpen={false} /> */}
+          {/* <DevTools /> */}
+
+          <BridgeProvider>
+            <Routers />
+          </BridgeProvider>
+          <Toast />
+        </QueryClientProvider>
+      </Suspense>
+    </MixpanelProvider>
   </React.StrictMode>,
 );

--- a/src/app/login/SetNicknamePage.tsx
+++ b/src/app/login/SetNicknamePage.tsx
@@ -1,5 +1,4 @@
 import Cookies from "js-cookie";
-import { useParams } from "react-router-dom";
 
 import { Button, ButtonProvider } from "@/component/common/button";
 import { Input } from "@/component/common/input";
@@ -8,22 +7,21 @@ import { TipCard } from "@/component/common/tip";
 import { Typography } from "@/component/common/typography";
 import { usePostSignUp } from "@/hooks/api/login/usePostSignUp";
 import { useInput } from "@/hooks/useInput";
+import { useRequiredParams } from "@/hooks/useRequiredParams";
 import { DefaultLayout } from "@/layout/DefaultLayout";
-import { trackEvent } from "@/lib/mixpanel/event";
 import { SocialLoginKind } from "@/types/loginType";
 
 export function SetNickNamePage() {
   const { value: nickName, handleInputChange } = useInput("");
   const maxLength = 10;
   const { mutate: signUpMutation, isPending } = usePostSignUp();
-  const { socialType } = useParams<{ socialType: SocialLoginKind }>();
+  const { socialType } = useRequiredParams<{ socialType: SocialLoginKind }>();
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
 
     const accessToken = Cookies.get(`${socialType}AccessToken`) || "";
 
-    trackEvent("회원가입");
     signUpMutation({ accessToken, name: nickName, socialType: socialType });
   };
 

--- a/src/app/login/SetNicknamePage.tsx
+++ b/src/app/login/SetNicknamePage.tsx
@@ -9,6 +9,7 @@ import { Typography } from "@/component/common/typography";
 import { usePostSignUp } from "@/hooks/api/login/usePostSignUp";
 import { useInput } from "@/hooks/useInput";
 import { DefaultLayout } from "@/layout/DefaultLayout";
+import { trackEvent } from "@/lib/mixpanel/event";
 import { SocialLoginKind } from "@/types/loginType";
 
 export function SetNickNamePage() {
@@ -22,6 +23,7 @@ export function SetNickNamePage() {
 
     const accessToken = Cookies.get(`${socialType}AccessToken`) || "";
 
+    trackEvent("회원가입");
     signUpMutation({ accessToken, name: nickName, socialType: socialType });
   };
 

--- a/src/app/retrospect/template/recommend/RecommendTemplatePage.tsx
+++ b/src/app/retrospect/template/recommend/RecommendTemplatePage.tsx
@@ -5,10 +5,11 @@ import { useNavigate } from "react-router-dom";
 import { api } from "@/api";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { RecommendTemplate } from "@/component/retrospect/template/recommend/RecommendTemplate";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { recommendTemplateState } from "@/store/retrospect/template/recommend/recommendAtom";
 import { RecommendTemplateType } from "@/types/retrospectCreate/recommend";
 
-type RecommendTemplateResponse = {
+export type RecommendTemplateResponse = {
   formId: number;
   formImageUrl: string;
   formName: string;
@@ -19,6 +20,7 @@ export function RecommendTemplatePage() {
   const navigate = useNavigate();
   const resetTemplateValue = useResetAtom(recommendTemplateState);
   const [isLoading, setIsLoading] = useState(false);
+  const { track } = useMixpanel();
 
   const onSubmit = async (recommendValue: RecommendTemplateType & { spaceId: string }) => {
     try {
@@ -30,6 +32,11 @@ export function RecommendTemplatePage() {
           period,
           purpose: purpose.join(","),
         },
+      });
+      track("TEMPLATE_RECOMMEND", {
+        formId: data.formId,
+        formName: data.formName,
+        tag: data.tag,
       });
       navigate("/retrospect/recommend/done", { state: { templateId: data.formId, spaceId: recommendValue.spaceId } });
       resetTemplateValue();

--- a/src/app/retrospectCreate/RetrospectCreate.tsx
+++ b/src/app/retrospectCreate/RetrospectCreate.tsx
@@ -16,7 +16,6 @@ import { usePostRecentTemplateId } from "@/hooks/api/template/usePostRecentTempl
 import { useModal } from "@/hooks/useModal";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
 import { DefaultLayout } from "@/layout/DefaultLayout";
-import { trackEvent } from "@/lib/mixpanel/event";
 import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
 
@@ -115,10 +114,6 @@ export function RetrospectCreate() {
 
   const handleSubmit = useCallback(() => {
     if (!pageState.isLastStep) return;
-    trackEvent("회고 생성 완료", {
-      spaceId: `${spaceId}`,
-      isNewTemplate: `${retroCreateData.isNewForm}`,
-    });
     const questionsWithRequired = REQUIRED_QUESTIONS.concat(retroCreateData.questions);
     postRetrospectCreate({
       spaceId,

--- a/src/app/retrospectCreate/RetrospectCreate.tsx
+++ b/src/app/retrospectCreate/RetrospectCreate.tsx
@@ -115,7 +115,7 @@ export function RetrospectCreate() {
 
   const handleSubmit = useCallback(() => {
     if (!pageState.isLastStep) return;
-    trackEvent("Retrospect Create Complete", {
+    trackEvent("회고 생성 완료", {
       spaceId: `${spaceId}`,
       isNewTemplate: `${retroCreateData.isNewForm}`,
     });

--- a/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
+++ b/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
@@ -14,6 +14,7 @@ import { TemplateContext } from "@/component/retrospectCreate/steps/CustomTempla
 import { useInput } from "@/hooks/useInput";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
 import { useToast } from "@/hooks/useToast";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 
 type QuestionsListProps = {
@@ -33,12 +34,19 @@ export function ConfirmEditTemplate({ goNext, goPrev }: QuestionsListProps) {
   const { value: title, handleInputChange: handleTitleChange } = useInput(retroCreateData.formName);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
+  const { track } = useMixpanel();
 
   const handleDataSave = () => {
     setRetroCreateData((prev) => ({ ...prev, formName: title }));
   };
 
   const onNext = () => {
+    if (retroCreateData.isNewForm) {
+      track("RETROSPECT_CREATE_EDIT_QUESTIONS", {
+        hasChangedOriginal: retroCreateData.hasChangedOriginal,
+        questions: retroCreateData.questions.map(({ questionContent }) => questionContent),
+      });
+    }
     handleDataSave();
     goNext();
   };

--- a/src/component/retrospectCreate/steps/MainInfo.tsx
+++ b/src/component/retrospectCreate/steps/MainInfo.tsx
@@ -8,6 +8,7 @@ import { Header } from "@/component/common/header";
 import { Input, InputLabelContainer, Label, TextArea } from "@/component/common/input";
 import { TipCard } from "@/component/common/tip/TipCard";
 import { useInput } from "@/hooks/useInput";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 
 export function MainInfo() {
@@ -15,9 +16,14 @@ export function MainInfo() {
   const [retroCreateData, setRetroCreateData] = useAtom(retrospectCreateAtom);
   const { value: title, handleInputChange: handleNameChange } = useInput(retroCreateData.title);
   const { value: introduction, handleInputChange: handleDescriptionChange } = useInput(retroCreateData.introduction);
+  const { track } = useMixpanel();
 
   const handleDataSave = () => {
     setRetroCreateData((prev) => ({ ...prev, title, introduction }));
+    track("RETROSPECT_CREATE_MAININFO", {
+      titleLength: title.length,
+      introLength: introduction.length,
+    });
     goNext();
   };
 

--- a/src/component/retrospectCreate/steps/Start.tsx
+++ b/src/component/retrospectCreate/steps/Start.tsx
@@ -7,11 +7,12 @@ import { RetrospectCreateContext } from "@/app/retrospectCreate/RetrospectCreate
 import retrospect_create_start_lottie from "@/assets/lottie/retropsect/create/speech_bubble_envelope.json";
 import { ButtonProvider } from "@/component/common/button";
 import { Header } from "@/component/common/header";
-import { trackEvent } from "@/lib/mixpanel/event";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 
 export function Start() {
   const { spaceId } = useLocation().state as { spaceId: number; templateId: number; saveTemplateId?: boolean };
   const { goNext, confirmQuitPage } = useContext(RetrospectCreateContext);
+  const { track } = useMixpanel();
   return (
     <>
       <Header title={"회고를 만들어볼까요"} contents={"회고를 진행할 질문들을 구성해요"} theme="white" />
@@ -29,7 +30,7 @@ export function Start() {
         <ButtonProvider.White
           onClick={() => {
             goNext();
-            trackEvent("회고 생성 시작", {
+            track("RETROSPECT_CREATE_START", {
               spaceId: `${spaceId}`,
             });
           }}

--- a/src/component/retrospectCreate/steps/Start.tsx
+++ b/src/component/retrospectCreate/steps/Start.tsx
@@ -31,7 +31,7 @@ export function Start() {
           onClick={() => {
             goNext();
             track("RETROSPECT_CREATE_START", {
-              spaceId: `${spaceId}`,
+              spaceId,
             });
           }}
         >

--- a/src/component/retrospectCreate/steps/Start.tsx
+++ b/src/component/retrospectCreate/steps/Start.tsx
@@ -29,7 +29,7 @@ export function Start() {
         <ButtonProvider.White
           onClick={() => {
             goNext();
-            trackEvent("Retrospect Create Start", {
+            trackEvent("회고 생성 시작", {
               spaceId: `${spaceId}`,
             });
           }}

--- a/src/component/space/create/CreateSpace.tsx
+++ b/src/component/space/create/CreateSpace.tsx
@@ -15,7 +15,6 @@ import { Info } from "@/component/space/create/Info";
 import { Thumb } from "@/component/space/create/Thumb";
 import { useApiPostSpace } from "@/hooks/api/space/useApiPostSpace";
 import { DefaultLayout } from "@/layout/DefaultLayout";
-import { trackEvent } from "@/lib/mixpanel/event";
 import { spaceState } from "@/store/space/spaceAtom";
 import { SpaceValue } from "@/types/space";
 
@@ -39,7 +38,6 @@ export function CreateSpace() {
       ...prevValues,
       step: prevValues.step + 1,
     }));
-    trackEvent("스페이스 생성");
   };
 
   const handleCategoryChange = (typeValues: Pick<SpaceValue, "category">) => {

--- a/src/component/space/create/CreateSpace.tsx
+++ b/src/component/space/create/CreateSpace.tsx
@@ -39,7 +39,7 @@ export function CreateSpace() {
       ...prevValues,
       step: prevValues.step + 1,
     }));
-    trackEvent("Space Create");
+    trackEvent("스페이스 생성");
   };
 
   const handleCategoryChange = (typeValues: Pick<SpaceValue, "category">) => {

--- a/src/component/write/phase/Prepare.tsx
+++ b/src/component/write/phase/Prepare.tsx
@@ -10,13 +10,15 @@ import { Header } from "@/component/common/header";
 import { Icon } from "@/component/common/Icon";
 import { QuestionItem } from "@/component/write/QuestionItem";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { ANIMATION } from "@/style/common/animation.ts";
 import "swiper/css";
 import "@/style/swiper/swiper.css";
 
 export function Prepare() {
-  const { incrementPhase, data } = useContext(PhaseContext);
+  const { incrementPhase, data, retrospectId, spaceId } = useContext(PhaseContext);
   const navigate = useNavigate();
+  const { track } = useMixpanel();
 
   return (
     <DefaultLayout theme={"dark"} LeftComp={<Icon icon={"ic_back_white"} onClick={() => navigate(-1)} />}>
@@ -89,7 +91,16 @@ export function Prepare() {
       </div>
 
       <ButtonProvider>
-        <Button colorSchema={"white"} onClick={incrementPhase}>
+        <Button
+          colorSchema={"white"}
+          onClick={() => {
+            incrementPhase();
+            track("WRITE_START", {
+              retrospectId,
+              spaceId,
+            });
+          }}
+        >
           시작하기
         </Button>
       </ButtonProvider>

--- a/src/config/storage-keys.ts
+++ b/src/config/storage-keys.ts
@@ -1,3 +1,7 @@
 export const COOKIE_KEYS = {
   redirectPrevPathKey: "prev-path",
-};
+} as const;
+
+export const LOCAL_STORAGE_KEYS = {
+  utmParamsKey: "UTM_PARAMS",
+} as const;

--- a/src/hooks/api/analysis/useApiGetAnalysis.ts
+++ b/src/hooks/api/analysis/useApiGetAnalysis.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { Insight } from "@/types/analysis";
 
 export type AnalysisType = {
@@ -23,8 +24,14 @@ export type AnalysisType = {
 };
 
 export const useApiGetAnalysis = ({ spaceId, retrospectId }: { spaceId: string; retrospectId: string }) => {
+  const { track } = useMixpanel();
+
   const getAnalysis = () => {
     const res = api.get<AnalysisType>(`/space/${spaceId}/retrospect/${retrospectId}/analyze`).then((res) => res.data);
+    track("RESULT_ANALYSIS_VIEW", {
+      retrospectId: +retrospectId,
+      spaceId: +spaceId,
+    });
     return res;
   };
 

--- a/src/hooks/api/login/usePostSignUp.ts
+++ b/src/hooks/api/login/usePostSignUp.ts
@@ -8,6 +8,7 @@ import { COOKIE_VALUE_SAVE_SPACE_ID_PHASE } from "@/app/space/space.const.ts";
 import { PATHS } from "@/config/paths";
 import { useApiJoinSpace } from "@/hooks/api/space/useApiJoinSpace.ts";
 import { useToast } from "@/hooks/useToast";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { authAtom } from "@/store/auth/authAtom";
 import { AuthResponse, SocialLoginKind } from "@/types/loginType";
 
@@ -22,6 +23,8 @@ export const usePostSignUp = () => {
   const { toast } = useToast();
   const [, setAuth] = useAtom(authAtom);
   const { mutate } = useApiJoinSpace();
+  const { setPeople, track } = useMixpanel();
+
   const signUpWithToken = async ({ accessToken, name, socialType }: PostSignUp): Promise<AuthResponse> => {
     const response = await api.post<AuthResponse>(
       "/api/auth/sign-up",
@@ -46,6 +49,10 @@ export const usePostSignUp = () => {
         Cookies.set("accessToken", data.accessToken, { expires: 7 });
         Cookies.set("refreshToken", data.refreshToken, { expires: 7 });
         setAuth({ isLogin: true, name: data.name, email: data.email, memberRole: data.memberRole, imageUrl: data.imageUrl });
+        track("SIGN_UP", {
+          memberId: data.memberId,
+        });
+        setPeople(data.memberId.toString());
       }
 
       const saveSpaceIdPhase = Cookies.get(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);

--- a/src/hooks/api/space/useApiPostSpace.ts
+++ b/src/hooks/api/space/useApiPostSpace.ts
@@ -3,12 +3,14 @@ import { useResetAtom } from "jotai/utils";
 import { useNavigate } from "react-router-dom";
 
 import { api } from "@/api";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { spaceState } from "@/store/space/spaceAtom";
 import { SpaceValue } from "@/types/space";
 
 export const useApiPostSpace = () => {
   const navigate = useNavigate();
   const resetSpaceValue = useResetAtom(spaceState);
+  const { track } = useMixpanel();
 
   const postSpace = async (formData: SpaceValue) => {
     const { imgUrl: bannerUrl, category, field: fieldList, name, introduction } = formData;
@@ -24,7 +26,14 @@ export const useApiPostSpace = () => {
 
   return useMutation({
     mutationFn: (formData: SpaceValue) => postSpace(formData),
-    onSuccess: ({ spaceId }) => {
+    onSuccess: ({ spaceId }, variables) => {
+      track("SPACE_CREATE", {
+        category: variables.category,
+        field: variables.field,
+        introduction: variables.introduction,
+        name: variables.name,
+      });
+
       navigate(`/space/create/done`, { state: { spaceId } });
       resetSpaceValue();
     },

--- a/src/layout/GlobalLayout.tsx
+++ b/src/layout/GlobalLayout.tsx
@@ -1,6 +1,5 @@
 import { css } from "@emotion/react";
 import Hotjar from "@hotjar/browser";
-import mixpanel from "mixpanel-browser";
 import { useEffect } from "react";
 import { Outlet } from "react-router-dom";
 
@@ -15,15 +14,6 @@ export default function GlobalLayout() {
 
   useEffect(() => {
     Hotjar.init(siteId, hotjarVersion);
-    if (import.meta.env.MODE === "production") {
-      mixpanel.init(`${import.meta.env.VITE_MIXPANEL_TOKEN}`, {
-        track_pageview: true,
-      });
-    } else {
-      mixpanel.init(`${import.meta.env.VITE_MIXPANEL_TOKEN}`, {
-        debug: true,
-      });
-    }
   }, []);
 
   return (

--- a/src/layout/RequireLoginLayout.tsx
+++ b/src/layout/RequireLoginLayout.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { fetchMemberInfo } from "@/api/login";
 import { PATHS } from "@/config/paths";
 import { COOKIE_KEYS } from "@/config/storage-keys";
+import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { authAtom } from "@/store/auth/authAtom";
 
 type RequireLoginProps = {
@@ -16,6 +17,7 @@ export function RequireLoginLayout({ children }: RequireLoginProps) {
   const [auth, setAuth] = useAtom(authAtom);
   const navigate = useNavigate();
   const curPath = window.location.pathname;
+  const { setPeople } = useMixpanel();
 
   const redirectLogin = () => {
     Cookies.set(COOKIE_KEYS.redirectPrevPathKey, curPath);
@@ -31,6 +33,8 @@ export function RequireLoginLayout({ children }: RequireLoginProps) {
         try {
           const response = await fetchMemberInfo();
           setAuth({ isLogin: true, name: response.name, email: response.email, memberRole: response.memberRole, imageUrl: response.imageUrl });
+
+          setPeople(response.memberId.toString());
         } catch (error) {
           console.error("Error fetching member info:", error);
           redirectLogin();

--- a/src/lib/mixpanel/event.ts
+++ b/src/lib/mixpanel/event.ts
@@ -1,9 +1,8 @@
 import mixpanel from "mixpanel-browser";
 
-type TargetEvent = "Space Create" | "Retrospect Create Start" | "Retrospect Create Complete";
-
-export const trackEvent = (event: TargetEvent, properties?: Record<string, string>) => {
+export const trackEvent = (event: string, properties?: Record<string, string>) => {
   if (import.meta.env.MODE === "development") {
+    console.log("mixpanel tracking:", event, properties);
     return;
   }
   mixpanel.track(event, properties);

--- a/src/lib/mixpanel/event.ts
+++ b/src/lib/mixpanel/event.ts
@@ -1,9 +1,0 @@
-import mixpanel from "mixpanel-browser";
-
-export const trackEvent = (event: string, properties?: Record<string, string>) => {
-  if (import.meta.env.MODE === "development") {
-    console.log("mixpanel tracking:", event, properties);
-    return;
-  }
-  mixpanel.track(event, properties);
-};

--- a/src/lib/provider/mix-pannel-provider/event.type.ts
+++ b/src/lib/provider/mix-pannel-provider/event.type.ts
@@ -2,59 +2,41 @@ import { RecommendTemplateResponse } from "@/app/retrospect/template/recommend/R
 import { RetrospectCreateReq } from "@/types/retrospectCreate";
 import { SpaceValue } from "@/types/space";
 
-export type TrackEvent<T extends Events["event"]> = Extract<Events, { event: T }>["args"];
+export type TrackFunction = <T extends keyof EVENTS_TO_PROPERTIES>(eventName: T, properties: EVENTS_TO_PROPERTIES[T]) => void;
 
-export type TrackFunction = <T extends Events["event"]>(eventName: T, args: TrackEvent<T>) => void;
+type EVENTS_TO_PROPERTIES = {
+  SIGN_UP: {
+    memberId: number;
+  };
 
-type Events =
-  | WRITE_DONE
-  | WRITE_START
-  | TEMPLATE_RECOMMEND
-  | RETROSPECT_CREATE_DONE
-  | RETROSPECT_CREATE_EDIT_QUESTIONS
-  | RETROSPECT_CREATE_MAININFO
-  | RETROSPECT_CREATE_START
-  | SPACE_CREATE
-  | SIGN_UP;
+  SPACE_CREATE: Omit<SpaceValue, "step">;
 
-type SIGN_UP = { event: "SIGN_UP"; args: { memberId: number } };
-
-type SPACE_CREATE = { event: "SPACE_CREATE"; args: Omit<SpaceValue, "step"> };
-
-type RETROSPECT_CREATE_START = { event: "RETROSPECT_CREATE_START"; args: object };
-type RETROSPECT_CREATE_MAININFO = { event: "RETROSPECT_CREATE_MAININFO"; args: { titleLength: number; introLength: number } };
-type RETROSPECT_CREATE_EDIT_QUESTIONS = {
-  event: "RETROSPECT_CREATE_EDIT_QUESTIONS";
-  args: Pick<RetrospectCreateReq, "hasChangedOriginal"> & { questions: string[] };
-};
-type RETROSPECT_CREATE_DONE = {
-  event: "RETROSPECT_CREATE_DONE";
-  args: {
+  RETROSPECT_CREATE_START: { spaceId: number };
+  RETROSPECT_CREATE_MAININFO: { titleLength: number; introLength: number };
+  RETROSPECT_CREATE_EDIT_QUESTIONS: Pick<RetrospectCreateReq, "hasChangedOriginal"> & { questions: string[] };
+  RETROSPECT_CREATE_DONE: {
     templateId: number;
     spaceId: number;
     title: string;
     deadline: string;
   };
-};
 
-type TEMPLATE_RECOMMEND = {
-  event: "TEMPLATE_RECOMMEND";
-  args: Omit<RecommendTemplateResponse, "formImageUrl">;
-};
+  TEMPLATE_RECOMMEND: Omit<RecommendTemplateResponse, "formImageUrl">;
 
-type WRITE_START = {
-  event: "WRITE_START";
-  args: {
+  WRITE_START: {
     retrospectId: number;
     spaceId: number;
   };
-};
-type WRITE_DONE = {
-  event: "WRITE_DONE";
-  args: {
+
+  WRITE_DONE: {
     retrospectId: number;
     spaceId: number;
     answerLengths: number[];
     averageAnswerLength: number;
+  };
+
+  RESULT_ANALYSIS_VIEW: {
+    retrospectId: number;
+    spaceId: number;
   };
 };

--- a/src/lib/provider/mix-pannel-provider/event.type.ts
+++ b/src/lib/provider/mix-pannel-provider/event.type.ts
@@ -1,0 +1,41 @@
+import { RecommendTemplateResponse } from "@/app/retrospect/template/recommend/RecommendTemplatePage";
+import { RetrospectCreateReq } from "@/types/retrospectCreate";
+import { SpaceValue } from "@/types/space";
+
+export type TrackEvent<T extends Events["event"]> = Extract<Events, { event: T }>["args"];
+
+export type TrackFunction = <T extends Events["event"]>(eventName: T, args: TrackEvent<T>) => void;
+
+type Events =
+  | TEMPLATE_RECOMMEND
+  | RETROSPECT_CREATE_DONE
+  | RETROSPECT_CREATE_EDIT_QUESTIONS
+  | RETROSPECT_CREATE_MAININFO
+  | RETROSPECT_CREATE_START
+  | SPACE_CREATE
+  | SIGN_UP;
+
+type SIGN_UP = { event: "SIGN_UP"; args: { memberId: number } };
+
+type SPACE_CREATE = { event: "SPACE_CREATE"; args: Omit<SpaceValue, "step"> };
+
+type RETROSPECT_CREATE_START = { event: "RETROSPECT_CREATE_START"; args: object };
+type RETROSPECT_CREATE_MAININFO = { event: "RETROSPECT_CREATE_MAININFO"; args: { titleLength: number; introLength: number } };
+type RETROSPECT_CREATE_EDIT_QUESTIONS = {
+  event: "RETROSPECT_CREATE_EDIT_QUESTIONS";
+  args: Pick<RetrospectCreateReq, "hasChangedOriginal"> & { questions: string[] };
+};
+type RETROSPECT_CREATE_DONE = {
+  event: "RETROSPECT_CREATE_DONE";
+  args: {
+    templateId: number;
+    spaceId: number;
+    title: string;
+    deadline: string;
+  };
+};
+
+type TEMPLATE_RECOMMEND = {
+  event: "TEMPLATE_RECOMMEND";
+  args: Omit<RecommendTemplateResponse, "formImageUrl">;
+};

--- a/src/lib/provider/mix-pannel-provider/event.type.ts
+++ b/src/lib/provider/mix-pannel-provider/event.type.ts
@@ -7,6 +7,8 @@ export type TrackEvent<T extends Events["event"]> = Extract<Events, { event: T }
 export type TrackFunction = <T extends Events["event"]>(eventName: T, args: TrackEvent<T>) => void;
 
 type Events =
+  | WRITE_DONE
+  | WRITE_START
   | TEMPLATE_RECOMMEND
   | RETROSPECT_CREATE_DONE
   | RETROSPECT_CREATE_EDIT_QUESTIONS
@@ -38,4 +40,21 @@ type RETROSPECT_CREATE_DONE = {
 type TEMPLATE_RECOMMEND = {
   event: "TEMPLATE_RECOMMEND";
   args: Omit<RecommendTemplateResponse, "formImageUrl">;
+};
+
+type WRITE_START = {
+  event: "WRITE_START";
+  args: {
+    retrospectId: number;
+    spaceId: number;
+  };
+};
+type WRITE_DONE = {
+  event: "WRITE_DONE";
+  args: {
+    retrospectId: number;
+    spaceId: number;
+    answerLengths: number[];
+    averageAnswerLength: number;
+  };
 };

--- a/src/lib/provider/mix-pannel-provider/index.tsx
+++ b/src/lib/provider/mix-pannel-provider/index.tsx
@@ -35,6 +35,7 @@ const MixpanelProvider = ({ children }: PropsWithChildren) => {
     const [eventName, args] = params;
     if (isDev) {
       console.log("Mixpanel tracking event...", eventName, args);
+      return;
     }
 
     const utmParams = getUtmFromLocalStorage();
@@ -44,6 +45,7 @@ const MixpanelProvider = ({ children }: PropsWithChildren) => {
   const setPeople = useCallback((memberId: string) => {
     if (isDev) {
       console.log("Mixpanel tracking user...", memberId);
+      return;
     }
 
     const utmParams = getUtmFromLocalStorage();

--- a/src/lib/provider/mix-pannel-provider/index.tsx
+++ b/src/lib/provider/mix-pannel-provider/index.tsx
@@ -1,0 +1,82 @@
+import mixpanel, { type OverridedMixpanel } from "mixpanel-browser";
+import { type PropsWithChildren } from "react";
+import { useRef, useCallback } from "react";
+
+import { LOCAL_STORAGE_KEYS } from "@/config/storage-keys";
+import { createContext } from "@/lib/create-context";
+import { TrackFunction } from "@/lib/provider/mix-pannel-provider/event.type";
+
+export const UTM_PARAMS_KEY = "UTM_PARAM";
+
+const isDev = !!import.meta.env.DEV;
+
+if (isDev) {
+  mixpanel.init(`${import.meta.env.VITE_MIXPANEL_TOKEN}`, {
+    debug: true,
+  });
+} else {
+  mixpanel.init(`${import.meta.env.VITE_MIXPANEL_TOKEN}`, {
+    track_pageview: "url-with-path",
+  });
+}
+
+interface MixpanelContext {
+  mixpanel: OverridedMixpanel;
+  track: TrackFunction;
+  setPeople: (memberId: string) => void;
+}
+
+const [Provider, useMixpanel] = createContext<MixpanelContext>("MIX_PANEL_PROVIDER");
+
+const MixpanelProvider = ({ children }: PropsWithChildren) => {
+  const mixpanelRef = useRef(mixpanel).current;
+
+  const track: MixpanelContext["track"] = useCallback((...params) => {
+    if (isDev) return;
+
+    const utmParams = getUtmFromLocalStorage();
+    const [eventName, args] = params;
+    mixpanel.track(eventName, { ...args, ...utmParams });
+  }, []);
+
+  const setPeople = useCallback((memberId: string) => {
+    if (isDev) return;
+
+    const utmParams = getUtmFromLocalStorage();
+    mixpanel.identify(memberId);
+    mixpanel.people.set({ ...utmParams });
+  }, []);
+
+  return (
+    <Provider mixpanel={mixpanelRef} track={track} setPeople={setPeople}>
+      {children}
+    </Provider>
+  );
+};
+
+export { MixpanelProvider, useMixpanel };
+
+type UtmParam = {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+};
+
+function getUtmFromLocalStorage() {
+  const storageValue = localStorage.getItem(LOCAL_STORAGE_KEYS.utmParamsKey) ?? "{}";
+  const utmParams = new Map(Object.entries(JSON.parse(storageValue) as Record<string, string>));
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const result = {
+    utm_campaign: searchParams.get("utm_campaign") || utmParams.get("utm_campaign"),
+    utm_content: searchParams.get("utm_content") || utmParams.get("utm_content"),
+    utm_medium: searchParams.get("utm_medium") || utmParams.get("utm_medium"),
+    utm_source: searchParams.get("utm_source") || utmParams.get("utm_source"),
+    utm_ter: searchParams.get("utm_ter") || utmParams.get("utm_ter"),
+  } as UtmParam;
+
+  localStorage.setItem(LOCAL_STORAGE_KEYS.utmParamsKey, JSON.stringify(result));
+  return result;
+}

--- a/src/lib/provider/mix-pannel-provider/index.tsx
+++ b/src/lib/provider/mix-pannel-provider/index.tsx
@@ -32,15 +32,19 @@ const MixpanelProvider = ({ children }: PropsWithChildren) => {
   const mixpanelRef = useRef(mixpanel).current;
 
   const track: MixpanelContext["track"] = useCallback((...params) => {
-    if (isDev) return;
+    const [eventName, args] = params;
+    if (isDev) {
+      console.log("Mixpanel tracking event...", eventName, args);
+    }
 
     const utmParams = getUtmFromLocalStorage();
-    const [eventName, args] = params;
     mixpanel.track(eventName, { ...args, ...utmParams });
   }, []);
 
   const setPeople = useCallback((memberId: string) => {
-    if (isDev) return;
+    if (isDev) {
+      console.log("Mixpanel tracking user...", memberId);
+    }
 
     const utmParams = getUtmFromLocalStorage();
     mixpanel.identify(memberId);

--- a/src/store/retrospect/retrospectCreate.ts
+++ b/src/store/retrospect/retrospectCreate.ts
@@ -9,4 +9,5 @@ export const retrospectCreateAtom = atomWithReset<RetrospectCreateReq>({
   deadline: "",
   isNewForm: false,
   hasChangedOriginal: false,
+  curFormId: -1,
 });

--- a/src/types/retrospectCreate/index.ts
+++ b/src/types/retrospectCreate/index.ts
@@ -22,5 +22,5 @@ export type RetrospectCreateReq = {
   hasChangedOriginal: boolean;
   formName?: string;
   formIntroduction?: string;
-  curFormId?: number;
+  curFormId: number;
 };


### PR DESCRIPTION
> ### 믹스패널 Provider 작성, 이벤트 추가
---

### 🏄🏼‍♂️‍ Summary (요약)

- 믹스패널 Provider 작성, 이벤트 타이핑 (샤라웃 투 @raymondanythings )
- 회고 생성 각 단계별 이벤트 추가
- 회고 작성 시작/완료 이벤트 추가
- 회원가입 이벤트 추가
- 결과 확인 화면에서 분석 탭 View 이벤트 추가 (해당 페이지는 url이 변경되지 않아서 분석 탭을 열었을 때 Page View이벤트로 트래킹이 되지 않아서 별도로 추가했습니다!)
- 템플릿 추천 이벤트 추가

### 🫨 Describe your Change (변경사항)

- 

### 🧐 Issue number and link (참고)

- #289 
### 📚 Reference (참조)

-
