### PR TITLE
feat: 회고 분석 페이지 세팅

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
@@ -1,0 +1,140 @@
+import { Icon } from "@/component/common/Icon";
+import { Typography } from "@/component/common/typography";
+import { currentSpaceState } from "@/store/space/spaceAtom";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { css } from "@emotion/react";
+import { useAtomValue } from "jotai";
+
+export default function AnalysisOverviewHeader() {
+  const currentSelectedSpace = useAtomValue(currentSpaceState);
+
+  const { name, introduction, memberCount, formTag } = currentSelectedSpace || {};
+
+  return (
+    <section>
+      {/* ---------- 스페이스 이름 ---------- */}
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+          gap: 0.4rem;
+          margin-bottom: 0.8rem;
+        `}
+      >
+        <Typography variant="heading24Bold" color="gray900">
+          {name}
+        </Typography>
+        <Icon icon="ic_more" size={2.0} color={DESIGN_TOKEN_COLOR.gray900} />
+      </div>
+
+      {/* ---------- 스페이스 소개 ---------- */}
+      <Typography variant="body14SemiBold" color="gray600">
+        {introduction}
+      </Typography>
+
+      {/* ---------- 회고 추가 / 회고 템플릿 / 인원수 ---------- */}
+      <section
+        css={css`
+          display: flex;
+          gap: 0.6rem;
+          margin-top: 1.8rem;
+        `}
+      >
+        {/* ---------- 회고 추가 버튼 ---------- */}
+        <article
+          css={css`
+            display: flex;
+            padding: 0.8rem 1.2rem;
+            background-color: ${DESIGN_TOKEN_COLOR.blue600};
+            border-radius: 0.8rem;
+            align-items: center;
+            justify-content: center;
+            gap: 0.4rem;
+            cursor: pointer;
+          `}
+        >
+          <Icon icon={"ic_plus"} size={1.2} color={DESIGN_TOKEN_COLOR.gray00} />
+          <Typography variant="body14SemiBold" color="gray00">
+            회고 추가
+          </Typography>
+        </article>
+
+        {/* ---------- 회고 템플릿 필터 ---------- */}
+        <article
+          css={css`
+            display: flex;
+            padding: 0.8rem;
+            border-radius: 0.8rem;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.6rem;
+            background-color: ${DESIGN_TOKEN_COLOR.white};
+            flex: 1;
+            cursor: pointer;
+          `}
+        >
+          <Icon icon={"ic_document_color"} size={2.0} color={DESIGN_TOKEN_COLOR.gray00} />
+          <Typography variant="body14SemiBold" color="gray600">
+            {formTag}
+          </Typography>
+          <Icon icon={"ic_chevron_down"} size={1.4} color={DESIGN_TOKEN_COLOR.gray600} />
+        </article>
+
+        {/* ---------- 회고 인원수 필터 ---------- */}
+        <article
+          css={css`
+            display: flex;
+            padding: 0.8rem;
+            border-radius: 0.8rem;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.6rem;
+            background-color: ${DESIGN_TOKEN_COLOR.white};
+            flex: 1;
+            cursor: pointer;
+          `}
+        >
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+              gap: 0.6rem;
+            `}
+          >
+            <Icon icon={"ic_team"} size={2.0} color={DESIGN_TOKEN_COLOR.gray00} />
+            <Typography variant="body14SemiBold" color="gray600">
+              {memberCount}
+            </Typography>
+          </div>
+          <Icon icon={"ic_chevron_down"} size={1.4} color={DESIGN_TOKEN_COLOR.gray600} />
+        </article>
+      </section>
+
+      {/* ---------- 실행목표 ---------- */}
+      <section
+        css={css`
+          margin-top: 1.6rem;
+        `}
+      >
+        <article
+          css={css`
+            display: flex;
+            height: 3.7rem;
+            padding: 0.8rem 1.2rem;
+            justify-content: space-between;
+            align-items: center;
+            align-self: stretch;
+            border-radius: 0.8rem;
+            background: ${DESIGN_TOKEN_COLOR.gray00};
+            cursor: pointer;
+          `}
+        >
+          <Typography variant="body14Strong" color="gray900">
+            실행목표
+          </Typography>
+          <Icon icon="ic_chevron_down" size={1.6} color={DESIGN_TOKEN_COLOR.gray900} />
+        </article>
+      </section>
+    </section>
+  );
+}

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
@@ -6,6 +6,7 @@ import { css } from "@emotion/react";
 import { useAtomValue } from "jotai";
 
 export default function AnalysisOverviewHeader() {
+  // TODO: 새로고침해도 query를 통해서 데이터를 불러오도록 수정 필요
   const currentSelectedSpace = useAtomValue(currentSpaceState);
 
   const { name, introduction, memberCount, formTag } = currentSelectedSpace || {};

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/InProgressRetrospectsWrapper.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/InProgressRetrospectsWrapper.tsx
@@ -1,0 +1,88 @@
+import { Typography } from "@/component/common/typography";
+import { css } from "@emotion/react";
+
+import InProgressRetrospectCard from "../../home/InProgressRetrospectCard";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
+import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+export default function InProgressRetrospectsWrapper() {
+  const { spaceId } = useParams();
+
+  // * 스페이스 회고 목록 조회
+  const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId));
+
+  // * 진행중인 회고 필터링
+  const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);
+
+  return (
+    <section
+      css={css`
+        width: 34.4rem;
+        margin-top: 3.2rem;
+        padding: 0 3rem 3.2rem 1.8rem;
+        box-sizing: border-box;
+      `}
+    >
+      {/* ---------- 제목 ---------- */}
+      <section
+        css={css`
+          display: flex;
+          align-items: center;
+          gap: 0.6rem;
+        `}
+      >
+        <Typography variant="title16Bold2" color="gray900">
+          진행중인 회고
+        </Typography>
+        <Typography variant="title16Bold2" color="gray600">
+          {proceedingRetrospects?.length || 0}
+        </Typography>
+      </section>
+
+      <section
+        css={css`
+          margin-top: 1.6rem;
+        `}
+      >
+        {isRetrospectsPending ? (
+          <div
+            css={css`
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              width: 100%;
+              height: 13.8rem;
+              border-radius: 1.2rem;
+              border: 1px dashed ${DESIGN_TOKEN_COLOR.gray500};
+            `}
+          >
+            <LoadingSpinner />
+          </div>
+        ) : !retrospects || proceedingRetrospects.length === 0 ? (
+          <div
+            css={css`
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              width: 100%;
+              height: 13.8rem;
+              background-color: ${DESIGN_TOKEN_COLOR.gray100};
+              border-radius: 1.2rem;
+              border: 1px dashed ${DESIGN_TOKEN_COLOR.gray500};
+            `}
+          >
+            <Typography variant="body14Medium" color="gray800">
+              작성중인 회고가 없습니다.
+            </Typography>
+          </div>
+        ) : (
+          proceedingRetrospects.map((retrospect) => <InProgressRetrospectCard key={retrospect.retrospectId} retrospect={retrospect} />)
+        )}
+      </section>
+    </section>
+  );
+}

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
@@ -2,18 +2,71 @@ import { css } from "@emotion/react";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
-
-import type { Retrospect } from "@/types/retrospect"; // Retrospect 타입을 가져옵니다.
+import type { Retrospect } from "@/types/retrospect";
 import RetrospectCard from "../../home/InProgressRetrospectCard";
 
 interface RetrospectSectionProps {
   title: string;
-  isLoading: boolean;
+  isPending: boolean;
   retrospects: Retrospect[];
   emptyMessage: string;
 }
 
