### PR TITLE
fix: #409 카카오 인앱 브라우저에서도 서비스 화면 그대로 띄우도록 재수정

### DIFF
--- a/apps/web/src/helper/preventExternalBrowser.tsx
+++ b/apps/web/src/helper/preventExternalBrowser.tsx
@@ -8,7 +8,6 @@ export function PreventExternalBrowser({ children }: PropsWithChildren) {
 
   if (isKakao) {
     window.open(`kakaotalk://web/openExternal?url=${encodeURIComponent(URL)}`);
-    return <span> 시스템 브라우저를 이용해주세요 </span>;
   } else if (isInstagram) {
     /**
      * NOTE: 현재는 해당 인스타그램 인앱 탈출 코드가 작동하지 않는 것 같음


### PR DESCRIPTION
> ### 카카오 인앱 브라우저에서도 서비스 화면 그대로 띄우도록 재수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 기존에 서비스 브라우저를 이용해주세요 라고 서비스 화면을 안 띄우도록했는데, 다시 띄우도록 변경하였습니다.

### 🫨 Describe your Change (변경사항)
- 커밋 내용 참조

### 🧐 Issue number and link (참고)
- #409 

### 📚 Reference (참조)
-
