### PR TITLE
fix: 실행목표 편집 에러 수정

### DIFF
--- a/apps/web/src/app/actionItem/ActionItemEditPage.tsx
+++ b/apps/web/src/app/actionItem/ActionItemEditPage.tsx
@@ -32,18 +32,18 @@ type retrospectInfoType = {
 export function ActionItemEditPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { data: retrospectInfo } = location.state as { data: retrospectInfoType[] };
+  const { data: retrospectInfo } = location.state as { data: retrospectInfoType };
   const { mutate: deleteActionItem, isPending: deleteActionItemPending } = useDeleteActionItemList();
   const { mutate: patchActionItem, isPending: patchActionItemPending } = usePatchActionItemList();
   const { mutate: createActionItem, isPending: createActionItemPending } = useCreateActionItem();
   const { open } = useModal();
   const { toast } = useToast();
-  const actionItems = retrospectInfo?.flatMap((item) =>
-    item.actionItemList.map((actionItem) => ({
-      id: actionItem.actionItemId,
-      content: actionItem.content,
-    })),
-  );
+
+  const actionItems = retrospectInfo.actionItemList.map((actionItem) => ({
+    id: actionItem.actionItemId,
+    content: actionItem.content,
+  }));
+
   const [data, setData] = useState(actionItems);
   const isLimit = data.length >= 6;
 
@@ -93,7 +93,7 @@ export function ActionItemEditPage() {
   const handleAdd = () => {
     if (isLimit) return;
     createActionItem(
-      { retrospectId: retrospectInfo[0].retrospectId, content: "" },
+      { retrospectId: retrospectInfo.retrospectId, content: "" },
       {
         onSuccess: (res: AxiosResponse<{ actionItemId: number }>) => {
           try {
@@ -108,7 +108,7 @@ export function ActionItemEditPage() {
 
   const handleComplete = () => {
     patchActionItem(
-      { retrospectId: retrospectInfo[0].retrospectId, actionItems: data },
+      { retrospectId: retrospectInfo.retrospectId, actionItems: data },
       {
         onSuccess: () => {
           toast.success("실행목표 편집이 완료되었어요!");

--- a/apps/web/src/component/actionItem/ActionItemBox.tsx
+++ b/apps/web/src/component/actionItem/ActionItemBox.tsx
@@ -294,9 +294,11 @@ export default function ActionItemBox({
                   variant={"subtitle14SemiBold"}
                   color={"gray800"}
                   onClick={() => {
+                    const selectedRetrospect = retrospectInfo.find((item) => item.retrospectId === id);
+
                     navigate(PATHS.goalsEdit(), {
                       state: {
-                        data: retrospectInfo,
+                        data: selectedRetrospect,
                       },
                     });
                   }}


### PR DESCRIPTION
> ### PR 제목은 핵심 변경 사항을 요약해주세요
---

### 🏄🏼‍♂️‍ Summary (요약)

- 특정 회고의 실행목표를 편집하려고 할 때, 해당 회고의 실행목표만 나오는 것이 아닌 스페이스의 모든 실행목표가 보이고 편집이 가능했습니다.

### 🫨 Describe your Change (변경사항)

- 모든 retrospectInfo를 전달하기보다 특정 회고의 id로 걸러진 retrospectInfo만 ActionItemEditPage 페이지로 넘기도록 변경했습니다.

### 🧐 Issue number and link (참고)

- #443 

### 📚 Reference (참조)

https://github.com/user-attachments/assets/3e12bf8b-9939-4363-86d3-f18c69c5419b

close #443 