### PR TITLE
공지사항 노출 여부 쿠키 만료 기간 설정

### DIFF
--- a/apps/web/src/layout/GlobalLayout.tsx
+++ b/apps/web/src/layout/GlobalLayout.tsx
@@ -55,7 +55,7 @@ export default function GlobalLayout() {
           contents={
             <Announcement
               onConfirm={() => {
-                Cookies.set(SHOW_ANNOUNCEMENT_KEY, "true");
+                Cookies.set(SHOW_ANNOUNCEMENT_KEY, new Date().toISOString(), { expires: 1 });
                 closeBottomSheet();
               }}
             />


### PR DESCRIPTION
> ### 공지사항 노출 여부 쿠키 만료 기간 설정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 현재 세션 쿠키로 설정되어 브라우저 닫으면 쿠키가 사라짐
- 만료기간 하루로 설정하여 브라우저 닫아도 쿠키 유지

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

- #337
### 📚 Reference (참조)

-
