### PR TITLE
fix: #586 확대된 해상도에서 온보딩 화면 일부가 잘려보이는 현상 수정

### DIFF
--- a/apps/web/src/app/desktop/login/DesktopLoginPage.tsx
+++ b/apps/web/src/app/desktop/login/DesktopLoginPage.tsx
@@ -194,7 +194,6 @@ export default function DesktopLoginPage() {
             loop={true}
             css={css`
               width: 100%;
-              height: 100%;
               border-radius: 1.6rem;
               position: relative;
               overflow: hidden;


### PR DESCRIPTION
> ### 확대된 해상도에서 온보딩 화면 일부가 잘려보이는 현상을 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 확대된 해상도에서 온보딩 화면 일부가 잘려보이는 현상을 수정

### 🫨 Describe your Change (변경사항)
- apps/web/src/app/desktop/login/DesktopLoginPage.tsx

### 🧐 Issue number and link (참고)
- closes: #586 

### 📚 Reference (참조)
https://github.com/user-attachments/assets/2971e106-7dcc-4a55-b279-c6ef2a602bee



