### PR TITLE
분석 페이지 포인트가 없을시 조건 추가

### DIFF
--- a/apps/web/src/component/home/SummaryInsightBox.tsx
+++ b/apps/web/src/component/home/SummaryInsightBox.tsx
@@ -17,7 +17,7 @@ type SummaryInsightBoxProps = {
 
 export function SummaryInsightBox({ type, insightArr }: SummaryInsightBoxProps) {
   const transformPoints = transformPointsFun(insightArr);
-
+  if (transformPoints.length === 0) return;
   return (
     <div
       css={css`
@@ -43,9 +43,11 @@ export function SummaryInsightBox({ type, insightArr }: SummaryInsightBoxProps) 
           gap: 1rem;
         `}
       >
-        {transformPoints.map((point, idx) => (
-          <InsightBox key={idx} type={type} insight={point} />
-        ))}
+        {transformPoints
+          .filter((v) => v.point != null)
+          .map((point, idx) => (
+            <InsightBox key={idx} type={type} insight={point} />
+          ))}
       </div>
     </div>
   );


### PR DESCRIPTION
> ### 분석 페이지 포인트가 없을시 조건 추가
---

### 🏄🏼‍♂️‍ Summary (요약)

- 분석 페이지 포인트가 없을시 기존 컴포넌트를 보여줬는데 안보이게끔 조건문을 추가했어요.

<img width="490" alt="image" src="https://github.com/user-attachments/assets/cb826ae8-465b-4b37-937b-c78c6fcaed90">


### 🫨 Describe your Change (변경사항)

-  apps/web/src/component/home/SummaryInsightBox.tsx

### 🧐 Issue number and link (참고)

- #391
### 📚 Reference (참조)

-
