### PR TITLE
feat: 회고 분석 다이얼로그 개별 탭 작업

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisContent.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisContent.tsx
@@ -1,66 +1,20 @@
-import { Typography } from "@/component/common/typography";
-import { CAchievementTemplate, CDescriptiveTemplate, CSatisfactionTemplate } from "@/component/write/template/complete";
-import { AnswersType, getAnalysisResponse, QuestionsType } from "@/hooks/api/retrospect/analysis/useGetAnalysisAnswer";
-import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
-import { css } from "@emotion/react";
+import { getAnalysisResponse } from "@/hooks/api/retrospect/analysis/useGetAnalysisAnswer";
+import AnalysisQuestionsTab from "./AnalysisQuestionsTab";
+import AnalysisIndividualTab from "./AnalysisIndividualTab";
 
 type AnalysisContentProps = {
+  selectedTab: "질문" | "개별" | "분석";
   analysisData: getAnalysisResponse;
 };
 
-export default function AnalysisContent({ analysisData }: AnalysisContentProps) {
-  const { questions } = analysisData;
-
-  const renderQuestionComponent = (question: QuestionsType) => {
-    const { questionType, answers } = question;
-
-    return answers.map((answer: AnswersType, index: number) => {
-      const { name, answerContent } = answer;
-
-      switch (questionType) {
-        case "number":
-          return <CSatisfactionTemplate key={index} name={name} index={parseInt(answerContent)} />;
-        case "range":
-          return <CAchievementTemplate key={index} name={name} index={parseInt(answerContent)} />;
-        case "plain_text":
-          return <CDescriptiveTemplate key={index} name={name} answer={answerContent} />;
-        default:
-          return null;
-      }
-    });
-  };
+export default function AnalysisContent({ selectedTab, analysisData }: AnalysisContentProps) {
+  const { questions, individuals } = analysisData;
 
   return (
-    <section
-      css={css`
-        flex: 1;
-        display: flex;
-        gap: 2rem;
-        overflow-x: auto;
-        overflow-y: auto;
-        min-height: 80vh;
-      `}
-    >
-      {questions.map((question: QuestionsType, questionIndex: number) => (
-        <article
-          key={questionIndex}
-          css={css`
-            flex-shrink: 0;
-            width: 34rem;
-            height: 100%;
-            background-color: ${DESIGN_TOKEN_COLOR.gray100};
-            border-radius: 1.2rem;
-            margin-top: 2rem;
-            padding: 2rem 1.6rem;
-          `}
-        >
-          <Typography variant="body15Normal" color="gray900">
-            {question.questionContent}
-          </Typography>
-
-          <article>{renderQuestionComponent(question)}</article>
-        </article>
-      ))}
-    </section>
+    <>
+      {selectedTab === "질문" && <AnalysisQuestionsTab questions={questions} />}
+      {selectedTab === "개별" && <AnalysisIndividualTab individuals={individuals} />}
+      {selectedTab === "분석" && <div>분석 탭 컴포넌트 (추후 구현)</div>}
+    </>
   );
 }

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualTab.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualTab.tsx
@@ -1,0 +1,64 @@
+import { Typography } from "@/component/common/typography";
+import { CAchievementTemplate, CDescriptiveTemplate, CSatisfactionTemplate } from "@/component/write/template/complete";
+import { IndividualsAnswersType, IndividualsType } from "@/hooks/api/retrospect/analysis/useGetAnalysisAnswer";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { css } from "@emotion/react";
+
+type AnalysisIndividualTabProps = {
+  individuals: IndividualsType[];
+};
+
+export default function AnalysisIndividualTab({ individuals }: AnalysisIndividualTabProps) {
+  console.log("individuals", individuals);
+
+  const renderQuestionComponent = (answer: IndividualsAnswersType, index: number) => {
+    const { questionContent, questionType, answerContent } = answer;
+
+    switch (questionType) {
+      case "number":
+        return <CSatisfactionTemplate key={index} question={questionContent} index={parseInt(answerContent)} />;
+      case "range":
+        return <CAchievementTemplate key={index} question={questionContent} index={parseInt(answerContent)} />;
+      case "plain_text":
+        return <CDescriptiveTemplate key={index} question={questionContent} answer={answerContent} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <section
+      css={css`
+        flex: 1;
+        display: flex;
+        gap: 2rem;
+        overflow-x: auto;
+        overflow-y: auto;
+        min-height: 80vh;
+      `}
+    >
+      {individuals.map((individual: IndividualsType, individualIndex: number) => (
+        <article
+          key={individualIndex}
+          css={css`
+            flex-shrink: 0;
+            width: 34rem;
+            height: 100%;
+            background-color: ${DESIGN_TOKEN_COLOR.gray100};
+            border-radius: 1.2rem;
+            margin-top: 2rem;
+            padding: 2rem 1.6rem;
+          `}
+        >
+          <Typography variant="body15Normal" color="gray900">
+            {individual.name}
+          </Typography>
+
+          {individual.answers.map((answer, index) => (
+            <article key={index}>{renderQuestionComponent(answer, index)}</article>
+          ))}
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisQuestionsTab.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisQuestionsTab.tsx
@@ -1,0 +1,64 @@
+import { Typography } from "@/component/common/typography";
+import { CAchievementTemplate, CDescriptiveTemplate, CSatisfactionTemplate } from "@/component/write/template/complete";
+import { AnswersType, QuestionsType } from "@/hooks/api/retrospect/analysis/useGetAnalysisAnswer";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { css } from "@emotion/react";
+
+type AnalysisQuestionsTabProps = {
+  questions: QuestionsType[];
+};
+
+export default function AnalysisQuestionsTab({ questions }: AnalysisQuestionsTabProps) {
+  const renderQuestionComponent = (question: QuestionsType) => {
+    const { questionType, answers } = question;
+
+    return answers.map((answer: AnswersType, index: number) => {
+      const { name, answerContent } = answer;
+
+      switch (questionType) {
+        case "number":
+          return <CSatisfactionTemplate key={index} name={name} index={parseInt(answerContent)} />;
+        case "range":
+          return <CAchievementTemplate key={index} name={name} index={parseInt(answerContent)} />;
+        case "plain_text":
+          return <CDescriptiveTemplate key={index} name={name} answer={answerContent} />;
+        default:
+          return null;
+      }
+    });
+  };
+
+  return (
+    <section
+      css={css`
+        flex: 1;
+        display: flex;
+        gap: 2rem;
+        overflow-x: auto;
+        overflow-y: auto;
+        min-height: 80vh;
+      `}
+    >
+      {questions.map((question: QuestionsType, questionIndex: number) => (
+        <article
+          key={questionIndex}
+          css={css`
+            flex-shrink: 0;
+            width: 34rem;
+            height: 100%;
+            background-color: ${DESIGN_TOKEN_COLOR.gray100};
+            border-radius: 1.2rem;
+            margin-top: 2rem;
+            padding: 2rem 1.6rem;
+          `}
+        >
+          <Typography variant="body15Normal" color="gray900">
+            {question.questionContent}
+          </Typography>
+
+          <article>{renderQuestionComponent(question)}</article>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/index.tsx
@@ -40,7 +40,7 @@ export default function AnalysisDialog({ spaceId, retrospectId }: AnalysisDialog
 
       {isPendingAnalysisData && <LoadingSpinner />}
 
-      {!isPendingAnalysisData && analysisData && <AnalysisContent analysisData={analysisData} />}
+      {!isPendingAnalysisData && analysisData && <AnalysisContent selectedTab={selectedTab} analysisData={analysisData} />}
     </article>
   );
 }

--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -21,7 +21,6 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
   const handleCardClick = () => {
     // TODO: spaceId가 없는 경우 처리(예: 홈 화면 최상단의 카드 클릭 시)
 
-    // TODO: PATH 상수 사용하도록 변경
     if (spaceId) {
       navigate(PATHS.retrospectAnalysis(spaceId, retrospectId, title));
     }

--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -21,6 +21,7 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
   const handleCardClick = () => {
     // TODO: spaceId가 없는 경우 처리(예: 홈 화면 최상단의 카드 클릭 시)
 
+    // TODO: PATH 상수 사용하도록 변경
     if (spaceId) {
       navigate(PATHS.retrospectAnalysis(spaceId, retrospectId, title));
     }

--- a/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
+++ b/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
@@ -14,6 +14,7 @@ export default function AnalysisPage() {
       css={css`
         display: flex;
         overflow-x: hidden;
+        height: 100vh;
       `}
     >
       <AnalysisOverview spaceId={spaceId} />

--- a/apps/web/src/component/write/template/complete/ResultContainer.tsx
+++ b/apps/web/src/component/write/template/complete/ResultContainer.tsx
@@ -20,7 +20,7 @@ export function ResultContainer({ name, question, children, ...props }: PropsWit
         height: ${isDesktop ? "11rem" : "auto"};
         margin-top: 2.4rem;
         border-radius: 0.78rem;
-        padding: ${isDesktop ? "1.2rem" : "1.9rem 2rem 1.7rem 2rem"};
+        padding: ${isDesktop ? (name ? "1.2rem" : "1.6rem") : "1.9rem 2rem 1.7rem 2rem"};
         min-height: fit-content;
         box-shadow: 0 3.886px 11.657px 0 rgba(33, 37, 41, 0.04);
         font-size: 1.6rem;
@@ -40,11 +40,12 @@ export function ResultContainer({ name, question, children, ...props }: PropsWit
           >
             {question}
           </span>
+
           <div
             id="line"
             css={css`
               width: 100%;
-              border: solid 0.01rem #eee;
+              border: ${isDesktop ? "none" : "solid 0.01rem #eee"};
               background: transparent;
               border-radius: 5rem;
               margin: 1.3rem 0;


### PR DESCRIPTION
> ### 회고 분석 다이얼로그 개별 탭 작업
---

### 🏄🏼‍♂️‍ Summary (요약)
 
- 회고 분석 다이얼로그에 개별 분석 UI를 구현하고, 관련 API를 연동했습니다.

### 🫨 Describe your Change (변경사항)

- 개별 질문을 위한 UI 컴포넌트를 구현하고, 필요한 API를 연동했습니다.
- `ResultContainer`에서 `name`과 `question` 유무에 따라 다른 스타일링을 적용(데스크톱 한정)하도록 했습니다.

### 🧐 Issue number and link (참고)
- close #531 

### 📚 Reference (참조)

<img width="1726" height="957" alt="image" src="https://github.com/user-attachments/assets/ed020a4f-cac3-4758-8965-88994b87dc35" />