-export default function RetrospectSection({ title, isLoading, retrospects, emptyMessage }: RetrospectSectionProps) {
+const determineStatus = (isPending: boolean, retrospects: Retrospect[]): "loading" | "empty" | "success" => {
+  if (isPending) {
+    return "loading";
+  }
+  if (retrospects.length === 0) {
+    return "empty";
+  }
+  return "success";
+};
+
+export default function RetrospectSection({ title, isPending, retrospects, emptyMessage }: RetrospectSectionProps) {
+  const status = determineStatus(isPending, retrospects);
+
+  const contentMap = {
+    // * Loading 상태인 경우
+    loading: (
+      <div
+        css={css`
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          width: 100%;
+          height: 13.8rem;
+          border-radius: 1.2rem;
+          border: 1px dashed ${DESIGN_TOKEN_COLOR.gray500};
+        `}
+      >
+        <LoadingSpinner />
+      </div>
+    ),
+
+    // * 회고가 없는 경우
+    empty: (
+      <div
+        css={css`
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          width: 100%;
+          height: 13.8rem;
+          background-color: ${DESIGN_TOKEN_COLOR.gray100};
+          border-radius: 1.2rem;
+          border: 1px dashed ${DESIGN_TOKEN_COLOR.gray500};
+        `}
+      >
+        <Typography variant="body14Medium" color="gray800">
+          {emptyMessage}
+        </Typography>
+      </div>
+    ),
+
+    // * 회고가 있는 경우
+    success: retrospects.map((retrospect) => <RetrospectCard key={retrospect.retrospectId} retrospect={retrospect} />),
+  };
+
   return (
     <>
       {/* ---------- 제목 ---------- */}
@@ -37,42 +90,12 @@ export default function RetrospectSection({ title, isLoading, retrospects, empty
       <section
         css={css`
           margin-top: 1.6rem;
+          display: flex;
+          flex-direction: column;
+          gap: 1.2rem;
         `}
       >
-        {isLoading ? (
-          <div
-            css={css`
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              width: 100%;
-              height: 13.8rem;
-              border-radius: 1.2rem;
-              border: 1px dashed ${DESIGN_TOKEN_COLOR.gray500};
-            `}
-          >
-            <LoadingSpinner />
-          </div>
-        ) : retrospects.length === 0 ? (
-          <div
-            css={css`
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              width: 100%;
-              height: 13.8rem;
-              background-color: ${DESIGN_TOKEN_COLOR.gray100};
-              border-radius: 1.2rem;
-              border: 1px dashed ${DESIGN_TOKEN_COLOR.gray500};
-            `}
-          >
-            <Typography variant="body14Medium" color="gray800">
-              {emptyMessage}
-            </Typography>
-          </div>
-        ) : (
-          retrospects.map((retrospect) => <RetrospectCard key={retrospect.retrospectId} retrospect={retrospect} />)
-        )}
+        {contentMap[status]}
       </section>
     </>
   );

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
@@ -1,54 +1,44 @@
-import { Typography } from "@/component/common/typography";
 import { css } from "@emotion/react";
-
-import InProgressRetrospectCard from "../../home/InProgressRetrospectCard";
+import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
-import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
-import { useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import InProgressRetrospectCard from "../../home/InProgressRetrospectCard";
+import type { Retrospect } from "@/types/retrospect"; // Retrospect 타입을 가져옵니다.
 
-export default function InProgressRetrospectsWrapper() {
-  const { spaceId } = useParams();
+interface RetrospectSectionProps {
+  title: string;
+  isLoading: boolean;
+  retrospects: Retrospect[];
+  emptyMessage: string;
+}
 
-  // * 스페이스 회고 목록 조회
-  const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId));
-
-  // * 진행중인 회고 필터링
-  const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);
-
+export default function RetrospectSection({ title, isLoading, retrospects, emptyMessage }: RetrospectSectionProps) {
   return (
-    <section
-      css={css`
-        width: 34.4rem;
-        margin-top: 3.2rem;
-        padding: 0 3rem 3.2rem 1.8rem;
-        box-sizing: border-box;
-      `}
-    >
+    <>
       {/* ---------- 제목 ---------- */}
       <section
         css={css`
           display: flex;
           align-items: center;
           gap: 0.6rem;
+          margin-top: 2.4rem;
         `}
       >
         <Typography variant="title16Bold2" color="gray900">
-          진행중인 회고
+          {title}
         </Typography>
         <Typography variant="title16Bold2" color="gray600">
-          {proceedingRetrospects?.length || 0}
+          {retrospects.length}
         </Typography>
       </section>
 
+      {/* ---------- 회고 컨텐츠 ---------- */}
       <section
         css={css`
           margin-top: 1.6rem;
         `}
       >
-        {isRetrospectsPending ? (
+        {isLoading ? (
           <div
             css={css`
               display: flex;
@@ -62,7 +52,7 @@ export default function InProgressRetrospectsWrapper() {
           >
             <LoadingSpinner />
           </div>
-        ) : !retrospects || proceedingRetrospects.length === 0 ? (
+        ) : retrospects.length === 0 ? (
           <div
             css={css`
               display: flex;
@@ -76,13 +66,13 @@ export default function InProgressRetrospectsWrapper() {
             `}
           >
             <Typography variant="body14Medium" color="gray800">
-              작성중인 회고가 없습니다.
+              {emptyMessage}
             </Typography>
           </div>
         ) : (
-          proceedingRetrospects.map((retrospect) => <InProgressRetrospectCard key={retrospect.retrospectId} retrospect={retrospect} />)
+          retrospects.map((retrospect) => <InProgressRetrospectCard key={retrospect.retrospectId} retrospect={retrospect} />)
         )}
       </section>
-    </section>
+    </>
   );
 }

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
@@ -2,8 +2,9 @@ import { css } from "@emotion/react";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
-import InProgressRetrospectCard from "../../home/InProgressRetrospectCard";
+
 import type { Retrospect } from "@/types/retrospect"; // Retrospect 타입을 가져옵니다.
+import RetrospectCard from "../../home/InProgressRetrospectCard";
 
 interface RetrospectSectionProps {
   title: string;
@@ -70,7 +71,7 @@ export default function RetrospectSection({ title, isLoading, retrospects, empty
             </Typography>
           </div>
         ) : (
-          retrospects.map((retrospect) => <InProgressRetrospectCard key={retrospect.retrospectId} retrospect={retrospect} />)
+          retrospects.map((retrospect) => <RetrospectCard key={retrospect.retrospectId} retrospect={retrospect} />)
         )}
       </section>
     </>

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -1,0 +1,34 @@
+import { css } from "@emotion/react";
+
+import ActionItems from "@/component/retrospect/space/ActionItems";
+import CompletedRetrospects from "@/component/retrospect/space/CompletedRetrospects";
+import InProgressRetrospects from "@/component/retrospect/space/InProgressRetrospects";
+
+export default function AnalysisOverview() {
+  return (
+    <section
+      css={css`
+        display: none;
+        gap: 2.4rem;
+        flex: 1;
+        overflow-y: auto;
+
+        @media (max-width: 979px) {
+          display: flex;
+        }
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 4rem;
+        `}
+      >
+        <InProgressRetrospects />
+        <CompletedRetrospects />
+      </div>
+      <ActionItems />
+    </section>
+  );
+}

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -33,14 +33,14 @@ export default function AnalysisOverview() {
 
       <RetrospectSection
         title="진행중인 회고"
-        isLoading={isRetrospectsPending}
+        isPending={isRetrospectsPending}
         retrospects={proceedingRetrospects}
         emptyMessage="작성중인 회고가 없습니다."
       />
 
       <RetrospectSection
         title="마감된 회고"
-        isLoading={isRetrospectsPending}
+        isPending={isRetrospectsPending}
         retrospects={closedRetrospects}
         emptyMessage="마감된 회고가 없습니다."
       />

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -1,34 +1,46 @@
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+
 import { css } from "@emotion/react";
 
-import ActionItems from "@/component/retrospect/space/ActionItems";
-import CompletedRetrospects from "@/component/retrospect/space/CompletedRetrospects";
-import InProgressRetrospects from "@/component/retrospect/space/InProgressRetrospects";
+import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
+import RetrospectSection from "./RetrospectSection";
 
 export default function AnalysisOverview() {
+  const { spaceId } = useParams();
+
+  // * 스페이스 회고 목록 조회
+  const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId));
+
+  // * 진행중인 회고 필터링
+  const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);
+
+  // * 마감된 회고 필터링
+  const closedRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "DONE") || [], [retrospects]);
+
   return (
     <section
       css={css`
-        display: none;
-        gap: 2.4rem;
-        flex: 1;
-        overflow-y: auto;
-
-        @media (max-width: 979px) {
-          display: flex;
-        }
+        width: 34.4rem;
+        margin-top: 3.2rem;
+        padding: 0 3rem 3.2rem 1.8rem;
+        box-sizing: border-box;
       `}
     >
-      <div
-        css={css`
-          display: flex;
-          flex-direction: column;
-          gap: 4rem;
-        `}
-      >
-        <InProgressRetrospects />
-        <CompletedRetrospects />
-      </div>
-      <ActionItems />
+      <RetrospectSection
+        title="진행중인 회고"
+        isLoading={isRetrospectsPending}
+        retrospects={proceedingRetrospects}
+        emptyMessage="작성중인 회고가 없습니다."
+      />
+
+      <RetrospectSection
+        title="마감된 회고"
+        isLoading={isRetrospectsPending}
+        retrospects={closedRetrospects}
+        emptyMessage="마감된 회고가 없습니다."
+      />
     </section>
   );
 }

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -17,7 +17,7 @@ export default function AnalysisOverview() {
 
   const currentSelectedSpace = useAtomValue(currentSpaceState);
 
-  const { name } = currentSelectedSpace || {};
+  const { name, introduction } = currentSelectedSpace || {};
 
   // * 스페이스 회고 목록 조회
   const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId));
@@ -32,22 +32,26 @@ export default function AnalysisOverview() {
     <section
       css={css`
         width: 34.4rem;
-        margin-top: 3.2rem;
         padding: 0 3rem 3.2rem 1.8rem;
         box-sizing: border-box;
       `}
     >
-      <section
-        css={css`
-          display: flex;
-          align-items: center;
-          gap: 0.4rem;
-        `}
-      >
-        <Typography variant="heading24Bold" color="gray900">
-          {name}
+      <section>
+        <div
+          css={css`
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+          `}
+        >
+          <Typography variant="heading24Bold" color="gray900">
+            {name}
+          </Typography>
+          <Icon icon="ic_more" size={2.0} color={DESIGN_TOKEN_COLOR.gray900} />
+        </div>
+        <Typography variant="body14SemiBold" color="gray700" style={{ marginTop: "0.4rem" }}>
+          {introduction}
         </Typography>
-        <Icon icon="ic_more" size={2.0} color={DESIGN_TOKEN_COLOR.gray900} />
       </section>
 
       <RetrospectSection

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -6,18 +6,11 @@ import { css } from "@emotion/react";
 
 import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
 import RetrospectSection from "./RetrospectSection";
-import { Typography } from "@/component/common/typography";
-import { useAtomValue } from "jotai";
-import { currentSpaceState } from "@/store/space/spaceAtom";
-import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
-import { Icon } from "@/component/common/Icon";
+
+import AnalysisOverviewHeader from "./AnalysisOverviewHeader";
 
 export default function AnalysisOverview() {
   const { spaceId } = useParams();
-
-  const currentSelectedSpace = useAtomValue(currentSpaceState);
-
-  const { name, introduction } = currentSelectedSpace || {};
 
   // * 스페이스 회고 목록 조회
   const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId));
@@ -36,23 +29,7 @@ export default function AnalysisOverview() {
         box-sizing: border-box;
       `}
     >
-      <section>
-        <div
-          css={css`
-            display: flex;
-            align-items: center;
-            gap: 0.4rem;
-          `}
-        >
-          <Typography variant="heading24Bold" color="gray900">
-            {name}
-          </Typography>
-          <Icon icon="ic_more" size={2.0} color={DESIGN_TOKEN_COLOR.gray900} />
-        </div>
-        <Typography variant="body14SemiBold" color="gray700" style={{ marginTop: "0.4rem" }}>
-          {introduction}
-        </Typography>
-      </section>
+      <AnalysisOverviewHeader />
 
       <RetrospectSection
         title="진행중인 회고"

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { css } from "@emotion/react";
@@ -10,10 +10,11 @@ import RetrospectSection from "./RetrospectSection";
 import AnalysisOverviewHeader from "./AnalysisOverviewHeader";
 
 export default function AnalysisOverview() {
-  const { spaceId } = useParams();
+  const [searchParams] = useSearchParams();
+  const spaceId = searchParams.get("spaceId");
 
   // * 스페이스 회고 목록 조회
-  const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId));
+  const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId || undefined));
 
   // * 진행중인 회고 필터링
   const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -6,9 +6,18 @@ import { css } from "@emotion/react";
 
 import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
 import RetrospectSection from "./RetrospectSection";
+import { Typography } from "@/component/common/typography";
+import { useAtomValue } from "jotai";
+import { currentSpaceState } from "@/store/space/spaceAtom";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { Icon } from "@/component/common/Icon";
 
 export default function AnalysisOverview() {
   const { spaceId } = useParams();
+
+  const currentSelectedSpace = useAtomValue(currentSpaceState);
+
+  const { name } = currentSelectedSpace || {};
 
   // * 스페이스 회고 목록 조회
   const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId));
@@ -28,6 +37,19 @@ export default function AnalysisOverview() {
         box-sizing: border-box;
       `}
     >
+      <section
+        css={css`
+          display: flex;
+          align-items: center;
+          gap: 0.4rem;
+        `}
+      >
+        <Typography variant="heading24Bold" color="gray900">
+          {name}
+        </Typography>
+        <Icon icon="ic_more" size={2.0} color={DESIGN_TOKEN_COLOR.gray900} />
+      </section>
+
       <RetrospectSection
         title="진행중인 회고"
         isLoading={isRetrospectsPending}

--- a/apps/web/src/app/desktop/component/home/InProgressRetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/InProgressRetrospectCard/index.tsx
@@ -18,7 +18,7 @@ export default function InProgressRetrospectCard({ retrospect }: InProgressRetro
       css={css`
         display: flex;
         flex-direction: column;
-        width: 30rem;
+        width: 29.6rem;
         height: 13.8rem;
         padding: 1.6rem;
         background-color: white;

--- a/apps/web/src/app/desktop/component/home/InProgressRetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/InProgressRetrospectCard/index.tsx
@@ -21,7 +21,7 @@ export default function RetrospectCard({ retrospect, spaceId }: InProgressRetros
     // TODO: spaceId가 없는 경우 처리(예: 홈 화면 최상단의 카드 클릭 시)
 
     if (spaceId) {
-      navigate(`/retrospectSpace/${spaceId}/analysis/${retrospectId}`);
+      navigate(`/retrospect/analysis?spaceId=${spaceId}&retrospectId=${retrospectId}`);
     }
   };
 

--- a/apps/web/src/app/desktop/component/home/InProgressRetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/InProgressRetrospectCard/index.tsx
@@ -5,13 +5,25 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Retrospect } from "@/types/retrospect";
 import { formatDateAndTime } from "@/utils/date";
 import { ProceedingTextBox } from "@/component/space/view/ProceedingTextBox";
+import { useNavigate } from "react-router-dom";
 
 interface InProgressRetrospectCardProps {
   retrospect: Retrospect;
+  spaceId?: string;
 }
 
-export default function InProgressRetrospectCard({ retrospect }: InProgressRetrospectCardProps) {
-  const { title, introduction, deadline, totalCount, writeCount, writeStatus, analysisStatus } = retrospect;
+export default function RetrospectCard({ retrospect, spaceId }: InProgressRetrospectCardProps) {
+  const navigate = useNavigate();
+
+  const { retrospectId, title, introduction, deadline, totalCount, writeCount, writeStatus, analysisStatus } = retrospect;
+
+  const handleCardClick = () => {
+    // TODO: spaceId가 없는 경우 처리(예: 홈 화면 최상단의 카드 클릭 시)
+
+    if (spaceId) {
+      navigate(`/retrospectSpace/${spaceId}/analysis/${retrospectId}`);
+    }
+  };
 
   return (
     <section
@@ -32,6 +44,7 @@ export default function InProgressRetrospectCard({ retrospect }: InProgressRetro
           box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
         }
       `}
+      onClick={handleCardClick}
     >
       {/* ---------- 상단 라벨 ---------- */}
       <div

--- a/apps/web/src/app/desktop/component/home/InProgressRetrospectsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/InProgressRetrospectsWrapper/index.tsx
@@ -35,7 +35,7 @@ export default function InProgressRetrospectsWrapper() {
         slidesPerView={3}
         navigation
         css={css`
-          margin-top: 1.6rem;
+          margin-top: 1.2rem;
           width: 100%;
           position: relative;
           overflow-x: visible;

--- a/apps/web/src/app/desktop/component/home/InProgressRetrospectsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/InProgressRetrospectsWrapper/index.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { Typography } from "@/component/common/typography";
-import InProgressRetrospectCard from "../InProgressRetrospectCard";
+
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -10,6 +10,7 @@ import "swiper/css";
 import "swiper/css/navigation";
 import { useGetAllRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
+import RetrospectCard from "../InProgressRetrospectCard";
 
 export default function InProgressRetrospectsWrapper() {
   // * 작성중인 모든 회고 리스트 요청
@@ -161,7 +162,7 @@ export default function InProgressRetrospectsWrapper() {
         ) : (
           retrospects.map((retrospect) => (
             <SwiperSlide key={retrospect.retrospectId}>
-              <InProgressRetrospectCard retrospect={retrospect} />
+              <RetrospectCard retrospect={retrospect} />
             </SwiperSlide>
           ))
         )}

--- a/apps/web/src/app/desktop/component/home/InProgressRetrospectsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/InProgressRetrospectsWrapper/index.tsx
@@ -35,7 +35,7 @@ export default function InProgressRetrospectsWrapper() {
         slidesPerView={3}
         navigation
         css={css`
-          margin-top: 1.2rem;
+          padding-top: 1.2rem;
           width: 100%;
           position: relative;
           overflow-x: visible;

--- a/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
+++ b/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
@@ -5,7 +5,9 @@ export default function AnalysisPage() {
   return (
     <section
       css={css`
-        padding: 2.8rem 0;
+        /* padding: 2.8rem 0; */
+        padding-top: 2.8rem;
+        height: 100vh;
       `}
     >
       <AnalysisOverview />

--- a/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
+++ b/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
@@ -1,13 +1,14 @@
 import { css } from "@emotion/react";
+import InProgressRetrospectsWrapper from "../component/analysis/AnalysisOverview/InProgressRetrospectsWrapper";
 
 export default function AnalysisPage() {
   return (
     <section
       css={css`
-        padding-top: 2.8rem;
+        padding: 2.8rem 0;
       `}
     >
-      Analysis Page
+      <InProgressRetrospectsWrapper />
     </section>
   );
 }

--- a/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
+++ b/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import InProgressRetrospectsWrapper from "../component/analysis/AnalysisOverview/InProgressRetrospectsWrapper";
+import AnalysisOverview from "../component/analysis/AnalysisOverview";
 
 export default function AnalysisPage() {
   return (
@@ -8,7 +8,7 @@ export default function AnalysisPage() {
         padding: 2.8rem 0;
       `}
     >
-      <InProgressRetrospectsWrapper />
+      <AnalysisOverview />
     </section>
   );
 }

--- a/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
+++ b/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
@@ -1,0 +1,13 @@
+import { css } from "@emotion/react";
+
+export default function AnalysisPage() {
+  return (
+    <section
+      css={css`
+        padding-top: 2.8rem;
+      `}
+    >
+      Analysis Page
+    </section>
+  );
+}

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/HomeButton.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/HomeButton.tsx
@@ -5,9 +5,22 @@ import { Typography } from "../../typography";
 import { useNavigation } from "../context/NavigationContext";
 
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useSetAtom } from "jotai";
+import { currentSpaceState } from "@/store/space/spaceAtom";
 
 export default function HomeButton() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const { isCollapsed } = useNavigation();
+
+  const setCurrentSpace = useSetAtom(currentSpaceState);
+
+  const handleHomeButtonClick = () => {
+    setCurrentSpace(null);
+    navigate("/");
+  };
 
   return (
     <button
@@ -18,6 +31,7 @@ export default function HomeButton() {
         justify-content: center;
         align-items: center;
       `}
+      onClick={handleHomeButtonClick}
     >
       <div
         css={css`
@@ -28,7 +42,7 @@ export default function HomeButton() {
           height: ${isCollapsed ? "3.2rem" : "3.9rem"};
           gap: 1.6rem;
           padding: ${isCollapsed ? "0.4rem" : "0.4rem 0.8rem"};
-          background-color: "transparent";
+          background-color: ${location.pathname === "/" ? DESIGN_TOKEN_COLOR.gray100 : "transparent"};
           border-radius: 0.8rem;
           transition: background-color 0.2s ease-in-out;
           cursor: pointer;

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
@@ -9,21 +9,48 @@ import { Space } from "@/types/spaceType";
 import { currentSpaceState } from "@/store/space/spaceAtom";
 
 import spaceDefaultImg from "@/assets/imgs/space/spaceDefaultImg.png";
+import { useLocation, useNavigate } from "react-router-dom";
 
 interface SpaceItemProps {
   space: Space;
 }
 
+// 상태별 스타일 정의
+const SPACE_ITEM_STYLES = {
+  backgroundColor: {
+    default: "transparent",
+    currentInSpace: DESIGN_TOKEN_COLOR.gray100,
+    currentInHome: "transparent",
+  },
+  hover: DESIGN_TOKEN_COLOR.gray100,
+};
+
 export default function SpaceItem({ space }: SpaceItemProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
   const { isCollapsed } = useNavigation();
   const { id: spaceId, name, introduction, bannerUrl } = space;
 
   const [currentSpace, setCurrentSpace] = useAtom(currentSpaceState);
 
+  const isHome = location.pathname === "/";
   const isCurrent = String(currentSpace?.id) === String(spaceId);
+
+  const getBackgroundColor = () => {
+    if (isCurrent) {
+      return SPACE_ITEM_STYLES.backgroundColor.currentInSpace;
+    }
+
+    if (isHome) {
+      return SPACE_ITEM_STYLES.backgroundColor.currentInHome;
+    }
+
+    return SPACE_ITEM_STYLES.backgroundColor.default;
+  };
 
   const handleSelectSpace = () => {
     setCurrentSpace(space);
+    navigate(`/retrospectSpace/${spaceId}`);
   };
 
   return (
@@ -33,7 +60,7 @@ export default function SpaceItem({ space }: SpaceItemProps) {
         align-items: center;
         gap: 1rem;
         width: 100%;
-        background-color: ${isCurrent ? DESIGN_TOKEN_COLOR.gray100 : "transparent"};
+        background-color: ${getBackgroundColor()};
         border-radius: 0.8rem;
         cursor: pointer;
         transition: background-color 0.2s ease-in-out;
@@ -51,7 +78,7 @@ export default function SpaceItem({ space }: SpaceItemProps) {
             `}
 
         &:hover {
-          background-color: ${DESIGN_TOKEN_COLOR.gray100};
+          background-color: ${SPACE_ITEM_STYLES.hover};
         }
       `}
       onClick={handleSelectSpace}

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
@@ -16,12 +16,11 @@ interface SpaceItemProps {
 
 export default function SpaceItem({ space }: SpaceItemProps) {
   const { isCollapsed } = useNavigation();
-
-  const { id, name, introduction, bannerUrl } = space;
+  const { id: spaceId, name, introduction, bannerUrl } = space;
 
   const [currentSpace, setCurrentSpace] = useAtom(currentSpaceState);
 
-  const isCurrent = String(currentSpace?.id) === String(id);
+  const isCurrent = String(currentSpace?.id) === String(spaceId);
 
   const handleSelectSpace = () => {
     setCurrentSpace(space);

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -61,7 +61,7 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
         flex-direction: column;
         align-items: ${isCollapsed ? "center" : "flex-start"};
         gap: 0.4rem;
-        margin-top: 1rem;
+        margin-top: 1.2rem;
         padding: 0;
         flex: 1;
         overflow-y: auto;

--- a/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
@@ -1,61 +1,45 @@
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
-import InProgressRetrospectCard from "@/app/desktop/component/home/InProgressRetrospectCard";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { css } from "@emotion/react";
 import { DragDropContext, Draggable, Droppable, DropResult } from "@hello-pangea/dnd";
-import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
+import { useEffect, useMemo, useState } from "react";
+import RetrospectCard from "@/app/desktop/component/home/InProgressRetrospectCard";
 import { Retrospect } from "@/types/retrospect";
 
 export default function CompletedRetrospects() {
-  // TODO: API 연결 후 데이터 추가
-  const [retrospects, setRetrospects] = useState<Retrospect[]>([
-    {
-      retrospectId: 11,
-      title: "중간발표 이후 회고",
-      introduction: "중간발표 과정 및 팀의 커뮤니케이션 과정",
-      writeStatus: "DONE",
-      retrospectStatus: "DONE",
-      analysisStatus: "DONE",
-      totalCount: 4,
-      writeCount: 4,
-      createdAt: "2024.07.30 10:00",
-      deadline: "2024.08.05 23:59",
-    },
-    {
-      retrospectId: 12,
-      title: "프로젝트 기획 회고",
-      introduction: "기획 단계에서의 문제점 및 개선 방안 논의",
-      writeStatus: "DONE",
-      retrospectStatus: "DONE",
-      analysisStatus: "DONE",
-      totalCount: 4,
-      writeCount: 4,
-      createdAt: "2024.08.01 14:00",
-      deadline: "2024.08.10 23:59",
-    },
-    {
-      retrospectId: 13,
-      title: "1차 스프린트 회고",
-      introduction: "개발 과정에서의 기술적 어려움과 해결 과정",
-      writeStatus: "DONE",
-      retrospectStatus: "DONE",
-      analysisStatus: "DONE",
-      totalCount: 4,
-      writeCount: 4,
-      createdAt: "2024.08.05 16:00",
-      deadline: null,
-    },
-  ]);
+  const { spaceId } = useParams();
+
+  // * 스페이스 회고 목록 조회
+  const { data: retrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
+
+  // * 마감된 회고 필터링
+  const completedRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "DONE") || [], [retrospects]);
+
+  const [displayedRetrospects, setDisplayedRetrospects] = useState<Retrospect[]>([]);
 
   const handleOnDragEnd = ({ source, destination }: DropResult) => {
     if (!destination) return;
 
-    setRetrospects((prev) => {
-      const reorderedItem = prev[source.index];
-      return prev.toSpliced(source.index, 1).toSpliced(destination.index, 0, reorderedItem);
+    setDisplayedRetrospects((prev) => {
+      const items = Array.from(prev);
+      const [reorderedItem] = items.splice(source.index, 1);
+      items.splice(destination.index, 0, reorderedItem);
+      return items;
     });
+
+    // TODO: 여기서 변경된 순서를 서버에 저장하는 API를 호출 필요
   };
+
+  useEffect(() => {
+    if (completedRetrospects) {
+      const completed = completedRetrospects.filter((r) => r.retrospectStatus === "DONE");
+      setDisplayedRetrospects(completed);
+    }
+  }, [completedRetrospects]);
 
   return (
     <section
@@ -70,9 +54,9 @@ export default function CompletedRetrospects() {
         min-width: 30rem;
       `}
     >
-      <Typography variant="title16Bold">마감된 회고 {retrospects.length}</Typography>
+      <Typography variant="title16Bold">마감된 회고 {completedRetrospects.length}</Typography>
 
-      {retrospects.length === 0 ? (
+      {completedRetrospects.length === 0 ? (
         <div
           css={css`
             display: flex;
@@ -112,7 +96,7 @@ export default function CompletedRetrospects() {
                   padding-bottom: 2rem;
                 `}
               >
-                {retrospects.map((retrospect, index) => (
+                {displayedRetrospects.map((retrospect, index) => (
                   <Draggable key={retrospect.retrospectId.toString()} draggableId={retrospect.retrospectId.toString()} index={index}>
                     {(provided, snapshot) => (
                       <div
@@ -135,7 +119,7 @@ export default function CompletedRetrospects() {
                           }
                         `}
                       >
-                        <InProgressRetrospectCard retrospect={retrospect} />
+                        <RetrospectCard retrospect={retrospect} spaceId={spaceId} />
                       </div>
                     )}
                   </Draggable>

--- a/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
@@ -105,7 +105,7 @@ export default function CompletedRetrospects() {
                   display: flex;
                   flex-direction: column;
                   gap: 1.6rem;
-                  margin-top: 2.4rem;
+                  padding-top: 1.6rem;
                   flex: 1;
                   overflow-y: auto;
                   overflow-x: hidden;
@@ -125,7 +125,6 @@ export default function CompletedRetrospects() {
                           `
                           opacity: 0.8;
                           transform: rotate(5deg);
-                          box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
                         `}
 
                           /* 평상시 스타일 */
@@ -133,7 +132,6 @@ export default function CompletedRetrospects() {
 
                           &:hover {
                             transform: translateY(-2px);
-                            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
                           }
                         `}
                       >

--- a/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
@@ -78,7 +78,7 @@ export default function InProgressRetrospects() {
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            padding: 4rem 2rem;
+            padding: 1.6rem 2rem 4rem;
             text-align: center;
             gap: 2.4rem;
           `}
@@ -111,7 +111,7 @@ export default function InProgressRetrospects() {
                   display: flex;
                   flex-direction: column;
                   gap: 1.6rem;
-                  margin-top: 2.4rem;
+                  padding-top: 1.6rem;
                   flex: 1;
                   overflow-y: auto;
                   overflow-x: hidden;
@@ -131,7 +131,6 @@ export default function InProgressRetrospects() {
                           `
                             opacity: 0.8;
                             transform: rotate(5deg);
-                            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
                           `}
 
                           /* 평상시 스타일 */
@@ -139,7 +138,6 @@ export default function InProgressRetrospects() {
 
                           &:hover {
                             transform: translateY(-2px);
-                            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
                           }
                         `}
                       >

--- a/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
@@ -1,61 +1,47 @@
-import { Typography } from "@/component/common/typography";
-import InProgressRetrospectCard from "@/app/desktop/component/home/InProgressRetrospectCard";
-import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { useParams } from "react-router-dom";
 import { css } from "@emotion/react";
+
+import { Typography } from "@/component/common/typography";
+
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { DragDropContext, Droppable, Draggable, DropResult } from "@hello-pangea/dnd";
-import { useState } from "react";
+
 import { Icon } from "@/component/common/Icon";
+import { useQuery } from "@tanstack/react-query";
+import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
+import { useEffect, useMemo, useState } from "react";
+import RetrospectCard from "@/app/desktop/component/home/InProgressRetrospectCard";
 import { Retrospect } from "@/types/retrospect";
 
 export default function InProgressRetrospects() {
-  // TODO: API 연결 후 데이터 추가
-  const [retrospects, setRetrospects] = useState<Retrospect[]>([
-    {
-      retrospectId: 1,
-      title: "중간발표 이후 회고",
-      introduction: "중간발표 과정 및 팀의 커뮤니케이션 과정",
-      writeStatus: "PROCEEDING",
-      retrospectStatus: "PROCEEDING",
-      analysisStatus: "NOT_STARTED",
-      totalCount: 4,
-      writeCount: 2,
-      createdAt: "2024.07.30 10:00",
-      deadline: "2024.08.05 23:59",
-    },
-    {
-      retrospectId: 2,
-      title: "프로젝트 기획 회고",
-      introduction: "기획 단계에서의 문제점 및 개선 방안 논의",
-      writeStatus: "PROCEEDING",
-      retrospectStatus: "PROCEEDING",
-      analysisStatus: "NOT_STARTED",
-      totalCount: 4,
-      writeCount: 1,
-      createdAt: "2024.08.01 14:00",
-      deadline: "2024.08.10 23:59",
-    },
-    {
-      retrospectId: 3,
-      title: "1차 스프린트 회고",
-      introduction: "개발 과정에서의 기술적 어려움과 해결 과정",
-      writeStatus: "PROCEEDING",
-      retrospectStatus: "PROCEEDING",
-      analysisStatus: "NOT_STARTED",
-      totalCount: 4,
-      writeCount: 3,
-      createdAt: "2024.08.05 16:00",
-      deadline: null,
-    },
-  ]);
+  const { spaceId } = useParams();
+
+  // * 스페이스 회고 목록 조회
+  const { data: retrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
+
+  const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);
+
+  const [displayedRetrospects, setDisplayedRetrospects] = useState<Retrospect[]>([]);
 
   const handleOnDragEnd = ({ source, destination }: DropResult) => {
     if (!destination) return;
 
-    setRetrospects((prev) => {
-      const reorderedItem = prev[source.index];
-      return prev.toSpliced(source.index, 1).toSpliced(destination.index, 0, reorderedItem);
+    setDisplayedRetrospects((prev) => {
+      const items = Array.from(prev);
+      const [reorderedItem] = items.splice(source.index, 1);
+      items.splice(destination.index, 0, reorderedItem);
+      return items;
     });
+
+    // TODO: 여기서 변경된 순서를 서버에 저장하는 API를 호출 필요
   };
+
+  useEffect(() => {
+    if (proceedingRetrospects) {
+      const proceeding = proceedingRetrospects.filter((r) => r.retrospectStatus === "PROCEEDING");
+      setDisplayedRetrospects(proceeding);
+    }
+  }, [proceedingRetrospects]);
 
   return (
     <section
@@ -69,9 +55,9 @@ export default function InProgressRetrospects() {
         min-width: 30rem;
       `}
     >
-      <Typography variant="title16Bold">진행중인 회고 {retrospects.length}</Typography>
+      <Typography variant="title16Bold">진행중인 회고 {proceedingRetrospects.length}</Typography>
 
-      {retrospects.length === 0 ? (
+      {proceedingRetrospects.length === 0 ? (
         <div
           css={css`
             display: flex;
@@ -118,7 +104,7 @@ export default function InProgressRetrospects() {
                   padding-bottom: 2rem;
                 `}
               >
-                {retrospects.map((retrospect, index) => (
+                {displayedRetrospects.map((retrospect, index) => (
                   <Draggable key={retrospect.retrospectId.toString()} draggableId={retrospect.retrospectId.toString()} index={index}>
                     {(provided, snapshot) => (
                       <div
@@ -141,7 +127,7 @@ export default function InProgressRetrospects() {
                           }
                         `}
                       >
-                        <InProgressRetrospectCard retrospect={retrospect} />
+                        <RetrospectCard retrospect={retrospect} spaceId={spaceId} />
                       </div>
                     )}
                   </Draggable>

--- a/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
+++ b/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
@@ -46,7 +46,6 @@ export default function RetrospectSpaceHeader() {
                 padding: 0.8rem 1.2rem;
                 background-color: ${DESIGN_TOKEN_COLOR.blue600};
                 border-radius: 0.8rem;
-                display: flex;
                 align-items: center;
                 justify-content: center;
                 gap: 0.4rem;
@@ -65,7 +64,6 @@ export default function RetrospectSpaceHeader() {
                 display: flex;
                 padding: 0.8rem 1.2rem;
                 border-radius: 0.8rem;
-                display: flex;
                 align-items: center;
                 justify-content: center;
                 gap: 0.4rem;
@@ -86,7 +84,6 @@ export default function RetrospectSpaceHeader() {
                 display: flex;
                 padding: 0.8rem 1.2rem;
                 border-radius: 0.8rem;
-                display: flex;
                 align-items: center;
                 justify-content: center;
                 gap: 0.4rem;

--- a/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
+++ b/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
@@ -1,9 +1,15 @@
 import { Icon } from "@/component/common/Icon/Icon";
 import { Typography } from "@/component/common/typography";
+import { currentSpaceState } from "@/store/space/spaceAtom";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { css } from "@emotion/react";
+import { useAtomValue } from "jotai";
 
 export default function RetrospectSpaceHeader() {
+  const currentSpace = useAtomValue(currentSpaceState);
+
+  const { name, introduction } = currentSpace || {};
+
   return (
     <section
       css={css`
@@ -27,7 +33,7 @@ export default function RetrospectSpaceHeader() {
             justify-content: space-between;
           `}
         >
-          <Typography variant="heading24Bold">떡잎마을방범대 </Typography>
+          <Typography variant="heading24Bold">{name}</Typography>
           <div
             css={css`
               display: flex;
@@ -50,7 +56,7 @@ export default function RetrospectSpaceHeader() {
             >
               <Icon icon={"ic_plus"} size={1.2} color={DESIGN_TOKEN_COLOR.gray00} />
 
-              <Typography variant="body14Bold" color="gray00">
+              <Typography variant="body14SemiBold" color="gray00">
                 회고 추가하기
               </Typography>
             </div>
@@ -70,7 +76,7 @@ export default function RetrospectSpaceHeader() {
             >
               <Icon icon={"ic_document_color"} size={2.0} color={DESIGN_TOKEN_COLOR.gray00} />
 
-              <Typography variant="body14Bold" color="gray600">
+              <Typography variant="body14SemiBold" color="gray600">
                 KPT
               </Typography>
               <Icon icon={"ic_chevron_down"} size={1.6} color={DESIGN_TOKEN_COLOR.gray600} />
@@ -91,14 +97,14 @@ export default function RetrospectSpaceHeader() {
             >
               <Icon icon={"ic_team"} size={2.0} color={DESIGN_TOKEN_COLOR.gray00} />
 
-              <Typography variant="body14Bold" color="gray600">
+              <Typography variant="body14SemiBold" color="gray600">
                 11
               </Typography>
               <Icon icon={"ic_chevron_down"} size={1.6} color={DESIGN_TOKEN_COLOR.gray600} />
             </div>
           </div>
         </div>
-        <Typography variant="body14Medium">IT 연합동아리 디프만 15기의 프로젝트 방향성 세우기</Typography>
+        <Typography variant="body14Medium">{introduction}</Typography>
       </div>
     </section>
   );

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -50,6 +50,7 @@ import { HomePage } from "@/app/desktop/home/HomePage";
 import RetroSpectSpacePage from "@/app/desktop/retrospectSpace/RetroSpectSpacePage";
 import { RetrospectTestPage } from "@/app/desktop/retrospect/RetrospectTestPage";
 import DesktopSetNickNamePage from "@/app/desktop/login/DesktopSetNickNamePage";
+import AnalysisPage from "@/app/desktop/retrospect/AnalysisPage";
 
 type RouteChildren = {
   auth: boolean;
@@ -103,8 +104,8 @@ const deviceSpecificRoutes: RouteChildren[] = [
         element: <HomePage />,
       },
       {
-        path: "analysis",
-        element: <div>Desktop Analysis</div>, // TODO: 데스크탑용 분석
+        path: "analysis/:spaceId",
+        element: <AnalysisPage />, // TODO: 데스크탑용 분석
       },
       {
         path: "goals",

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -104,16 +104,18 @@ const deviceSpecificRoutes: RouteChildren[] = [
         element: <HomePage />,
       },
       {
-        path: "analysis/:spaceId",
-        element: <AnalysisPage />, // TODO: 데스크탑용 분석
-      },
-      {
         path: "goals",
-        element: <div>Desktop Goals</div>, // TODO: 데스크탑용 목표
+        element: <div>Desktop Goals</div>,
       },
       {
+        // 스페이스 페이지: 회고 목록을 보여줌
         path: "retrospectSpace/:spaceId",
         element: <RetroSpectSpacePage />,
+      },
+      {
+        // 분석 페이지: 독립된 페이지로 렌더링됨
+        path: "retrospectSpace/:spaceId/analysis/:retrospectId",
+        element: <AnalysisPage />,
       },
     ],
     auth: true,

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -112,7 +112,7 @@ const deviceSpecificRoutes: RouteChildren[] = [
         element: <RetroSpectSpacePage />,
       },
       {
-        path: "retrospectSpace/:spaceId/analysis/:retrospectId",
+        path: "retrospect/analysis",
         element: <AnalysisPage />,
       },
     ],

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -112,7 +112,7 @@ const deviceSpecificRoutes: RouteChildren[] = [
         element: <div>Desktop Goals</div>, // TODO: 데스크탑용 목표
       },
       {
-        path: "retrospectSpace",
+        path: "retrospectSpace/:spaceId",
         element: <RetroSpectSpacePage />,
       },
     ],

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -108,12 +108,10 @@ const deviceSpecificRoutes: RouteChildren[] = [
         element: <div>Desktop Goals</div>,
       },
       {
-        // 스페이스 페이지: 회고 목록을 보여줌
         path: "retrospectSpace/:spaceId",
         element: <RetroSpectSpacePage />,
       },
       {
-        // 분석 페이지: 독립된 페이지로 렌더링됨
         path: "retrospectSpace/:spaceId/analysis/:retrospectId",
         element: <AnalysisPage />,
       },

--- a/apps/web/src/style/designTokens.ts
+++ b/apps/web/src/style/designTokens.ts
@@ -64,6 +64,11 @@ export const DESIGN_TOKEN_TEXT = {
     fontWeight: "400",
     lineHeight: "140%",
   },
+  body14Strong: {
+    fontSize: "1.4rem",
+    fontWeight: "700",
+    lineHeight: "150%",
+  },
   body14SemiBold: {
     fontSize: "1.4rem",
     fontWeight: "500",

--- a/apps/web/src/style/designTokens.ts
+++ b/apps/web/src/style/designTokens.ts
@@ -24,6 +24,11 @@ export const DESIGN_TOKEN_TEXT = {
     fontWeight: "600",
     lineHeight: "140%",
   },
+  title16Bold2: {
+    fontSize: "1.6rem",
+    fontWeight: "700",
+    lineHeight: "150%",
+  },
   subtitle18SemiBold: {
     fontSize: "1.8rem",
     fontWeight: "500",

--- a/apps/web/src/style/designTokens.ts
+++ b/apps/web/src/style/designTokens.ts
@@ -64,7 +64,7 @@ export const DESIGN_TOKEN_TEXT = {
     fontWeight: "400",
     lineHeight: "140%",
   },
-  body14Bold: {
+  body14SemiBold: {
     fontSize: "1.4rem",
     fontWeight: "500",
     lineHeight: "140%",


### PR DESCRIPTION
> ### 회고 분석 페이지 추가 및 목록 표시 기능 개선
---

### 🏄🏼‍♂️‍ Summary (요약)
- 회고 완료 시 진입하는 페이지 컴포넌트를 추가하고, 회고 목록을 확인할 수 있는 컴포넌트를 분리하는 작업을 진행했습니다.

### 🫨 Describe your Change (변경사항)
- 회고 완료 페이지 관련 신규 컴포넌트를 추가했습니다.
- 회고 완료 후 해당 페이지로 이동하도록 네비게이션 로직을 적용했습니다.
- 스페이스에서 실제 데이터를 불러오도록 요청 로직을 적용했습니다.
- 관련 컴포넌트들의 스타일링을 개선했습니다.

### 🧐 Issue number and link (참고)
- close #522

### 📚 Reference (참조)
<img width="360" height="958" alt="image" src="https://github.com/user-attachments/assets/09f6b8f4-84f1-449a-91ee-8c9e4f9a1025" />

