### PR TITLE
feat: 메인 스페이스 리스트 레이아웃(칩, 텍스트) 개선

### DIFF
--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -15,7 +15,6 @@ module.exports = {
   parserOptions: {
     ecmaVersion: "latest",
     sourceType: "module",
-    project: true,
     tsconfigRootDir: __dirname,
   },
   ignorePatterns: ["postcss.config.cjs", "dist", ".eslintrc.cjs", "**/*.cjs"],

--- a/apps/web/src/component/common/StatusChips/index.tsx
+++ b/apps/web/src/component/common/StatusChips/index.tsx
@@ -1,0 +1,21 @@
+import { DESIGN_TOKEN_TEXT } from "@/style/designTokens";
+import { css } from "@emotion/react";
+import { ReactNode } from "react";
+
+export default function Index({ children }: { children: ReactNode }) {
+  return (
+    // TODO: 디자인 팀에 새로운 배경 컬러에 따른 디자인 토큰 요청하기
+    <div
+      css={css`
+        ${DESIGN_TOKEN_TEXT.body12SemiBold}
+        color: #73a2ff;
+        background: #f0f4ff;
+        padding: 0.35rem 0.6rem;
+        border-radius: 0.4rem;
+        width: fit-content;
+      `}
+    >
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/component/home/SpaceOverview.tsx
+++ b/apps/web/src/component/home/SpaceOverview.tsx
@@ -2,20 +2,19 @@ import { css } from "@emotion/react";
 import { forwardRef } from "react";
 
 import spaceDefaultImg from "@/assets/imgs/space/spaceDefaultImg.png";
-import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
-import { TagBox } from "@/component/home";
 import { useTestNatigate } from "@/lib/test-natigate";
 import { ANIMATION } from "@/style/common/animation.ts";
-import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { DESIGN_TOKEN_COLOR, DESIGN_TOKEN_TEXT } from "@/style/designTokens";
 import { Space } from "@/types/spaceType";
+import StatusChips from "@/component/common/StatusChips";
 
 type SpaceOverviewProps = {
   space: Space;
 };
 
 const SpaceOverview = forwardRef<HTMLDivElement, SpaceOverviewProps>(
-  ({ space: { id, category, bannerUrl, fieldList, name, introduction, memberCount } }, ref) => {
+  ({ space: { id, bannerUrl, name, introduction, memberCount, proceedingRetrospectCount, retrospectCount } }, ref) => {
     const navigate = useTestNatigate();
     return (
       <div
@@ -63,10 +62,22 @@ const SpaceOverview = forwardRef<HTMLDivElement, SpaceOverviewProps>(
             height: 100%;
             display: flex;
             flex-direction: column;
-            gap: 0.2rem;
+            gap: 0.6rem;
           `}
         >
-          <Typography variant="title18Bold">{name}</Typography>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+
+              & > div:nth-of-type(1) {
+                margin-left: auto;
+              }
+            `}
+          >
+            <Typography variant="title16Bold">{name}</Typography>
+            {proceedingRetrospectCount > 0 && <StatusChips> 진행 중 {proceedingRetrospectCount} </StatusChips>}
+          </div>
           <Typography variant="body14Medium" color="gray600">
             {introduction}
           </Typography>
@@ -76,36 +87,22 @@ const SpaceOverview = forwardRef<HTMLDivElement, SpaceOverviewProps>(
               display: flex;
               justify-content: space-between;
               align-items: center;
-              margin-top: 1.4rem;
+              margin-top: 0.2rem;
             `}
           >
             <div
               css={css`
+                ${DESIGN_TOKEN_TEXT.body12Medium};
                 display: flex;
                 gap: 0.4rem;
-                width: 87%;
                 overflow-x: auto;
                 white-space: nowrap;
+                color: ${DESIGN_TOKEN_COLOR.gray600};
               `}
             >
-              <TagBox tagName={category} />
-              {fieldList.map((field, idx) => (
-                <TagBox key={idx} tagName={field} />
-              ))}
-            </div>
-            <div
-              css={css`
-                width: auto;
-                height: 2rem;
-                display: flex;
-                align-items: center;
-                gap: 0.4rem;
-              `}
-            >
-              <Icon icon="ic_user" size={1.7} />
-              <Typography variant="body14Medium" color="gray900">
-                {memberCount}
-              </Typography>
+              <span> 멤버 {memberCount}명</span>
+              <span> · </span>
+              <span> 회고 {retrospectCount}개</span>
             </div>
           </div>
         </div>

--- a/apps/web/src/types/spaceType/index.ts
+++ b/apps/web/src/types/spaceType/index.ts
@@ -9,4 +9,6 @@ export type Space = {
   bannerUrl: string;
   memberCount: number;
   leader: { id: number; name: string };
+  proceedingRetrospectCount: number;
+  retrospectCount: number;
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -27,10 +27,10 @@
     },
 
     /* Type checking */
-    "types": ["vite-plugin-svgr/client"],
+    "types": ["vite-plugin-svgr/client"], // for vite-plugin-svgr
 
     /* Emotion */
-    "jsxImportSource": "@emotion/react", // for vite-plugin-svgr
+    "jsxImportSource": "@emotion/react",
 
     /* Matter-js library file */
     "allowJs": true


### PR DESCRIPTION
> ### 디자인 요구사항 반영 작업
---

### 요약
- 메인 리스트 레이아웃(칩, 텍스트) 개선하는 작업을 진행했어요

### 변경사항
- apps/web/src/component/common/StatusChips/index.tsx
  - 상태를 나타내는 스타일 칩 컴포넌트 추가 
- apps/web/src/component/home/SpaceOverview.tsx
  - 회고 리스트 카드 뷰 레이아웃 수정
- apps/web/src/types/spaceType/index.ts
  - 회고 리스트 카드 뷰 레이아웃 수정을 위한 일부 타입 추가

### 이슈 번호 또는 링크
- close: #475

### 비고
- 회고 스페이스 및 공간 생성 플로우에 대해서는 디자인 확정 후 추후 반영 예정입니다-!