### PR TITLE
회고 분석의 badPoints에 대한 옵셔널 체이닝 처리

### DIFF
--- a/apps/web/src/app/retrospect/analysis/RetrospectAnalysisPage.tsx
+++ b/apps/web/src/app/retrospect/analysis/RetrospectAnalysisPage.tsx
@@ -34,6 +34,9 @@ export const RetrospectAnalysisPage = () => {
   let pendingPeopleCnt = 0;
 
   if (spaceInfo && data) {
+    // TODO: 로직을 어떻게 픽스해야할지 서버 개발자들이랑 같이 이야기를 해보아야 함
+    // spaceInfo.memberCount : 스페이스에 들어와있는 멤버 수
+    // data.individuals.length : 현재 해당 회고에 대한 질문 답변 수
     pendingPeopleCnt = spaceInfo.memberCount - data.individuals.length;
   }
 

--- a/apps/web/src/component/retrospect/analysis/Analysis.tsx
+++ b/apps/web/src/component/retrospect/analysis/Analysis.tsx
@@ -127,9 +127,9 @@ export function AnalysisContainer({ spaceId, retrospectId, hasAIAnalyzed }: Anal
       )}
       {selectedTab === "personal" && (
         <>
-          {data?.individualAnalyze.badPoints == null &&
-          data?.individualAnalyze.goodPoints == null &&
-          data?.individualAnalyze.improvementPoints == null ? (
+          {data?.individualAnalyze?.badPoints == null &&
+          data?.individualAnalyze?.goodPoints == null &&
+          data?.individualAnalyze?.improvementPoints == null ? (
             <EmptyList
               message={
                 <>
@@ -142,13 +142,13 @@ export function AnalysisContainer({ spaceId, retrospectId, hasAIAnalyzed }: Anal
             />
           ) : (
             <>
-              {data?.individualAnalyze.goodPoints && (
+              {data?.individualAnalyze?.goodPoints && (
                 <InsightsBoxSection type="goodPoints" insightArr={data.individualAnalyze.goodPoints} isTeam={false} />
               )}
-              {data?.individualAnalyze.badPoints && (
+              {data?.individualAnalyze?.badPoints && (
                 <InsightsBoxSection type="badPoints" insightArr={data.individualAnalyze.badPoints} isTeam={false} />
               )}
-              {data?.individualAnalyze.improvementPoints && (
+              {data?.individualAnalyze?.improvementPoints && (
                 <InsightsBoxSection type="improvementPoints" insightArr={data.individualAnalyze.improvementPoints} isTeam={false} />
               )}
             </>


### PR DESCRIPTION
> ### 회고 분석의 badPoints에 대한 옵셔널 체이닝 처리
---

### 🏄🏼‍♂️‍ Summary (요약)
- 회고 분석에 따른 일부 로직의 옵셔널 체이닝 처리를 진행합니다.

### 🫨 Describe your Change (변경사항)
- apps/web/src/component/retrospect/analysis/Analysis.tsx

### 🧐 Issue number and link (참고)
- #429 

### 📚 Reference (참조)
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the retrospective analysis display to safely handle missing data, ensuring a more reliable and error-free experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->