### PR TITLE
feat: 홈 화면 - 내 회고 리포트 작성중인 회고 UI 작업

### DIFF
--- a/apps/web/src/app/desktop/home/HomePage.tsx
+++ b/apps/web/src/app/desktop/home/HomePage.tsx
@@ -16,7 +16,7 @@ export function HomePage() {
           text-align: center;
         `}
       >
-        <Typography color="gray900" variant="T2">
+        <Typography color="gray900" variant="heading28Bold">
           내 회고 리포트
         </Typography>
 

--- a/apps/web/src/app/desktop/home/HomePage.tsx
+++ b/apps/web/src/app/desktop/home/HomePage.tsx
@@ -1,0 +1,39 @@
+import { Typography } from "@/component/common/typography";
+import QuickActionButton from "@/component/home/QuickActionButton";
+import { css } from "@emotion/react";
+
+export function HomePage() {
+  return (
+    <section
+      css={css`
+        width: "100%";
+      `}
+    >
+      <header
+        css={css`
+          padding-top: 4.5rem;
+          margin: 0 auto;
+          text-align: center;
+        `}
+      >
+        <Typography color="gray900" variant="T2">
+          내 회고 리포트
+        </Typography>
+
+        <section
+          css={css`
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 0.8rem;
+            margin-top: 1.5rem;
+          `}
+        >
+          <QuickActionButton action="작성 예정 회고보기" />
+          <QuickActionButton action="회고 생성하기" />
+          <QuickActionButton action="회고 작성하기" />
+        </section>
+      </header>
+    </section>
+  );
+}

--- a/apps/web/src/app/desktop/home/HomePage.tsx
+++ b/apps/web/src/app/desktop/home/HomePage.tsx
@@ -1,39 +1,20 @@
-import { Typography } from "@/component/common/typography";
-import QuickActionButton from "@/component/home/QuickActionButton";
 import { css } from "@emotion/react";
+
+import HomePageHeader from "@/component/home/HomePageHeader";
+import InProgressRetrospectsWrapper from "@/component/home/InProgressRetrospectsWrapper";
 
 export function HomePage() {
   return (
     <section
       css={css`
         width: "100%";
+        margin: 0 auto;
+        max-width: 92.8rem;
       `}
     >
-      <header
-        css={css`
-          padding-top: 4.5rem;
-          margin: 0 auto;
-          text-align: center;
-        `}
-      >
-        <Typography color="gray900" variant="heading28Bold">
-          내 회고 리포트
-        </Typography>
+      <HomePageHeader />
 
-        <section
-          css={css`
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            gap: 0.8rem;
-            margin-top: 1.5rem;
-          `}
-        >
-          <QuickActionButton action="작성 예정 회고보기" />
-          <QuickActionButton action="회고 생성하기" />
-          <QuickActionButton action="회고 작성하기" />
-        </section>
-      </header>
+      <InProgressRetrospectsWrapper />
     </section>
   );
 }

--- a/apps/web/src/app/mobile/home/HomePage.tsx
+++ b/apps/web/src/app/mobile/home/HomePage.tsx
@@ -2,6 +2,7 @@ import { Outlet } from "react-router-dom";
 
 import { NavigationBar } from "@/component/home";
 
+// TODO: 사용되지 않는 코드, 추후 제거
 export function HomePage() {
   return (
     <div>

--- a/apps/web/src/app/mobile/space/SpaceViewPage.tsx
+++ b/apps/web/src/app/mobile/space/SpaceViewPage.tsx
@@ -51,6 +51,7 @@ export function SpaceViewPage() {
     queries: [useApiOptionsGetRetrospects(spaceId), useApiOptionsGetSpaceInfo(spaceId), useAPiOptionsRecentTeamActionList(spaceId)],
   });
 
+  // TODO: 상태 관리 useQueries로 통합 관리하도록 개선
   const [proceedingRetrospects, setProceedingRetrospects] = useState<Retrospect[]>([]);
   const [doneRetrospects, setDoneRetrospects] = useState<Retrospect[]>([]);
 

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -26,7 +26,7 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
     isPending,
     isFetchingNextPage,
     fetchNextPage,
-  } = useApiGetSpaceList(currentCategory, undefined, {
+  } = useApiGetSpaceList(currentCategory, {
     refetchOnWindowFocus: false,
   });
 

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -20,15 +20,7 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
 
   const observerRef = useRef<HTMLDivElement>(null);
 
-  const {
-    data: spaceData,
-    hasNextPage,
-    isPending,
-    isFetchingNextPage,
-    fetchNextPage,
-  } = useApiGetSpaceList(currentCategory, {
-    refetchOnWindowFocus: false,
-  });
+  const { data: spaceData, hasNextPage, isPending, isFetchingNextPage, fetchNextPage } = useApiGetSpaceList(currentCategory);
 
   const spaces = spaceData?.pages.flatMap((page) => page.data) ?? [];
 

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -8,6 +8,7 @@ import { useApiGetSpaceList } from "@/hooks/api/space/useApiGetSpaceList";
 import { PROJECT_CATEGORY_MAP } from "../../constants";
 import { useEffect, useRef } from "react";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
+import { queryOptions } from "@tanstack/react-query";
 
 interface SpacesListProps {
   currentTab: "전체" | "개인" | "팀";
@@ -20,7 +21,15 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
 
   const observerRef = useRef<HTMLDivElement>(null);
 
-  const { data: spaceData, hasNextPage, isFetching, isFetchingNextPage, fetchNextPage } = useApiGetSpaceList(currentCategory);
+  const {
+    data: spaceData,
+    hasNextPage,
+    isPending,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useApiGetSpaceList(currentCategory, undefined, {
+    refetchOnWindowFocus: false,
+  });
 
   const spaces = spaceData?.pages.flatMap((page) => page.data) ?? [];
 
@@ -50,7 +59,7 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
     };
   }, [hasNextPage, fetchNextPage]);
 
-  if (isFetching && !isFetchingNextPage) {
+  if (isPending && !isFetchingNextPage) {
     return <LoadingSpinner />;
   }
 

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -8,7 +8,6 @@ import { useApiGetSpaceList } from "@/hooks/api/space/useApiGetSpaceList";
 import { PROJECT_CATEGORY_MAP } from "../../constants";
 import { useEffect, useRef } from "react";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
-import { queryOptions } from "@tanstack/react-query";
 
 interface SpacesListProps {
   currentTab: "전체" | "개인" | "팀";

--- a/apps/web/src/component/common/LocalNavigationBar/index.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/index.tsx
@@ -3,11 +3,11 @@ import { css } from "@emotion/react";
 import Footer from "./Footer";
 import Header from "./Header";
 import Navigation from "./Navigation/Navigation";
-import { NavigationProvider, useNavigation } from "./context/NavigationContext";
+import { useNavigation } from "./context/NavigationContext";
 
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
-function LocalNavigationBarContent() {
+export default function LocalNavigationBar() {
   const { isCollapsed } = useNavigation();
 
   return (
@@ -33,13 +33,5 @@ function LocalNavigationBarContent() {
 
       <Footer />
     </aside>
-  );
-}
-
-export default function LocalNavigationBar() {
-  return (
-    <NavigationProvider>
-      <LocalNavigationBarContent />
-    </NavigationProvider>
   );
 }

--- a/apps/web/src/component/home/HomePageHeader/index.tsx
+++ b/apps/web/src/component/home/HomePageHeader/index.tsx
@@ -1,0 +1,33 @@
+import { Typography } from "@/component/common/typography";
+import { css } from "@emotion/react";
+import QuickActionButton from "../QuickActionButton";
+
+export default function HomePageHeader() {
+  return (
+    <header
+      css={css`
+        padding-top: 4.5rem;
+        margin: 0 auto;
+        text-align: center;
+      `}
+    >
+      <Typography color="gray900" variant="heading28Bold">
+        내 회고 리포트
+      </Typography>
+
+      <section
+        css={css`
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          gap: 0.8rem;
+          margin-top: 1.5rem;
+        `}
+      >
+        <QuickActionButton action="작성 예정 회고보기" />
+        <QuickActionButton action="회고 생성하기" />
+        <QuickActionButton action="회고 작성하기" />
+      </section>
+    </header>
+  );
+}

--- a/apps/web/src/component/home/InProgressRetrospectCard/index.tsx
+++ b/apps/web/src/component/home/InProgressRetrospectCard/index.tsx
@@ -1,0 +1,121 @@
+import { css } from "@emotion/react";
+import { Typography } from "@/component/common/typography";
+import { Icon } from "@/component/common/Icon";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+
+interface InProgressRetrospectCardProps {
+  title: string;
+  description: string;
+  createdAt: string;
+  memberCount?: number;
+}
+
+export default function InProgressRetrospectCard({ title, description, createdAt, memberCount = 0 }: InProgressRetrospectCardProps) {
+  return (
+    <section
+      css={css`
+        display: flex;
+        flex-direction: column;
+        max-width: 28rem;
+        height: 13.8rem;
+        padding: 1.6rem;
+        background-color: white;
+        border-radius: 1.2rem;
+        border: 1px solid #f1f3f5;
+        transition: all 0.2s ease;
+        cursor: pointer;
+        flex: 1;
+
+        &:hover {
+          border-color: #e9ecef;
+          transform: translateY(-2px);
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+      `}
+    >
+      {/* ---------- 상단 라벨 ---------- */}
+      <div
+        css={css`
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 1.2rem;
+        `}
+      >
+        <div
+          css={css`
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: fit-content;
+            height: 2.2rem;
+            padding: 0.3rem 0.6rem;
+            background-color: ${DESIGN_TOKEN_COLOR.gray200};
+            border-radius: 0.4rem;
+            border: 0.0883rem solid;
+            border-color: ${DESIGN_TOKEN_COLOR.gray400};
+          `}
+        >
+          <Typography variant="caption11Medium" color="gray700">
+            작성 전
+          </Typography>
+        </div>
+        <Icon icon="ic_more" size={2.0} color={DESIGN_TOKEN_COLOR.gray500} />
+      </div>
+
+      {/* ---------- 제목 ---------- */}
+      <Typography variant="body15Bold" color="gray900">
+        {title}
+      </Typography>
+
+      {/* ---------- 설명 ----------*/}
+      <div
+        css={css`
+          margin-top: 0.8rem;
+          flex: 1;
+        `}
+      >
+        <Typography
+          variant="body12SemiBold"
+          color="gray800"
+          css={css`
+            display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          `}
+        >
+          {description}
+        </Typography>
+      </div>
+
+      {/* ---------- 하단 정보 ---------- */}
+      <div
+        css={css`
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        `}
+      >
+        <Typography variant="body12SemiBold" color="gray500">
+          마감 예정 | {createdAt}
+        </Typography>
+
+        {memberCount > 0 && (
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+              gap: 0.2rem;
+            `}
+          >
+            <Icon icon="ic_person" size={1.8} color={DESIGN_TOKEN_COLOR.blue600} />
+            <Typography variant="body12SemiBold" color="gray500">
+              {memberCount} / {10}
+            </Typography>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/component/home/InProgressRetrospectCard/index.tsx
+++ b/apps/web/src/component/home/InProgressRetrospectCard/index.tsx
@@ -21,7 +21,6 @@ export default function InProgressRetrospectCard({ title, description, createdAt
         padding: 1.6rem;
         background-color: white;
         border-radius: 1.2rem;
-        border: 1px solid #f1f3f5;
         transition: all 0.2s ease;
         cursor: pointer;
         flex: 1;

--- a/apps/web/src/component/home/InProgressRetrospectsWrapper/index.tsx
+++ b/apps/web/src/component/home/InProgressRetrospectsWrapper/index.tsx
@@ -1,0 +1,65 @@
+import { css } from "@emotion/react";
+import { Typography } from "@/component/common/typography";
+import InProgressRetrospectCard from "../InProgressRetrospectCard";
+
+// TODO: 실제 데이터로 교체
+const DUMMY_RETROSPECTS = [
+  {
+    id: 1,
+    title: "중간발표 이후 회고",
+    description: "중간발표 과정 및 팀의 커뮤니케이션 과정",
+    createdAt: "2024.07.30 10:00",
+    memberCount: 4,
+  },
+  {
+    id: 2,
+    title: "중간발표 이후 회고",
+    description: "중간발표 과정 및 팀의 커뮤니케이션 과정",
+    createdAt: "2024.07.30 10:00",
+    memberCount: 4,
+  },
+  {
+    id: 3,
+    title: "중간발표 이후 회고",
+    description: "중간발표 과정 및 팀의 커뮤니케이션 과정",
+    createdAt: "2024.07.30 10:00",
+    memberCount: 4,
+  },
+];
+
+export default function InProgressRetrospectsWrapper() {
+  return (
+    <section
+      css={css`
+        margin-top: 3.2rem;
+        padding: 2.4rem;
+      `}
+    >
+      {/* ---------- 제목 ---------- */}
+      <Typography variant="body15Bold" color="gray800">
+        작성중인 회고 ({DUMMY_RETROSPECTS.length})
+      </Typography>
+
+      {/* ---------- 카드 그리드 ---------- */}
+      <section
+        css={css`
+          margin-top: 1.6rem;
+          display: flex;
+          align-items: center;
+          gap: 1.2rem;
+          max-width: 100%;
+        `}
+      >
+        {DUMMY_RETROSPECTS.map((retrospect) => (
+          <InProgressRetrospectCard
+            key={retrospect.id}
+            title={retrospect.title}
+            description={retrospect.description}
+            createdAt={retrospect.createdAt}
+            memberCount={retrospect.memberCount}
+          />
+        ))}
+      </section>
+    </section>
+  );
+}

--- a/apps/web/src/component/home/QuickActionButton/index.tsx
+++ b/apps/web/src/component/home/QuickActionButton/index.tsx
@@ -18,6 +18,12 @@ export default function QuickActionButton({ action }: QuickActionButtonProps) {
         background-color: white;
         border-radius: 9.9rem;
         cursor: pointer;
+        transition: all 0.2s ease;
+
+        &:hover {
+          background-color: #f8f9fa;
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
       `}
     >
       <Icon icon="ic_template" size={2.4} color="blue600" />

--- a/apps/web/src/component/home/QuickActionButton/index.tsx
+++ b/apps/web/src/component/home/QuickActionButton/index.tsx
@@ -1,0 +1,29 @@
+import { Icon } from "@/component/common/Icon";
+import { Typography } from "@/component/common/typography";
+import { css } from "@emotion/react";
+
+interface QuickActionButtonProps {
+  action: string;
+  // path: string; TODO: 추후에 경로 지정
+}
+
+export default function QuickActionButton({ action }: QuickActionButtonProps) {
+  return (
+    <div
+      css={css`
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.6rem 1.2rem;
+        background-color: white;
+        border-radius: 9.9rem;
+        cursor: pointer;
+      `}
+    >
+      <Icon icon="ic_template" size={2.4} color="blue600" />
+      <Typography color="gray800" variant="body13Bold">
+        {action}
+      </Typography>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
+++ b/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { InfiniteData, QueryKey, useInfiniteQuery, UseInfiniteQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
 import { Space } from "@/types/spaceType";
@@ -14,6 +14,11 @@ type SpaceFetchResponse = {
 type UseApiGetSpaceListOptions = {
   pageSize?: number;
 };
+
+type UseApiGetSpaceListQueryOptions = Omit<
+  UseInfiniteQueryOptions<SpaceFetchResponse, Error, InfiniteData<SpaceFetchResponse, unknown>, SpaceFetchResponse, QueryKey, unknown>,
+  "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam"
+>;
 
 const DEFAULT_PAGE_SIZE = 5;
 
@@ -33,7 +38,7 @@ export const spaceFetch = async (cursorId: number, category: string, pageSize: n
   return response.data;
 };
 
-export const useApiGetSpaceList = (category: string, options?: UseApiGetSpaceListOptions) => {
+export const useApiGetSpaceList = (category: string, options?: UseApiGetSpaceListOptions, queryOptions?: UseApiGetSpaceListQueryOptions) => {
   const { pageSize = DEFAULT_PAGE_SIZE } = options || {};
 
   return useInfiniteQuery<SpaceFetchResponse>({
@@ -43,5 +48,6 @@ export const useApiGetSpaceList = (category: string, options?: UseApiGetSpaceLis
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.meta.hasNextPage ? lastPage.meta.cursor : undefined),
+    ...queryOptions,
   });
 };

--- a/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
+++ b/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
@@ -1,4 +1,4 @@
-import { InfiniteData, QueryKey, useInfiniteQuery, UseInfiniteQueryOptions } from "@tanstack/react-query";
+import { useInfiniteQuery, UseInfiniteQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
 import { Space } from "@/types/spaceType";
@@ -13,12 +13,7 @@ type SpaceFetchResponse = {
 
 type UseApiGetSpaceListOptions = {
   pageSize?: number;
-};
-
-type UseApiGetSpaceListQueryOptions = Omit<
-  UseInfiniteQueryOptions<SpaceFetchResponse, Error, InfiniteData<SpaceFetchResponse, unknown>, SpaceFetchResponse, QueryKey, unknown>,
-  "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam"
->;
+} & Omit<UseInfiniteQueryOptions<SpaceFetchResponse>, "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam" | "select">;
 
 const DEFAULT_PAGE_SIZE = 5;
 
@@ -38,8 +33,8 @@ export const spaceFetch = async (cursorId: number, category: string, pageSize: n
   return response.data;
 };
 
-export const useApiGetSpaceList = (category: string, options?: UseApiGetSpaceListOptions, queryOptions?: UseApiGetSpaceListQueryOptions) => {
-  const { pageSize = DEFAULT_PAGE_SIZE } = options || {};
+export const useApiGetSpaceList = (category: string, options?: UseApiGetSpaceListOptions) => {
+  const { pageSize = DEFAULT_PAGE_SIZE, ...queryOptions } = options || {};
 
   return useInfiniteQuery<SpaceFetchResponse>({
     queryKey: ["spaces", category],

--- a/apps/web/src/hooks/useNavigationState.ts
+++ b/apps/web/src/hooks/useNavigationState.ts
@@ -1,0 +1,19 @@
+import { useState, useCallback } from "react";
+
+export function useNavigationState() {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const toggleCollapsed = useCallback(() => {
+    setIsCollapsed((prev) => !prev);
+  }, []);
+
+  const setCollapsed = useCallback((collapsed: boolean) => {
+    setIsCollapsed(collapsed);
+  }, []);
+
+  return {
+    isCollapsed,
+    toggleCollapsed,
+    setCollapsed,
+  };
+}

--- a/apps/web/src/layout/DesktopHomeLayout.tsx
+++ b/apps/web/src/layout/DesktopHomeLayout.tsx
@@ -2,18 +2,30 @@ import { css } from "@emotion/react";
 import { Outlet } from "react-router-dom";
 
 import LocalNavigationBar from "@/component/common/LocalNavigationBar";
+import { NavigationProvider, useNavigation } from "@/component/common/LocalNavigationBar/context/NavigationContext";
 
-export default function DesktopHomeLayout() {
+function DesktopHomeLayoutContent() {
+  const { isCollapsed } = useNavigation();
+
   return (
     <main>
       <LocalNavigationBar />
       <section
         css={css`
-          margin-left: calc(26rem + 2.4rem);
+          margin-left: calc(${isCollapsed ? "6rem" : "26rem"} + 2.4rem);
+          transition: margin-left 0.3s ease-in-out;
         `}
       >
         <Outlet />
       </section>
     </main>
+  );
+}
+
+export default function DesktopHomeLayout() {
+  return (
+    <NavigationProvider>
+      <DesktopHomeLayoutContent />
+    </NavigationProvider>
   );
 }

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -45,6 +45,7 @@ import ChannelService from "@/lib/channel-talk/service";
 import { useDeviceType } from "@/hooks/useDeviceType";
 import DesktopGlobalLayout from "@/layout/DesktopGlobalLayout";
 import DesktopHomeLayout from "@/layout/DesktopHomeLayout";
+import { HomePage } from "@/app/desktop/home/HomePage";
 
 type RouteChildren = {
   auth: boolean;
@@ -95,7 +96,7 @@ const deviceSpecificRoutes: RouteChildren[] = [
     children: [
       {
         path: "",
-        element: <div>Desktop Home</div>, // TODO: 데스크탑용 홈
+        element: <HomePage />,
       },
       {
         path: "analysis",

--- a/apps/web/src/style/designTokens.ts
+++ b/apps/web/src/style/designTokens.ts
@@ -49,6 +49,11 @@ export const DESIGN_TOKEN_TEXT = {
     fontWeight: "400",
     lineHeight: "140%",
   },
+  body13Bold: {
+    fontSize: "1.3rem",
+    fontWeight: "600",
+    lineHeight: "150%",
+  },
   body13Medium: {
     fontSize: "1.3rem",
     fontWeight: "400",

--- a/apps/web/src/style/designTokens.ts
+++ b/apps/web/src/style/designTokens.ts
@@ -44,6 +44,11 @@ export const DESIGN_TOKEN_TEXT = {
     fontWeight: "400",
     lineHeight: "140%",
   },
+  body15Bold: {
+    fontSize: "1.5rem",
+    fontWeight: "700",
+    lineHeight: "140%",
+  },
   body15Medium: {
     fontSize: "1.5rem",
     fontWeight: "400",

--- a/apps/web/src/style/designTokens.ts
+++ b/apps/web/src/style/designTokens.ts
@@ -1,4 +1,9 @@
 export const DESIGN_TOKEN_TEXT = {
+  heading28Bold: {
+    fontSize: "2.8rem",
+    fontWeight: "700",
+    lineHeight: "150%",
+  },
   heading24Bold: {
     fontSize: "2.4rem",
     fontWeight: "700",


### PR DESCRIPTION
> ### 내 회고 리포트 작성중인 회고 UI 작업
---

### 🏄🏼‍♂️‍ Summary (요약)
- 홈 화면에 '내 회고 리포트'의 작성중인 회고 UI를 구현했습니다.

### 🫨 Describe your Change (변경사항)
- '내 회고 리포트'의 `QuickActionButton` 컴포넌트를 추가했습니다.
- 작성중인 회고의 카드 컴포넌트(`InProgressRetrospectCard`)를 새롭게 추가했습니다.
- 스페이스 목록을 불러오는 커스텀훅을 개선하여, tanstack query의 옵션들을 자유롭게 설정할 수 있도록 개선했습니다.

### 🧐 Issue number and link (참고)
- #488 

### 📚 Reference (참조)

<img width="920" height="958" alt="image" src="https://github.com/user-attachments/assets/3c18dc10-b6f7-434c-b5b3-3f3cb7060d2c" />



++ 코드리뷰 양 조절을 위해서 여기서 끊고 갈게요..!

close #488 