### PR TITLE
feat: LNB에서 선택한 스페이스 상태 관리

### DIFF
--- a/apps/web/src/app/mobile/home/RetrospectViewPage.tsx
+++ b/apps/web/src/app/mobile/home/RetrospectViewPage.tsx
@@ -14,20 +14,23 @@ import { DefaultLayout } from "@/layout/DefaultLayout";
 import { useTestNatigate } from "@/lib/test-natigate";
 import { EmptySpaceList } from "@/component/space/view/EmptySpaceList";
 
+const PROJECT_CATEGORY_MAP = {
+  전체: "ALL",
+  개인: "INDIVIDUAL",
+  팀: "TEAM",
+} as const;
+
+const CATEGORY_NAMES = Object.keys(PROJECT_CATEGORY_MAP) as Array<keyof typeof PROJECT_CATEGORY_MAP>;
+
 export function RetrospectViewPage() {
   // const navigate = useNavigate();
-  const naviagte = useTestNatigate();
+  const navigate = useTestNatigate(); // TODO(prgmr99): 오탈자 확인
 
-  const tabMappings = {
-    전체: "ALL",
-    개인: "INDIVIDUAL",
-    팀: "TEAM",
-  } as const;
-  const tabNames = Object.keys(tabMappings) as Array<keyof typeof tabMappings>;
-  const { tabs, curTab, selectTab } = useTabs(tabNames);
-  const selectedView = tabMappings[curTab];
+  const { tabs, curTab, selectTab } = useTabs(CATEGORY_NAMES);
+  const currentCategory = PROJECT_CATEGORY_MAP[curTab];
 
-  const { data: spaceList, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } = useApiGetSpaceList(selectedView);
+  const { data: spaceList, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } = useApiGetSpaceList(currentCategory);
+
   const observer = useRef<IntersectionObserver | null>(null);
 
   const lastElementRef = useCallback(
@@ -44,11 +47,12 @@ export function RetrospectViewPage() {
   );
 
   const goToCreateSpace = () => {
-    naviagte(PATHS.spaceCreate());
+    navigate(PATHS.spaceCreate());
   };
 
   const isEmptySpaceList =
-    spaceList?.pages.flatMap((page) => page.data).filter((space) => (selectedView === "ALL" ? true : space.category === selectedView)).length === 0;
+    spaceList?.pages.flatMap((page) => page.data).filter((space) => (currentCategory === "ALL" ? true : space.category === currentCategory))
+      .length === 0;
 
   return (
     <DefaultLayout
@@ -76,7 +80,7 @@ export function RetrospectViewPage() {
       >
         {spaceList?.pages
           .flatMap((page) => page.data)
-          .filter((space) => (selectedView === "ALL" ? true : space.category === selectedView))
+          .filter((space) => (currentCategory === "ALL" ? true : space.category === currentCategory))
           .map((space, idx) => (
             <SpaceOverview
               key={space.id}

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/Navigation.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/Navigation.tsx
@@ -11,7 +11,6 @@ import { useNavigation } from "../context/NavigationContext";
 export default function Navigation() {
   const { isCollapsed } = useNavigation();
 
-  // TODO(prgmr99): 현재 탭을 기준으로 스페이스 리스트 불러오기
   const [currentTab, setCurrentTab] = useState<"전체" | "개인" | "팀">("전체");
 
   const handleCurrentTabClick = (tab: keyof typeof PROJECT_CATEGORY_MAP) => {
@@ -21,8 +20,10 @@ export default function Navigation() {
   return (
     <nav
       css={css`
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
         flex: 1;
-        overflow-y: auto;
         padding: ${isCollapsed ? "0.6rem" : "1.2rem"};
       `}
     >
@@ -32,6 +33,10 @@ export default function Navigation() {
       {/* ---------- 내 스페이스 ---------- */}
       <section
         css={css`
+          display: flex;
+          flex-direction: column;
+          min-height: 0;
+          flex: 1;
           margin-top: ${isCollapsed ? 0 : "0.8rem"};
         `}
       >

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/Navigation.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/Navigation.tsx
@@ -5,7 +5,7 @@ import HeaderSpaceAddButton from "./space/HeaderSpaceAddButton";
 import SpacesList from "./space/SpacesList";
 import SpaceTabs from "./space/SpaceTabs";
 import { useState } from "react";
-import { SPACE_TABS } from "../constants";
+import { PROJECT_CATEGORY_MAP } from "../constants";
 import { useNavigation } from "../context/NavigationContext";
 
 export default function Navigation() {
@@ -14,7 +14,7 @@ export default function Navigation() {
   // TODO(prgmr99): 현재 탭을 기준으로 스페이스 리스트 불러오기
   const [currentTab, setCurrentTab] = useState<"전체" | "개인" | "팀">("전체");
 
-  const handleCurrentTabClick = (tab: (typeof SPACE_TABS)[number]) => {
+  const handleCurrentTabClick = (tab: keyof typeof PROJECT_CATEGORY_MAP) => {
     setCurrentTab(tab);
   };
 
@@ -42,7 +42,7 @@ export default function Navigation() {
         <SpaceTabs currentTab={currentTab} handleCurrentTabClick={handleCurrentTabClick} />
 
         {/* ---------- 스페이스 리스트 ---------- */}
-        <SpacesList />
+        <SpacesList currentTab={currentTab} />
       </section>
     </nav>
   );

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { useAtom } from "jotai";
 
 import { Icon } from "../../../Icon";
 import { Typography } from "../../../typography";
@@ -6,8 +7,7 @@ import { useNavigation } from "../../context/NavigationContext";
 
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Space } from "@/types/spaceType";
-
-const IS_CURRENT_SPACE = false; // ! 임시변수, 아래의 TODO 완료 후 제거
+import { currentSpaceState } from "@/store/space/spaceAtom";
 
 interface SpaceItemProps {
   space: Space;
@@ -16,9 +16,15 @@ interface SpaceItemProps {
 export default function SpaceItem({ space }: SpaceItemProps) {
   const { isCollapsed } = useNavigation();
 
-  const { name, introduction } = space;
+  const { name, introduction, id } = space;
 
-  // TODO(prgmr99): 현재 선택된 스페이스 전역상태 업데이트 로직 추가
+  const [currentSpace, setCurrentSpace] = useAtom(currentSpaceState);
+
+  const isCurrent = String(currentSpace?.id) === String(id);
+
+  const handleSelectSpace = () => {
+    setCurrentSpace(space);
+  };
 
   return (
     <li
@@ -27,7 +33,7 @@ export default function SpaceItem({ space }: SpaceItemProps) {
         align-items: center;
         gap: 1rem;
         width: 100%;
-        background-color: ${IS_CURRENT_SPACE ? DESIGN_TOKEN_COLOR.gray100 : "transparent"};
+        background-color: ${isCurrent ? DESIGN_TOKEN_COLOR.gray100 : "transparent"};
         border-radius: 0.8rem;
         cursor: pointer;
         transition: background-color 0.2s ease-in-out;
@@ -48,6 +54,7 @@ export default function SpaceItem({ space }: SpaceItemProps) {
           background-color: ${DESIGN_TOKEN_COLOR.gray100};
         }
       `}
+      onClick={handleSelectSpace}
     >
       {/* ---------- 스페이스 이미지/아이콘 ---------- */}
       <div

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
@@ -5,11 +5,19 @@ import { Typography } from "../../../typography";
 import { useNavigation } from "../../context/NavigationContext";
 
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { Space } from "@/types/spaceType";
 
 const IS_CURRENT_SPACE = false; // ! 임시변수, 아래의 TODO 완료 후 제거
 
-export default function SpaceItem() {
+interface SpaceItemProps {
+  space: Space;
+}
+
+export default function SpaceItem({ space }: SpaceItemProps) {
   const { isCollapsed } = useNavigation();
+
+  const { name, introduction } = space;
+
   // TODO(prgmr99): 현재 선택된 스페이스 전역상태 업데이트 로직 추가
 
   return (
@@ -87,7 +95,7 @@ export default function SpaceItem() {
             text-overflow: ellipsis;
           `}
         >
-          스페이스 이름 1
+          {name}
         </Typography>
         <Typography
           variant="body12Medium"
@@ -98,7 +106,7 @@ export default function SpaceItem() {
             text-overflow: ellipsis;
           `}
         >
-          스페이스 설명
+          {introduction}
         </Typography>
       </div>
     </li>

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
@@ -1,13 +1,14 @@
 import { css } from "@emotion/react";
 import { useAtom } from "jotai";
 
-import { Icon } from "../../../Icon";
 import { Typography } from "../../../typography";
 import { useNavigation } from "../../context/NavigationContext";
 
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Space } from "@/types/spaceType";
 import { currentSpaceState } from "@/store/space/spaceAtom";
+
+import spaceDefaultImg from "@/assets/imgs/space/spaceDefaultImg.png";
 
 interface SpaceItemProps {
   space: Space;
@@ -16,7 +17,7 @@ interface SpaceItemProps {
 export default function SpaceItem({ space }: SpaceItemProps) {
   const { isCollapsed } = useNavigation();
 
-  const { name, introduction, id } = space;
+  const { id, name, introduction, bannerUrl } = space;
 
   const [currentSpace, setCurrentSpace] = useAtom(currentSpaceState);
 
@@ -62,11 +63,22 @@ export default function SpaceItem({ space }: SpaceItemProps) {
           width: 3.6rem;
           height: 3.6rem;
           background-color: ${DESIGN_TOKEN_COLOR.gray200};
-          padding: 0.6rem;
           border-radius: 50%;
         `}
       >
-        <Icon icon="ic_management_white" size={2.4} />
+        <img
+          src={bannerUrl}
+          alt={`${name}Image`}
+          onError={(e) => {
+            e.currentTarget.src = spaceDefaultImg;
+          }}
+          css={css`
+            width: 3.6rem;
+            height: 3.6rem;
+            border-radius: 100%;
+            object-fit: cover;
+          `}
+        />
       </div>
 
       {/* ---------- 스페이스 이름/설명 ---------- */}

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceTabs.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceTabs.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { Typography } from "@/component/common/typography";
 import { useNavigation } from "../../context/NavigationContext";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
-import { SPACE_TABS } from "../../constants";
+import { CATEGORY_NAMES } from "../../constants";
 
 interface SpaceTabsProps {
   currentTab: "전체" | "개인" | "팀";
@@ -39,7 +39,7 @@ export default function SpaceTabs({ currentTab, handleCurrentTabClick }: SpaceTa
             `}
       `}
     >
-      {SPACE_TABS.map((tab) => (
+      {CATEGORY_NAMES.map((tab) => (
         <button
           key={tab}
           onClick={() => handleCurrentTabClick(tab)}

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -63,6 +63,8 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
         gap: 0.4rem;
         margin-top: 1rem;
         padding: 0;
+        flex: 1;
+        overflow-y: auto;
       `}
     >
       {spaces.map((space) => (
@@ -72,7 +74,7 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
 
       {hasNextPage && <div ref={observerRef} style={{ height: "1px" }} />}
 
-      {/* TODO: 로딩 UI 디자인 확인 필요 */}
+      {/* TODO: 로딩 UI 디자인 확인 필요 (임시 적용)*/}
       {isFetchingNextPage && <LoadingSpinner />}
     </ul>
   );

--- a/apps/web/src/component/common/LocalNavigationBar/constants.ts
+++ b/apps/web/src/component/common/LocalNavigationBar/constants.ts
@@ -1,1 +1,3 @@
-export const SPACE_TABS = ["전체", "개인", "팀"] as const;
+export const PROJECT_CATEGORY_MAP = { 전체: "ALL", 개인: "INDIVIDUAL", 팀: "TEAM" } as const;
+
+export const CATEGORY_NAMES = Object.keys(PROJECT_CATEGORY_MAP) as Array<keyof typeof PROJECT_CATEGORY_MAP>;

--- a/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
+++ b/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
@@ -11,21 +11,35 @@ type SpaceFetchResponse = {
   };
 };
 
+type UseApiGetSpaceListOptions = {
+  pageSize?: number;
+};
+
+const DEFAULT_PAGE_SIZE = 5;
+
 export const spaceFetch = async (cursorId: number, category: string, pageSize: number) => {
-  const params = category !== "ALL" ? { cursorId: cursorId, category: category, pageSize: pageSize } : { cursorId: cursorId, pageSize: pageSize };
+  const params: { cursorId: number; pageSize: number; category?: string } = {
+    cursorId,
+    pageSize,
+  };
+
+  if (category !== "ALL") {
+    params.category = category;
+  }
 
   const response = await api.get<SpaceFetchResponse>("/api/space/list", {
-    params: params,
+    params,
   });
   return response.data;
 };
 
-export const useApiGetSpaceList = (selectedView: string) => {
+export const useApiGetSpaceList = (category: string, options?: UseApiGetSpaceListOptions) => {
+  const { pageSize = DEFAULT_PAGE_SIZE } = options || {};
+
   return useInfiniteQuery<SpaceFetchResponse>({
-    queryKey: ["spaces", selectedView],
-    queryFn: ({ queryKey, pageParam = 0 }) => {
-      const [, category] = queryKey;
-      return spaceFetch(pageParam as number, category as string, 5);
+    queryKey: ["spaces", category],
+    queryFn: ({ pageParam = 0 }) => {
+      return spaceFetch(pageParam as number, category, pageSize);
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.meta.hasNextPage ? lastPage.meta.cursor : undefined),

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -119,7 +119,7 @@ const deviceSpecificRoutes: RouteChildren[] = [
   },
   {
     path: "login",
-    element: <div>Desktop Login</div>, // TODO: 데스크탑용 로그인
+    element: <LoginPage />, // TODO: 데스크탑용 로그인(임시로 기존 로그인 페이지 사용)
     auth: false,
     deviceType: "desktop",
   },

--- a/apps/web/src/store/space/spaceAtom.ts
+++ b/apps/web/src/store/space/spaceAtom.ts
@@ -2,6 +2,7 @@ import { atomWithReset } from "jotai/utils";
 
 import { ProjectType, SpaceValue } from "@/types/space";
 import { atom } from "jotai";
+import { Space } from "@/types/spaceType";
 
 const initialState = {
   category: ProjectType.Individual,
@@ -16,4 +17,4 @@ const initialState = {
 export const spaceState = atomWithReset<SpaceValue>(initialState);
 
 // * 현재 선택된 스페이스 전역 상태
-export const currentSpaceState = atom<SpaceValue | null>(null);
+export const currentSpaceState = atom<Space | null>(null);


### PR DESCRIPTION
> ### LocalNavigationBar에서 선택한 스페이스 상태 관리
---

### 🏄🏼‍♂️‍ Summary (요약)
- 내 스페이스 목록 조회
    - 무한스크롤 적용
- 선택한 스페이스에 대한 전역 상태 갱신 로직 추가 

### 🫨 Describe your Change (변경사항)
- `apps/web/src/app/mobile/home/RetrospectViewPage.tsx`에서 사용되는 현재 선택된 카테고리를 나타내는 변수명 변경 
    (`selectedView` -> `currentCategory`)

### 🧐 Issue number and link (참고)
- #490 

### 📚 Reference (참조)

- loading lottie는 기존의 존재하는 것을 사용했는데, 이걸 사용해도 될지는 얘기가 필요해보입니다..!

https://github.com/user-attachments/assets/ea5f451f-22e8-443a-8142-604b765eabd2



close #490 