### PR TITLE
스페이스 수정 버튼을 클릭했을 때, 토글 메뉴가 뒤늦게 사라지는 현상 수정

### DIFF
--- a/apps/web/src/component/common/Modal/DesktopModal/DesktopModal.tsx
+++ b/apps/web/src/component/common/Modal/DesktopModal/DesktopModal.tsx
@@ -73,7 +73,7 @@ export default function DesktopModal() {
           >
             {contents}
           </div>
-          <DesktopModalFooter rightFunction={onConfirm} leftFunction={closeDesktopModal} options={options} />
+          <DesktopModalFooter rightFunction={onConfirm} leftFunction={onClose} options={options} />
         </div>
       </div>
     </Portal>
@@ -149,11 +149,10 @@ function DesktopModalHeader({ title, onBack, onClose }: DesktopModalHeaderProps)
   );
 }
 
-function DesktopModalFooter({ leftFunction, rightFunction = () => {}, options }: DesktopModalFooterProps) {
+function DesktopModalFooter({ leftFunction, rightFunction = () => {}, options = {} }: DesktopModalFooterProps) {
   const DEFAULT_BUTTON_TEXT = ["취소", "확인"];
-  const { buttonText = DEFAULT_BUTTON_TEXT, enableFooter = true } = options || { buttonText: DEFAULT_BUTTON_TEXT };
 
-  if (!enableFooter) return null;
+  if (!options.enableFooter) return null;
 
   return (
     <div
@@ -173,11 +172,11 @@ function DesktopModalFooter({ leftFunction, rightFunction = () => {}, options }:
       >
         {leftFunction && (
           <Button colorSchema={"gray"} onClick={leftFunction}>
-            {buttonText[0]}
+            {options?.buttonText?.[0] ?? DEFAULT_BUTTON_TEXT[0]}
           </Button>
         )}
         <Button colorSchema={"primary"} onClick={rightFunction}>
-          {buttonText[1]}
+          {options?.buttonText?.[1] ?? DEFAULT_BUTTON_TEXT[1]}
         </Button>
       </ButtonProvider>
     </div>

--- a/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
+++ b/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
@@ -18,7 +18,7 @@ export default function SpaceManageToggleMenu({
   iconSize?: number;
   iconColor?: keyof typeof DESIGN_TOKEN_COLOR;
 }) {
-  const { isShowMenu, showMenu } = useToggleMenu();
+  const { isShowMenu, showMenu, hideMenu } = useToggleMenu();
   const navigate = useNavigate();
   const { open: openDesktopModal } = useDesktopBasicModal();
   const { open: openAlertModal } = useModal();
@@ -46,6 +46,7 @@ export default function SpaceManageToggleMenu({
         enableFooter: false,
       },
     });
+    hideMenu();
   };
 
   /**
@@ -67,7 +68,6 @@ export default function SpaceManageToggleMenu({
         display: flex;
         align-items: center;
         justify-content: center;
-        transition: all 0.4s;
       `}
     >
       <Icon

--- a/apps/web/src/hooks/useDesktopBasicModal.ts
+++ b/apps/web/src/hooks/useDesktopBasicModal.ts
@@ -8,7 +8,16 @@ export const useDesktopBasicModal = () => {
   const [modalDataState, setModalDataState] = useAtom(desktopBasicModalState);
 
   const close = useCallback(() => {
-    setModalDataState({ ...modalDataState, isOpen: false });
+    setModalDataState({
+      ...modalDataState,
+      isOpen: false,
+      options: {
+        type: "confirm",
+        buttonText: [],
+        autoClose: true,
+        enableFooter: true,
+      },
+    });
   }, [modalDataState, setModalDataState]);
 
   const open = useCallback(


### PR DESCRIPTION
> ### 스페이스 수정 버튼을 클릭했을 때, 토글 메뉴가 뒤늦게 사라지는 현상 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 스페이스 수정 버튼을 클릭했을 때, 다른 곳을 클릭해야 토글 메뉴가 사라지던 현상을 수정했어요
- 데스크톱 모달에서 옵션 설정 시, 버튼 텍스트가 노출되지 않는 현상을 수정했어요

### 🫨 Describe your Change (변경사항)
- apps/web/src/component/common/Modal/DesktopModal/DesktopModal.tsx
  - 데스크톱 모달에서 옵션 설정 시, 버튼 텍스트가 정상적으로 노출되지 않던 현상 수정 
  - 취소 버튼에 `close` 이벤트를 자동으로 붙이던 코드 제거 (사용자가 주입한 `onClose` 이벤트만 들어가도록 수정
- apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
  - 스페이스 수정 버튼 클릭 시, 토글 메뉴가 같이 사라지도록 수정

### 🧐 Issue number and link (참고)
- closes: #567 

### 📚 Reference (참조)
- 데스크톱 모달 옵션 설정 시, 사이드 이펙트 수정
