### PR TITLE
fix: 분석 정보 확인 시에 노출되는 스페이스 관리 버튼 이벤트 연결

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
@@ -1,7 +1,9 @@
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
+import SpaceManageToggleMenu from "@/component/space/edit/SpaceManageToggleMenu";
 import { currentSpaceState } from "@/store/space/spaceAtom";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
+import { isSpaceLeader } from "@/utils/userUtil";
 import { css } from "@emotion/react";
 import { useAtomValue } from "jotai";
 
@@ -9,7 +11,8 @@ export default function AnalysisOverviewHeader() {
   // TODO: 새로고침해도 query를 통해서 데이터를 불러오도록 수정 필요
   const currentSelectedSpace = useAtomValue(currentSpaceState);
 
-  const { name, introduction, memberCount, formTag } = currentSelectedSpace || {};
+  const { name, introduction, memberCount, formTag, leader, id: spaceId } = currentSelectedSpace || {};
+  const isLeader = isSpaceLeader(leader?.id);
 
   return (
     <section>
@@ -25,7 +28,7 @@ export default function AnalysisOverviewHeader() {
         <Typography variant="heading24Bold" color="gray900">
           {name}
         </Typography>
-        <Icon icon="ic_more" size={2.0} color={DESIGN_TOKEN_COLOR.gray900} />
+        {isLeader && <SpaceManageToggleMenu spaceId={spaceId!} iconSize={2.0} iconColor={"gray900"} />}
       </div>
 
       {/* ---------- 스페이스 소개 ---------- */}

--- a/apps/web/src/app/desktop/space/modify/ModifySpacePage.tsx
+++ b/apps/web/src/app/desktop/space/modify/ModifySpacePage.tsx
@@ -3,7 +3,7 @@ import { ImageUploader } from "@/component/common/ImageUploader";
 import { Input, InputLabelContainer, Label, TextArea } from "@/component/common/input";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { Spacing } from "@/component/common/Spacing";
-import useModifySpace from "@/hooks/app/space/useModifySpace";
+import useModifySpace, { MODIFY_SPACE_ID_QUERY_KEY } from "@/hooks/app/space/useModifySpace";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
 import { css } from "@emotion/react";
 import { useSearchParams } from "react-router-dom";
@@ -11,7 +11,7 @@ import { useSearchParams } from "react-router-dom";
 // 데스크톱 환경에서는 해당 수정 페이지가 모달 안에 이식되어요
 export default function ModifySpacePage() {
   const [searchParams] = useSearchParams();
-  const spaceId = searchParams.get("spaceId") as string;
+  const spaceId = searchParams.get(MODIFY_SPACE_ID_QUERY_KEY) as string;
   const {
     data,
     isLoading,

--- a/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
+++ b/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
@@ -1,13 +1,13 @@
 import ModifySpacePage from "@/app/desktop/space/modify/ModifySpacePage";
 import { Icon } from "@/component/common/Icon";
 import { ToggleMenu } from "@/component/common/toggleMenu";
-import useModifySpace from "@/hooks/app/space/useModifySpace";
+import useModifySpace, { MODIFY_SPACE_METHOD_QUERY_KEY, MODIFY_SPACE_ID_QUERY_KEY } from "@/hooks/app/space/useModifySpace";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
 import { useModal } from "@/hooks/useModal";
 import useToggleMenu from "@/hooks/useToggleMenu";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { css } from "@emotion/react";
-import { useNavigate } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 export default function SpaceManageToggleMenu({
   iconSize = 1.8,
@@ -15,14 +15,14 @@ export default function SpaceManageToggleMenu({
   spaceId,
 }: {
   spaceId: string;
-  iconSize?: number;
+  iconSize?: number | string;
   iconColor?: keyof typeof DESIGN_TOKEN_COLOR;
 }) {
   const { isShowMenu, showMenu, hideMenu } = useToggleMenu();
-  const navigate = useNavigate();
   const { open: openDesktopModal } = useDesktopBasicModal();
   const { open: openAlertModal } = useModal();
-  const { onSubmitDeleteSpace, initializeSearchQuery } = useModifySpace({ id: spaceId });
+  const { onSubmitDeleteSpace, initializeSearchQuery } = useModifySpace({ id: spaceId.toString() });
+  const [_, setSearchParams] = useSearchParams();
 
   /**
    * @description 토글 메뉴 표시 함수
@@ -37,7 +37,11 @@ export default function SpaceManageToggleMenu({
    * @description 스페이스 수정 함수
    */
   const handleEditSpace = () => {
-    navigate(`?spaceId=${spaceId}&method=edit`, { replace: true });
+    setSearchParams((prev) => ({
+      ...Object.fromEntries(prev.entries()),
+      [MODIFY_SPACE_ID_QUERY_KEY]: spaceId,
+      [MODIFY_SPACE_METHOD_QUERY_KEY]: "edit",
+    }));
     openDesktopModal({
       title: "스페이스 수정",
       contents: <ModifySpacePage />,

--- a/apps/web/src/hooks/app/space/useModifySpace.ts
+++ b/apps/web/src/hooks/app/space/useModifySpace.ts
@@ -15,6 +15,9 @@ interface ModifySpaceProps {
   id: string;
 }
 
+export const MODIFY_SPACE_ID_QUERY_KEY = "modifyTargetId";
+export const MODIFY_SPACE_METHOD_QUERY_KEY = "method";
+
 export default function useModifySpace({ id }: ModifySpaceProps) {
   const { data, isLoading } = useApiGetSpace(id);
   const setterCurrentSpace = useSetAtom(currentSpaceState);
@@ -29,8 +32,8 @@ export default function useModifySpace({ id }: ModifySpaceProps) {
 
   const initializeSearchQuery = () => {
     const searchParams = new URLSearchParams(window.location.search);
-    searchParams.delete("method");
-    searchParams.delete("spaceId");
+    searchParams.delete(MODIFY_SPACE_METHOD_QUERY_KEY);
+    searchParams.delete(MODIFY_SPACE_ID_QUERY_KEY);
     navigate({ search: searchParams.toString() }, { replace: true });
   };
 


### PR DESCRIPTION
> ### 분석 정보 확인 시에 노출되는 스페이스 관리 버튼 이벤트 연결
---

### 🏄🏼‍♂️Summary (요약)
- 분석 정보 확인 시에 노출되는 스페이스 관리 버튼의 누락된 이벤트 연결을 진행합니다.

### 🫨 Describe your Change (변경사항)
- apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx

### 🧐 Issue number and link (참고)
- #595 

### 📚 Reference (참조)
- 쿼리 스트링에 들어가는 변수 값의 경우에 상수화를 통해 공통적으로 관리할 수 있도록 리팩토링을 했고, 분석 정보에 들어갔을 때 스페이스 관리 버튼의 모달을 열면 쿼리스트링이 초기화되는 이슈를 발견했는데 기존 로직이 초기화를 하고 있어서 이 부분도 리팩토링해서 손 보았습니다 :/


https://github.com/user-attachments/assets/717b106d-3772-42cc-90d7-193cde65c9d2