### PR TITLE
feat: 회고 분석 api 연동

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisContent.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisContent.tsx
@@ -15,7 +15,7 @@ export default function AnalysisContent({ selectedTab, analysisData }: AnalysisC
     <>
       {selectedTab === "질문" && <AnalysisQuestionsTab questions={questions} />}
       {selectedTab === "개별" && <AnalysisIndividualTab individuals={individuals} />}
-      {selectedTab === "분석" && <AnalysisTab />}
+      {selectedTab === "분석" && <AnalysisTab analysisData={analysisData} />}
     </>
   );
 }

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualContents.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualContents.tsx
@@ -5,6 +5,7 @@ import { SATISTFACTION_COLOR } from "@/component/write/template/template.const";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { css } from "@emotion/react";
 import RetrospectsOverview from "./RetrospectsOverview";
+import { IndividualAnalyzeType } from "@/hooks/api/analysis/useApiGetAnalysis";
 
 const EMOTIONS: IconType[] = ["ic_very_poor", "ic_poor", "ic_commonly", "ic_good", "ic_very_good"];
 
@@ -13,7 +14,11 @@ const achievementPercentage = 78; // TODO: 실제 목표달성률 할당 (0-100 
 
 const PADDING_SUM = 8;
 
-export default function AnalysisIndividualContents() {
+type AnalysisIndividualContentsProps = {
+  individualAnalysis?: IndividualAnalyzeType;
+};
+
+export default function AnalysisIndividualContents({ individualAnalysis }: AnalysisIndividualContentsProps) {
   return (
     <section
       css={css`
@@ -132,164 +137,173 @@ export default function AnalysisIndividualContents() {
           </section>
 
           {/* ---------- 목표달성률 ---------- */}
-          <section
-            css={css`
-              flex: 1;
-              height: 100%;
-              display: flex;
-              flex-direction: column;
-              gap: 8rem;
-            `}
-          >
-            <div>
-              <Typography variant="title18Bold" color="gray900">
-                목표달성률은{" "}
-              </Typography>
-              {/* TODO: 실제 목표달성률 할당 */}
-              <Typography variant="title18Bold" color="blue600">
-                {achievementPercentage}%
-              </Typography>
-
-              <Typography variant="title18Bold" color="gray900">
-                에요
-              </Typography>
-            </div>
-
-            {/* ---------- Progress bar ---------- */}
-            <div
+          {individualAnalysis && (
+            <section
               css={css`
-                position: relative;
-                padding: 0 6rem;
+                flex: 1;
+                height: 100%;
+                display: flex;
+                flex-direction: column;
+                gap: 8rem;
               `}
             >
-              {/* ---------- 말풍선 ---------- */}
-              <div
-                css={css`
-                  position: absolute;
-                  top: -5rem;
-                  left: ${achievementPercentage - PADDING_SUM}%; /* 비율에 따라 동적 위치 */
-                  transform: translateX(-50%); /* 중앙 정렬 */
-                  background-color: white;
-                  border-radius: 1.6rem;
-                  padding: 0.4rem 0.8rem;
-                  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-                  display: flex;
-                  align-items: center;
-                  gap: 0.8rem;
-                  z-index: 10;
-
-                  /* ---------- 말풍선 꼬리 ---------- */
-                  &::after {
-                    content: "";
-                    position: absolute;
-                    bottom: -0.8rem;
-                    left: 50%;
-                    transform: translateX(-50%);
-                    width: 0;
-                    height: 0;
-                    border-left: 0.8rem solid transparent;
-                    border-right: 0.8rem solid transparent;
-                    border-top: 0.8rem solid white;
-                  }
-                `}
-              >
-                <Icon icon="ic_person" size={2.0} color={DESIGN_TOKEN_COLOR.blue600} />
-                <Typography variant="title16Bold" color="gray900">
+              <div>
+                <Typography variant="title18Bold" color="gray900">
+                  목표달성률은{" "}
+                </Typography>
+                {/* TODO: 실제 목표달성률 할당 */}
+                <Typography variant="title18Bold" color="blue600">
                   {achievementPercentage}%
+                </Typography>
+
+                <Typography variant="title18Bold" color="gray900">
+                  에요
                 </Typography>
               </div>
 
-              {/* ---------- 5구간 프로그레스 바 ---------- */}
+              {/* ---------- Progress bar ---------- */}
               <div
                 css={css`
-                  display: flex;
-                  width: 100%;
-                  gap: 0.46rem;
                   position: relative;
+                  padding: 0 6rem;
                 `}
               >
-                {[0, 1, 2, 3, 4].map((index) => {
-                  // * 비율에 따라 각 구간의 채우기 정도 계산
-                  const getSegmentFill = () => {
-                    // 각 구간의 시작점 (0, 20, 40, 60, 80)
-                    const segmentStart = index * 20;
+                {/* ---------- 말풍선 ---------- */}
+                <div
+                  css={css`
+                    position: absolute;
+                    top: -5rem;
+                    left: ${achievementPercentage - PADDING_SUM}%; /* 비율에 따라 동적 위치 */
+                    transform: translateX(-50%); /* 중앙 정렬 */
+                    background-color: white;
+                    border-radius: 1.6rem;
+                    padding: 0.4rem 0.8rem;
+                    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+                    display: flex;
+                    align-items: center;
+                    gap: 0.8rem;
+                    z-index: 10;
 
-                    // 각 구간의 끝점 (20, 40, 60, 80, 100)
-                    const segmentEnd = (index + 1) * 20;
-
-                    if (achievementPercentage <= segmentStart) {
-                      return 0; // 비율이 구간 시작점보다 작으면 비움
-                    } else if (achievementPercentage >= segmentEnd) {
-                      return 1; // 비율이 구간 끝점보다 크면 완전히 채움
-                    } else {
-                      // 비율이 구간 내에 있으면 부분적으로 채움
-                      return (achievementPercentage - segmentStart) / 20;
+                    /* ---------- 말풍선 꼬리 ---------- */
+                    &::after {
+                      content: "";
+                      position: absolute;
+                      bottom: -0.8rem;
+                      left: 50%;
+                      transform: translateX(-50%);
+                      width: 0;
+                      height: 0;
+                      border-left: 0.8rem solid transparent;
+                      border-right: 0.8rem solid transparent;
+                      border-top: 0.8rem solid white;
                     }
-                  };
+                  `}
+                >
+                  <Icon icon="ic_person" size={2.0} color={DESIGN_TOKEN_COLOR.blue600} />
+                  <Typography variant="title16Bold" color="gray900">
+                    {achievementPercentage}%
+                  </Typography>
+                </div>
 
-                  const fillRatio = getSegmentFill();
-                  const isFirstSegment = index === 0;
-                  const isLastSegment = index === 4;
+                {/* ---------- 5구간 프로그레스 바 ---------- */}
+                <div
+                  css={css`
+                    display: flex;
+                    width: 100%;
+                    gap: 0.46rem;
+                    position: relative;
+                  `}
+                >
+                  {[0, 1, 2, 3, 4].map((index) => {
+                    // * 비율에 따라 각 구간의 채우기 정도 계산
+                    const getSegmentFill = () => {
+                      // 각 구간의 시작점 (0, 20, 40, 60, 80)
+                      const segmentStart = index * 20;
 
-                  return (
-                    <div
-                      key={index}
-                      css={css`
-                        flex: 1;
-                        height: 3rem;
-                        background-color: white;
-                        border-radius: ${isFirstSegment ? "1.5rem 0 0 1.5rem" : isLastSegment ? "0 1.5rem 1.5rem 0" : "0"};
-                        position: relative;
-                        overflow: hidden;
-                      `}
-                    >
-                      {/* ---------- 채워진 부분 ---------- */}
+                      // 각 구간의 끝점 (20, 40, 60, 80, 100)
+                      const segmentEnd = (index + 1) * 20;
+
+                      if (achievementPercentage <= segmentStart) {
+                        return 0; // 비율이 구간 시작점보다 작으면 비움
+                      } else if (achievementPercentage >= segmentEnd) {
+                        return 1; // 비율이 구간 끝점보다 크면 완전히 채움
+                      } else {
+                        // 비율이 구간 내에 있으면 부분적으로 채움
+                        return (achievementPercentage - segmentStart) / 20;
+                      }
+                    };
+
+                    const fillRatio = getSegmentFill();
+                    const isFirstSegment = index === 0;
+                    const isLastSegment = index === 4;
+
+                    return (
                       <div
+                        key={index}
                         css={css`
-                          width: ${fillRatio * 100}%;
-                          height: 100%;
-                          background-color: #6b9eff;
-                          border-radius: inherit;
-                          transition: width 0.3s ease;
+                          flex: 1;
+                          height: 3rem;
+                          background-color: white;
+                          border-radius: ${isFirstSegment ? "1.5rem 0 0 1.5rem" : isLastSegment ? "0 1.5rem 1.5rem 0" : "0"};
+                          position: relative;
+                          overflow: hidden;
                         `}
-                      />
-                    </div>
-                  );
-                })}
+                      >
+                        {/* ---------- 채워진 부분 ---------- */}
+                        <div
+                          css={css`
+                            width: ${fillRatio * 100}%;
+                            height: 100%;
+                            background-color: #6b9eff;
+                            border-radius: inherit;
+                            transition: width 0.3s ease;
+                          `}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {/* ---------- 0% 텍스트 ---------- */}
+                <span
+                  css={css`
+                    position: absolute;
+                    bottom: -2.5rem;
+                    left: 6rem;
+                    font-size: 1.2rem;
+                    color: ${DESIGN_TOKEN_COLOR.gray500};
+                  `}
+                >
+                  0
+                </span>
+
+                {/* ---------- 100% 텍스트 ---------- */}
+                <span
+                  css={css`
+                    position: absolute;
+                    bottom: -2.5rem;
+                    right: 6rem;
+                    font-size: 1.2rem;
+                    color: ${DESIGN_TOKEN_COLOR.gray500};
+                  `}
+                >
+                  100
+                </span>
               </div>
-
-              {/* ---------- 0% 텍스트 ---------- */}
-              <span
-                css={css`
-                  position: absolute;
-                  bottom: -2.5rem;
-                  left: 6rem;
-                  font-size: 1.2rem;
-                  color: ${DESIGN_TOKEN_COLOR.gray500};
-                `}
-              >
-                0
-              </span>
-
-              {/* ---------- 100% 텍스트 ---------- */}
-              <span
-                css={css`
-                  position: absolute;
-                  bottom: -2.5rem;
-                  right: 6rem;
-                  font-size: 1.2rem;
-                  color: ${DESIGN_TOKEN_COLOR.gray500};
-                `}
-              >
-                100
-              </span>
-            </div>
-          </section>
+            </section>
+          )}
         </section>
       </article>
 
       {/* ---------- 회고 ---------- */}
-      <RetrospectsOverview description="나는 이렇게 회고 하고 있어요!" />
+      {individualAnalysis && (
+        <RetrospectsOverview
+          description="나는 이렇게 회고 하고 있어요!"
+          goodPoints={individualAnalysis.goodPoints}
+          badPoints={individualAnalysis.badPoints}
+          improvementPoints={individualAnalysis.improvementPoints}
+        />
+      )}
     </section>
   );
 }

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualContents.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualContents.tsx
@@ -19,6 +19,7 @@ type AnalysisIndividualContentsProps = {
 };
 
 export default function AnalysisIndividualContents({ individualAnalysis }: AnalysisIndividualContentsProps) {
+  // TODO: 백엔드에 추가 API(개인) 수정 요청함. 백엔드 완료 후 작업 진행
   return (
     <section
       css={css`

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTab.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTab.tsx
@@ -4,15 +4,46 @@ import { useState } from "react";
 import TeamIndividualToggle from "./TeamIndividualToggle";
 import AnalysisIndividualContents from "./AnalysisIndividualContents";
 import AnalysisTeamContents from "./AnalysisTeamContents";
+import { useApiGetAnalysis } from "@/hooks/api/analysis/useApiGetAnalysis";
+import { useSearchParams } from "react-router-dom";
+import { LoadingModal } from "@/component/common/Modal/LoadingModal";
+import { getAnalysisResponse } from "@/hooks/api/retrospect/analysis/useGetAnalysisAnswer";
+import { AnalysisingComp } from "@/component/retrospect/analysis/Analysis";
 
 type ViewType = "개인" | "팀";
 
-export default function AnalysisTab() {
+type AnalysisTabProps = {
+  analysisData: getAnalysisResponse;
+};
+
+export default function AnalysisTab({ analysisData }: AnalysisTabProps) {
+  const [searchParams] = useSearchParams();
+
+  const spaceId = searchParams.get("spaceId");
+  const retrospectId = searchParams.get("retrospectId");
+
+  const { hasAIAnalyzed } = analysisData;
+
+  const { data: analysisRetrospectsData, isPending: isPendingAnalysisData } = useApiGetAnalysis({
+    spaceId: spaceId || "",
+    retrospectId: retrospectId || "",
+  });
+
+  console.log("analysisData", analysisData);
+
   const [selectedView, setSelectedView] = useState<ViewType>("개인");
 
   const handleToggle = (view: ViewType) => {
     setSelectedView(view);
   };
+
+  if (isPendingAnalysisData) {
+    return <LoadingModal />;
+  }
+
+  if (hasAIAnalyzed == false) {
+    return <AnalysisingComp />;
+  }
 
   return (
     <section
@@ -33,7 +64,11 @@ export default function AnalysisTab() {
           flex: 1;
         `}
       >
-        {selectedView === "개인" ? <AnalysisIndividualContents /> : <AnalysisTeamContents />}
+        {selectedView === "개인" ? (
+          <AnalysisIndividualContents individualAnalysis={analysisRetrospectsData?.individualAnalyze} />
+        ) : (
+          <AnalysisTeamContents teamAnalyze={analysisRetrospectsData?.teamAnalyze} />
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTeamContents.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTeamContents.tsx
@@ -6,12 +6,22 @@ import { css } from "@emotion/react";
 import RetrospectsOverview from "./RetrospectsOverview";
 
 import { TeamSatisfactionChart } from "@/component/retrospect/analysis/TeamSatisfactionChart";
-
-const achievementPercentage = 78; // TODO: 실제 목표달성률 할당 (0-100 사이의 숫자)
+import { TeamAnalyzeType } from "@/hooks/api/analysis/useApiGetAnalysis";
+import { useSatisfactionData } from "@/hooks/useSatisfactionData";
 
 const PADDING_SUM = 8;
 
-export default function AnalysisTeamContents() {
+type AnalysisTeamContentsProps = {
+  teamAnalyze?: TeamAnalyzeType;
+};
+
+export default function AnalysisTeamContents({ teamAnalyze }: AnalysisTeamContentsProps) {
+  // 만족도 데이터 처리
+  const { dominantCategory } = useSatisfactionData(
+    teamAnalyze
+      ? [teamAnalyze.scoreFive, teamAnalyze.scoreFour, teamAnalyze.scoreThree, teamAnalyze.scoreTwo, teamAnalyze.scoreOne]
+      : [5, 4, 3, 2, 1],
+  );
   return (
     <section
       css={css`
@@ -96,207 +106,223 @@ export default function AnalysisTeamContents() {
               <Typography variant="title18Bold" color="gray900">
                 진행상황에 대해 대부분{" "}
               </Typography>
-              {/* TODO: 실제 만족도 할당 */}
               <Typography variant="title18Bold" color="blue600">
-                {"만족해요"}
+                {dominantCategory}해요
               </Typography>
             </div>
 
             {/* ---------- 차트 컨테이너 ---------- */}
-            <TeamSatisfactionChart
-              satisfactionLevels={[5, 4, 3, 2, 1]}
-              layout="compact"
-              chartSize={{
-                width: 160,
-                height: 160,
-                innerRadius: 35,
-                outerRadius: 65,
-              }}
-              customStyles={{
-                container: css`
-                  padding: 0;
-                  background-color: transparent;
-                  gap: 0;
-                `,
-                title: css`
-                  display: none;
-                `,
-                chartContainer: css`
-                  flex-direction: row;
-                  justify-content: center;
-                  gap: 6.3rem;
-                  align-items: center;
-                  width: 100%;
-                `,
-                legend: css`
-                  display: flex;
-                  flex-direction: column;
-                  gap: 1rem;
-                  width: auto;
-                `,
-              }}
-            />
+            {teamAnalyze && (
+              <TeamSatisfactionChart
+                satisfactionLevels={[
+                  teamAnalyze.scoreFive,
+                  teamAnalyze.scoreFour,
+                  teamAnalyze.scoreThree,
+                  teamAnalyze.scoreTwo,
+                  teamAnalyze.scoreOne,
+                ]}
+                layout="compact"
+                chartSize={{
+                  width: 160,
+                  height: 160,
+                  innerRadius: 35,
+                  outerRadius: 65,
+                }}
+                customStyles={{
+                  container: css`
+                    padding: 0;
+                    background-color: transparent;
+                    gap: 0;
+                  `,
+                  title: css`
+                    display: none;
+                  `,
+                  chartContainer: css`
+                    flex-direction: row;
+                    justify-content: center;
+                    gap: 6.3rem;
+                    align-items: center;
+                    width: 100%;
+                  `,
+                  legend: css`
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1rem;
+                    width: auto;
+                  `,
+                }}
+              />
+            )}
           </section>
 
           {/* ---------- 목표달성률 ---------- */}
-          <section
-            css={css`
-              flex: 1;
-              height: 100%;
-              display: flex;
-              flex-direction: column;
-              gap: 8rem;
-            `}
-          >
-            <div>
-              <Typography variant="title18Bold" color="gray900">
-                목표달성률은{" "}
-              </Typography>
-              {/* TODO: 실제 목표달성률 할당 */}
-              <Typography variant="title18Bold" color="blue600">
-                {achievementPercentage}%
-              </Typography>
-
-              <Typography variant="title18Bold" color="gray900">
-                에요
-              </Typography>
-            </div>
-
-            {/* ---------- Progress bar ---------- */}
-            <div
+          {teamAnalyze && (
+            <section
               css={css`
-                position: relative;
-                padding: 0 6rem;
+                flex: 1;
+                height: 100%;
+                display: flex;
+                flex-direction: column;
+                gap: 8rem;
               `}
             >
-              {/* ---------- 말풍선 ---------- */}
-              <div
-                css={css`
-                  position: absolute;
-                  top: -5rem;
-                  left: ${achievementPercentage - PADDING_SUM}%; /* 비율에 따라 동적 위치 */
-                  transform: translateX(-50%); /* 중앙 정렬 */
-                  background-color: white;
-                  border-radius: 1.6rem;
-                  padding: 0.4rem 0.8rem;
-                  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-                  display: flex;
-                  align-items: center;
-                  gap: 0.8rem;
-                  z-index: 10;
+              <div>
+                <Typography variant="title18Bold" color="gray900">
+                  목표달성률은{" "}
+                </Typography>
+                {/* TODO: 실제 목표달성률 할당 */}
+                <Typography variant="title18Bold" color="blue600">
+                  {teamAnalyze.goalCompletionRate}%
+                </Typography>
 
-                  /* ---------- 말풍선 꼬리 ---------- */
-                  &::after {
-                    content: "";
-                    position: absolute;
-                    bottom: -0.8rem;
-                    left: 50%;
-                    transform: translateX(-50%);
-                    width: 0;
-                    height: 0;
-                    border-left: 0.8rem solid transparent;
-                    border-right: 0.8rem solid transparent;
-                    border-top: 0.8rem solid white;
-                  }
-                `}
-              >
-                <Icon icon="ic_person" size={2.0} color={DESIGN_TOKEN_COLOR.blue600} />
-                <Typography variant="title16Bold" color="gray900">
-                  {achievementPercentage}%
+                <Typography variant="title18Bold" color="gray900">
+                  에요
                 </Typography>
               </div>
 
-              {/* ---------- 5구간 프로그레스 바 ---------- */}
+              {/* ---------- Progress bar ---------- */}
               <div
                 css={css`
-                  display: flex;
-                  width: 100%;
-                  gap: 0.46rem;
                   position: relative;
+                  padding: 0 6rem;
                 `}
               >
-                {[0, 1, 2, 3, 4].map((index) => {
-                  // * 비율에 따라 각 구간의 채우기 정도 계산
-                  const getSegmentFill = () => {
-                    // 각 구간의 시작점 (0, 20, 40, 60, 80)
-                    const segmentStart = index * 20;
+                {/* ---------- 말풍선 ---------- */}
+                <div
+                  css={css`
+                    position: absolute;
+                    top: -5rem;
+                    left: ${teamAnalyze.goalCompletionRate - PADDING_SUM}%; /* 비율에 따라 동적 위치 */
+                    transform: translateX(-50%); /* 중앙 정렬 */
+                    background-color: white;
+                    border-radius: 1.6rem;
+                    padding: 0.4rem 0.8rem;
+                    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+                    display: flex;
+                    align-items: center;
+                    gap: 0.8rem;
+                    z-index: 10;
 
-                    // 각 구간의 끝점 (20, 40, 60, 80, 100)
-                    const segmentEnd = (index + 1) * 20;
-
-                    if (achievementPercentage <= segmentStart) {
-                      return 0; // 비율이 구간 시작점보다 작으면 비움
-                    } else if (achievementPercentage >= segmentEnd) {
-                      return 1; // 비율이 구간 끝점보다 크면 완전히 채움
-                    } else {
-                      // 비율이 구간 내에 있으면 부분적으로 채움
-                      return (achievementPercentage - segmentStart) / 20;
+                    /* ---------- 말풍선 꼬리 ---------- */
+                    &::after {
+                      content: "";
+                      position: absolute;
+                      bottom: -0.8rem;
+                      left: 50%;
+                      transform: translateX(-50%);
+                      width: 0;
+                      height: 0;
+                      border-left: 0.8rem solid transparent;
+                      border-right: 0.8rem solid transparent;
+                      border-top: 0.8rem solid white;
                     }
-                  };
+                  `}
+                >
+                  <Icon icon="ic_person" size={2.0} color={DESIGN_TOKEN_COLOR.blue600} />
+                  <Typography variant="title16Bold" color="gray900">
+                    {teamAnalyze.goalCompletionRate}%
+                  </Typography>
+                </div>
 
-                  const fillRatio = getSegmentFill();
-                  const isFirstSegment = index === 0;
-                  const isLastSegment = index === 4;
+                {/* ---------- 5구간 프로그레스 바 ---------- */}
+                <div
+                  css={css`
+                    display: flex;
+                    width: 100%;
+                    gap: 0.46rem;
+                    position: relative;
+                  `}
+                >
+                  {[0, 1, 2, 3, 4].map((index) => {
+                    // * 비율에 따라 각 구간의 채우기 정도 계산
+                    const getSegmentFill = () => {
+                      // 각 구간의 시작점 (0, 20, 40, 60, 80)
+                      const segmentStart = index * 20;
 
-                  return (
-                    <div
-                      key={index}
-                      css={css`
-                        flex: 1;
-                        height: 3rem;
-                        background-color: white;
-                        border-radius: ${isFirstSegment ? "1.5rem 0 0 1.5rem" : isLastSegment ? "0 1.5rem 1.5rem 0" : "0"};
-                        position: relative;
-                        overflow: hidden;
-                      `}
-                    >
-                      {/* ---------- 채워진 부분 ---------- */}
+                      // 각 구간의 끝점 (20, 40, 60, 80, 100)
+                      const segmentEnd = (index + 1) * 20;
+
+                      if (teamAnalyze.goalCompletionRate <= segmentStart) {
+                        return 0; // 비율이 구간 시작점보다 작으면 비움
+                      } else if (teamAnalyze.goalCompletionRate >= segmentEnd) {
+                        return 1; // 비율이 구간 끝점보다 크면 완전히 채움
+                      } else {
+                        // 비율이 구간 내에 있으면 부분적으로 채움
+                        return (teamAnalyze.goalCompletionRate - segmentStart) / 20;
+                      }
+                    };
+
+                    const fillRatio = getSegmentFill();
+                    const isFirstSegment = index === 0;
+                    const isLastSegment = index === 4;
+
+                    return (
                       <div
+                        key={index}
                         css={css`
-                          width: ${fillRatio * 100}%;
-                          height: 100%;
-                          background-color: #6b9eff;
-                          border-radius: inherit;
-                          transition: width 0.3s ease;
+                          flex: 1;
+                          height: 3rem;
+                          background-color: white;
+                          border-radius: ${isFirstSegment ? "1.5rem 0 0 1.5rem" : isLastSegment ? "0 1.5rem 1.5rem 0" : "0"};
+                          position: relative;
+                          overflow: hidden;
                         `}
-                      />
-                    </div>
-                  );
-                })}
+                      >
+                        {/* ---------- 채워진 부분 ---------- */}
+                        <div
+                          css={css`
+                            width: ${fillRatio * 100}%;
+                            height: 100%;
+                            background-color: #6b9eff;
+                            border-radius: inherit;
+                            transition: width 0.3s ease;
+                          `}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {/* ---------- 0% 텍스트 ---------- */}
+                <span
+                  css={css`
+                    position: absolute;
+                    bottom: -2.5rem;
+                    left: 6rem;
+                    font-size: 1.2rem;
+                    color: ${DESIGN_TOKEN_COLOR.gray500};
+                  `}
+                >
+                  0
+                </span>
+
+                {/* ---------- 100% 텍스트 ---------- */}
+                <span
+                  css={css`
+                    position: absolute;
+                    bottom: -2.5rem;
+                    right: 6rem;
+                    font-size: 1.2rem;
+                    color: ${DESIGN_TOKEN_COLOR.gray500};
+                  `}
+                >
+                  100
+                </span>
               </div>
-
-              {/* ---------- 0% 텍스트 ---------- */}
-              <span
-                css={css`
-                  position: absolute;
-                  bottom: -2.5rem;
-                  left: 6rem;
-                  font-size: 1.2rem;
-                  color: ${DESIGN_TOKEN_COLOR.gray500};
-                `}
-              >
-                0
-              </span>
-
-              {/* ---------- 100% 텍스트 ---------- */}
-              <span
-                css={css`
-                  position: absolute;
-                  bottom: -2.5rem;
-                  right: 6rem;
-                  font-size: 1.2rem;
-                  color: ${DESIGN_TOKEN_COLOR.gray500};
-                `}
-              >
-                100
-              </span>
-            </div>
-          </section>
+            </section>
+          )}
         </section>
       </article>
 
       {/* ---------- 회고 ---------- */}
-      <RetrospectsOverview description="우리팀은 이렇게 회고 하고 있어요!" />
+      {teamAnalyze && (
+        <RetrospectsOverview
+          description="우리팀은 이렇게 회고 하고 있어요!"
+          goodPoints={teamAnalyze.goodPoints}
+          badPoints={teamAnalyze.badPoints}
+          improvementPoints={teamAnalyze.improvementPoints}
+        />
+      )}
     </section>
   );
 }

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/RetrospectsOverview.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/RetrospectsOverview.tsx
@@ -1,13 +1,17 @@
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { Insight } from "@/types/analysis";
 import { css } from "@emotion/react";
 
 type RetrospectsOverviewProps = {
   description: string;
+  goodPoints: Insight[];
+  badPoints: Insight[];
+  improvementPoints: Insight[];
 };
 
-export default function RetrospectsOverview({ description }: RetrospectsOverviewProps) {
+export default function RetrospectsOverview({ description, goodPoints, badPoints, improvementPoints }: RetrospectsOverviewProps) {
   return (
     <article>
       {/* ---------- 제목 ---------- */}
@@ -81,8 +85,7 @@ export default function RetrospectsOverview({ description }: RetrospectsOverview
                 gap: 0.8rem;
               `}
             >
-              {/* 긍정적 항목들 */}
-              {["회의 내용 문서화", "꾸준한 글 작성", "적극적인 피드백"].map((item, index) => (
+              {goodPoints.map((item, index) => (
                 <div
                   key={index}
                   css={css`
@@ -97,7 +100,7 @@ export default function RetrospectsOverview({ description }: RetrospectsOverview
                 >
                   <Icon icon="ic_good_mark" size={1.6} />
                   <Typography variant="subtitle14Bold" color="gray800">
-                    {item}
+                    {item.content}
                   </Typography>
                 </div>
               ))}
@@ -123,8 +126,7 @@ export default function RetrospectsOverview({ description }: RetrospectsOverview
                 gap: 0.8rem;
               `}
             >
-              {/* 부족한 항목들 */}
-              {["짧은 회의 늘어짐", "회의 시간 준수", "꾸준한 글 작성"].map((item, index) => (
+              {badPoints.map((item, index) => (
                 <div
                   key={index}
                   css={css`
@@ -139,7 +141,7 @@ export default function RetrospectsOverview({ description }: RetrospectsOverview
                 >
                   <Icon icon="ic_bad_mark_red" size={1.6} />
                   <Typography variant="subtitle14Bold" color="gray800">
-                    {item}
+                    {item.content}
                   </Typography>
                 </div>
               ))}
@@ -165,8 +167,7 @@ export default function RetrospectsOverview({ description }: RetrospectsOverview
                 gap: 0.8rem;
               `}
             >
-              {/* 개선 필요 항목들 */}
-              {["설득력 갖추기", "꾸준한 자기계발", "적극적인 피드백"].map((item, index) => (
+              {improvementPoints.map((item, index) => (
                 <div
                   key={index}
                   css={css`
@@ -181,7 +182,7 @@ export default function RetrospectsOverview({ description }: RetrospectsOverview
                 >
                   <Icon icon="ic_improve_blue_mark" size={1.6} />
                   <Typography variant="subtitle14Bold" color="gray800">
-                    {item}
+                    {item.content}
                   </Typography>
                 </div>
               ))}

--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -16,12 +16,12 @@ interface RetrospectCardProps {
 export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardProps) {
   const navigate = useNavigate();
 
-  const { retrospectId, title, introduction, deadline, totalCount, writeCount, writeStatus, analysisStatus } = retrospect;
+  const { retrospectId, title, introduction, deadline, totalCount, writeCount, writeStatus, analysisStatus, retrospectStatus } = retrospect;
 
   const handleCardClick = () => {
     // TODO: spaceId가 없는 경우 처리(예: 홈 화면 최상단의 카드 클릭 시)
 
-    if (spaceId) {
+    if (spaceId && retrospectStatus === "DONE") {
       navigate(PATHS.retrospectAnalysis(spaceId, retrospectId, title));
     }
   };

--- a/apps/web/src/component/retrospect/analysis/Analysis.tsx
+++ b/apps/web/src/component/retrospect/analysis/Analysis.tsx
@@ -159,7 +159,7 @@ export function AnalysisContainer({ spaceId, retrospectId, hasAIAnalyzed }: Anal
   );
 }
 
-function AnalysisingComp() {
+export function AnalysisingComp() {
   return (
     <div
       css={css`

--- a/apps/web/src/component/retrospect/analysis/Analysis.tsx
+++ b/apps/web/src/component/retrospect/analysis/Analysis.tsx
@@ -12,6 +12,7 @@ import { Spacing } from "@/component/common/Spacing";
 import { Typography } from "@/component/common/typography";
 import { useApiGetAnalysis } from "@/hooks/api/analysis/useApiGetAnalysis";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { getDeviceType } from "@/utils/deviceUtils";
 
 type AnalysisContainerProps = {
   spaceId: string;
@@ -160,10 +161,12 @@ export function AnalysisContainer({ spaceId, retrospectId, hasAIAnalyzed }: Anal
 }
 
 export function AnalysisingComp() {
+  const { isDesktop } = getDeviceType();
+
   return (
     <div
       css={css`
-        height: 100dvh;
+        height: ${isDesktop ? "80vh" : "100dvh"};
         display: flex;
         flex-direction: column;
         justify-content: center;

--- a/apps/web/src/component/retrospect/analysis/TeamSatisfactionChart.tsx
+++ b/apps/web/src/component/retrospect/analysis/TeamSatisfactionChart.tsx
@@ -1,18 +1,10 @@
 import { css } from "@emotion/react";
-import { useMemo } from "react";
 import { PieChart, Pie, Cell, Tooltip } from "recharts";
 
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
-
-const COLORS = [
-  DESIGN_TOKEN_COLOR.blue600,
-  DESIGN_TOKEN_COLOR.blue500,
-  DESIGN_TOKEN_COLOR.blue400,
-  DESIGN_TOKEN_COLOR.blue700,
-  DESIGN_TOKEN_COLOR.blue800,
-];
+import { useSatisfactionData } from "@/hooks/useSatisfactionData";
 
 type TeamSatisfactionChartProps = {
   satisfactionLevels: number[];
@@ -35,7 +27,6 @@ type TeamSatisfactionChartProps = {
 };
 
 export function TeamSatisfactionChart({
-  satisfactionLevels,
   customStyles = {},
   chartSize = {
     width: 240,
@@ -44,21 +35,9 @@ export function TeamSatisfactionChart({
     outerRadius: 90,
   },
   layout = "default",
+  satisfactionLevels,
 }: TeamSatisfactionChartProps) {
-  const data = useMemo(() => {
-    const levels = [
-      { name: "매우 만족", value: satisfactionLevels[0], color: COLORS[0] },
-      { name: "만족", value: satisfactionLevels[1], color: COLORS[1] },
-      { name: "보통", value: satisfactionLevels[2], color: COLORS[2] },
-      { name: "불만족", value: satisfactionLevels[3], color: COLORS[3] },
-      { name: "매우 불만족", value: satisfactionLevels[4], color: COLORS[4] },
-    ];
-
-    return levels.filter((level) => level.value > 0).sort((a, b) => b.value - a.value);
-  }, [satisfactionLevels]);
-
-  const dominantCategory = data[0]?.name || "";
-  const dominantColor = data[0]?.color || COLORS[2];
+  const { data, dominantCategory, dominantColor } = useSatisfactionData(satisfactionLevels);
 
   // 기본 스타일
   const defaultContainerStyles = css`

--- a/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
@@ -10,12 +10,13 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Retrospect } from "@/types/retrospect";
 import RetrospectCard from "@/app/desktop/component/home/RetrospectCard";
+import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
 
 export default function CompletedRetrospects() {
   const { spaceId } = useParams();
 
   // * 스페이스 회고 목록 조회
-  const { data: retrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
+  const { data: retrospects, isPending: isPendingRetrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
 
   // * 마감된 회고 필터링
   const completedRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "DONE") || [], [retrospects]);
@@ -41,6 +42,10 @@ export default function CompletedRetrospects() {
       setDisplayedRetrospects(completed);
     }
   }, [completedRetrospects]);
+
+  if (isPendingRetrospects) {
+    return <LoadingSpinner />;
+  }
 
   return (
     <section

--- a/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
@@ -13,12 +13,13 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Retrospect } from "@/types/retrospect";
 import RetrospectCard from "@/app/desktop/component/home/RetrospectCard";
+import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
 
 export default function InProgressRetrospects() {
   const { spaceId } = useParams();
 
   // * 스페이스 회고 목록 조회
-  const { data: retrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
+  const { data: retrospects, isPending: isPendingRetrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
 
   const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);
 
@@ -34,7 +35,7 @@ export default function InProgressRetrospects() {
       return items;
     });
 
-    // TODO: 여기서 변경된 순서를 서버에 저장하는 API를 호출 필요
+    // TODO(supersett): 여기서 변경된 순서를 서버에 저장하는 API를 호출 필요
   };
 
   useEffect(() => {
@@ -43,6 +44,10 @@ export default function InProgressRetrospects() {
       setDisplayedRetrospects(proceeding);
     }
   }, [proceedingRetrospects]);
+
+  if (isPendingRetrospects) {
+    return <LoadingSpinner />;
+  }
 
   return (
     <section

--- a/apps/web/src/hooks/api/analysis/useApiGetAnalysis.ts
+++ b/apps/web/src/hooks/api/analysis/useApiGetAnalysis.ts
@@ -6,23 +6,27 @@ import { Insight } from "@/types/analysis";
 import { AxiosResponse } from "axios";
 import { ErrorResponse } from "react-router-dom";
 
+export type IndividualAnalyzeType = {
+  goodPoints: Insight[];
+  badPoints: Insight[];
+  improvementPoints: Insight[];
+};
+
+export type TeamAnalyzeType = {
+  scoreOne: number;
+  scoreTwo: number;
+  scoreThree: number;
+  scoreFour: number;
+  scoreFive: number;
+  goalCompletionRate: number;
+  goodPoints: Insight[];
+  badPoints: Insight[];
+  improvementPoints: Insight[];
+};
+
 export type AnalysisType = {
-  teamAnalyze: {
-    scoreOne: number;
-    scoreTwo: number;
-    scoreThree: number;
-    scoreFour: number;
-    scoreFive: number;
-    goalCompletionRate: number;
-    goodPoints: Insight[];
-    badPoints: Insight[];
-    improvementPoints: Insight[];
-  };
-  individualAnalyze: {
-    goodPoints: Insight[];
-    badPoints: Insight[];
-    improvementPoints: Insight[];
-  };
+  teamAnalyze: TeamAnalyzeType;
+  individualAnalyze: IndividualAnalyzeType;
 };
 
 export const useApiGetAnalysis = ({ spaceId, retrospectId }: { spaceId: string; retrospectId: string }) => {

--- a/apps/web/src/hooks/useSatisfactionData.ts
+++ b/apps/web/src/hooks/useSatisfactionData.ts
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+
+const COLORS = [
+  DESIGN_TOKEN_COLOR.blue600,
+  DESIGN_TOKEN_COLOR.blue500,
+  DESIGN_TOKEN_COLOR.blue400,
+  DESIGN_TOKEN_COLOR.blue700,
+  DESIGN_TOKEN_COLOR.blue800,
+];
+
+export type SatisfactionData = {
+  name: string;
+  value: number;
+  color: string;
+};
+
+type UseSatisfactionDataReturn = {
+  data: SatisfactionData[];
+  dominantCategory: string;
+  dominantColor: string;
+  totalCount: number;
+};
+
+/**
+ * 만족도 레벨 배열을 받아서 차트에 사용할 데이터로 변환하는 커스텀 훅
+ * @param satisfactionLevels [매우만족, 만족, 보통, 불만족, 매우불만족] 순서의 숫자 배열
+ * @returns 차트 데이터, 주요 카테고리, 주요 색상 등
+ */
+export const useSatisfactionData = (satisfactionLevels: number[]): UseSatisfactionDataReturn => {
+  const data = useMemo(() => {
+    const levels = [
+      { name: "매우 만족", value: satisfactionLevels[0] || 0, color: COLORS[0] },
+      { name: "만족", value: satisfactionLevels[1] || 0, color: COLORS[1] },
+      { name: "보통", value: satisfactionLevels[2] || 0, color: COLORS[2] },
+      { name: "불만족", value: satisfactionLevels[3] || 0, color: COLORS[3] },
+      { name: "매우 불만족", value: satisfactionLevels[4] || 0, color: COLORS[4] },
+    ];
+
+    // 값이 0보다 큰 항목만 필터링하고 내림차순 정렬
+    return levels.filter((level) => level.value > 0).sort((a, b) => b.value - a.value);
+  }, [satisfactionLevels]);
+
+  const dominantCategory = data[0]?.name || "보통";
+  const dominantColor = data[0]?.color || COLORS[2];
+  const totalCount = satisfactionLevels.reduce((sum, count) => sum + (count || 0), 0);
+
+  return {
+    data,
+    dominantCategory,
+    dominantColor,
+    totalCount,
+  };
+};


### PR DESCRIPTION
> ### 회고 분석 조회 api 연동
---

### 🏄🏼‍♂️‍ Summary (요약)
- 회고 분석 조회 API를 연동했습니다.

### 🫨 Describe your Change (변경사항)
- 회고 분석 조회 API를 개인 / 팀에 맞게 적용했습니다.
- 완료된 회고만 다이얼로그가 뜨도록 수정했습니다.
- AI 분석중 컴포넌트 높이 조절을 했습니다.

### 🧐 Issue number and link (참고)
- 개인의 일부는 회고 분석 조회 API 응답에 추가로 필요한 데이터가 있어서 백엔드 개발자분께 요청을 드렸습니다.
- 추가로 스페이스의 인원이 1명인 경우에는 #548 이슈에서 추가적인 퍼블리싱이 필요하여 해당 작업을 완료하면,
   스페이스의 인원이 1명인 경우에도 화면에 표기가 될 것 같습니다.

### 📚 Reference (참조)

https://github.com/user-attachments/assets/d8d6e51b-f820-4017-8d70-ee5fd469b07c



