### PR TITLE
fix: 회고 초대장의 스크롤이 길어 버튼이 노출되지 않는 현상 수정

### DIFF
--- a/apps/web/src/app/desktop/space/members/JoinSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/members/JoinSpacePage.tsx
@@ -8,6 +8,9 @@ export function JoinSpacePage() {
       css={css`
         width: 100dvw;
         height: 100dvh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         background-color: ${DESIGN_SYSTEM_COLOR.blue600};
       `}
     >
@@ -17,22 +20,25 @@ export function JoinSpacePage() {
           max-height: 68rem;
           width: 100%;
           height: 100%;
-          position: absolute;
           border-radius: 2rem;
           overflow: hidden;
-
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-
-          main {
-            padding-top 4.8rem;
-            padding-inline: 3.2rem;
-            padding-bottom: 3.2rem;
-          }
         `}
       >
-        <JoinSpace />
+        <div
+          css={css`
+            width: 100%;
+            height: 100%;
+            background-color: #f2f4f8;
+            padding-top: 4.8rem;
+            padding-inline: 3.2rem;
+            padding-bottom: 0.8rem;
+            position: relative;
+            display: flex;
+            flex-direction: column;
+          `}
+        >
+          <JoinSpace />
+        </div>
       </article>
     </section>
   );

--- a/apps/web/src/app/mobile/space/JoinSpacePage.tsx
+++ b/apps/web/src/app/mobile/space/JoinSpacePage.tsx
@@ -1,5 +1,10 @@
 import { JoinSpace } from "@/component/space/join/JoinSpace";
+import { DefaultLayout } from "@/layout/DefaultLayout";
 
 export function JoinSpacePage() {
-  return <JoinSpace />;
+  return (
+    <DefaultLayout theme="gray" LeftComp={null}>
+      <JoinSpace />
+    </DefaultLayout>
+  );
 }

--- a/apps/web/src/component/common/button/ButtonProvider.tsx
+++ b/apps/web/src/component/common/button/ButtonProvider.tsx
@@ -3,8 +3,6 @@ import { Children, cloneElement, isValidElement, PropsWithChildren } from "react
 
 import { Button, ButtonProps } from "@/component/common/button/Button.tsx";
 import { getDeviceType } from "@/utils/deviceUtils";
-import { useFunnelModal } from "@/hooks/useFunnelModal";
-import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
 type SortSet = "vertical" | "horizontal";
 
@@ -38,7 +36,6 @@ export const ButtonProvider = ({
   ...props
 }: PropsWithChildren<ButtonProviderProps>) => {
   const { isDesktop } = getDeviceType();
-  const { funnelModalState } = useFunnelModal();
 
   return (
     <div
@@ -57,7 +54,7 @@ export const ButtonProvider = ({
           position: sticky;
           bottom: 0;
           padding: ${isDesktop ? "0.8rem 0 1.6rem" : "4rem 0 2rem"};
-          background-color: ${isDesktop ? (funnelModalState.step === "retrospectWrite" ? DESIGN_TOKEN_COLOR.gray900 : "#fff") : ""};
+          background-color: transparent;
           margin-top: auto;
           z-index: 10000;
         `,

--- a/apps/web/src/component/space/join/JoinSpace.tsx
+++ b/apps/web/src/component/space/join/JoinSpace.tsx
@@ -14,7 +14,6 @@ import { useApiGetSpace } from "@/hooks/api/space/useApiGetSpace";
 import { useApiJoinSpace } from "@/hooks/api/space/useApiJoinSpace";
 import { useModal } from "@/hooks/useModal.ts";
 import { useToast } from "@/hooks/useToast.ts";
-import { DefaultLayout } from "@/layout/DefaultLayout";
 import { decryptId } from "@/utils/space/cryptoKey";
 import { getDeviceType } from "@/utils/deviceUtils";
 
@@ -36,80 +35,78 @@ export function JoinSpace() {
 
   return (
     <>
-      <DefaultLayout theme="gray" LeftComp={null}>
-        <span
-          id="essential_data"
-          css={css`
-            display: none;
+      <span
+        id="essential_data"
+        css={css`
+          display: none;
+        `}
+      >
+        <span id="name">{data?.leader.name}</span>
+        <span id="team">{data?.name}</span>
+      </span>
+      <Header title={`${data?.leader.name}님이\n${data?.name} 팀에 초대했어요!`} contents={`${data?.name} 팀에서 함께 회고를 진행해볼까요?`} />
+      <JoinLetter
+        space={data!.name}
+        description={data!.introduction}
+        imgUrl={data!.bannerUrl}
+        css={css`
+          ${isDesktop &&
+          css`
+            top: 58%;
+            scale: 0.85;
+            transform-origin: top left;
           `}
-        >
-          <span id="name">{data?.leader.name}</span>
-          <span id="team">{data?.name}</span>
-        </span>
-        <Header title={`${data?.leader.name}님이\n${data?.name} 팀에 초대했어요!`} contents={`${data?.name} 팀에서 함께 회고를 진행해볼까요?`} />
-        <JoinLetter
-          space={data!.name}
-          description={data!.introduction}
-          imgUrl={data!.bannerUrl}
-          css={css`
-            ${isDesktop &&
-            css`
-              top: 55%;
-              scale: 0.85;
-              transform-origin: top left;
-            `}
-          `}
-        />
-        <ButtonProvider isProgress={isPending}>
-          <ButtonProvider.Primary
-            onClick={() =>
-              mutate(Number(spaceId), {
-                onSuccess: () => {
-                  toast.success(`스페이스에 초대되었어요!`);
+        `}
+      />
+      <ButtonProvider isProgress={isPending}>
+        <ButtonProvider.Primary
+          onClick={() =>
+            mutate(Number(spaceId), {
+              onSuccess: () => {
+                toast.success(`스페이스에 초대되었어요!`);
+                navigate(PATHS.spaceDetail(spaceId));
+              },
+              onError: (error) => {
+                if (error.status === 400) {
+                  toast.success("이미 참여한 스페이스로 이동했어요!");
                   navigate(PATHS.spaceDetail(spaceId));
-                },
-                onError: (error) => {
-                  if (error.status === 400) {
-                    toast.success("이미 참여한 스페이스로 이동했어요!");
-                    navigate(PATHS.spaceDetail(spaceId));
-                  }
-                  if (error.status === 403) {
-                    // 로그인 또는 회원가입 후, 해당 쿠키 값을 판별하여 스페이스 가입을 진행합니다.
-                    // FIXME: Cookie 모음 저장 필요
-                    Cookies.set(COOKIE_VALUE_SAVE_SPACE_ID_PHASE, spaceId);
-                    open({
-                      title: "스페이스 참여를 위해 로그인이 필요해요",
-                      contents: "지금 팀원들과 함께 회고를 진행해보세요",
-                      overrideActionElements: (
-                        <Fragment>
-                          <SocialLoginArea
-                            css={css`
-                              width: 100%;
-                            `}
-                            onlyContainerStyle={css`
-                              padding: 1rem 0;
-                            `}
-                          />
-                          <Button
-                            onClick={() => {
-                              Cookies.remove(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);
-                              close();
-                            }}
-                          >
-                            다음에 하기
-                          </Button>
-                        </Fragment>
-                      ),
-                    });
-                  }
-                },
-              })
-            }
-          >
-            수락하기
-          </ButtonProvider.Primary>
-        </ButtonProvider>
-      </DefaultLayout>
+                }
+                if (error.status === 403) {
+                  // 로그인 또는 회원가입 후, 해당 쿠키 값을 판별하여 스페이스 가입을 진행합니다.
+                  // FIXME: Cookie 모음 저장 필요
+                  Cookies.set(COOKIE_VALUE_SAVE_SPACE_ID_PHASE, spaceId);
+                  open({
+                    title: "스페이스 참여를 위해 로그인이 필요해요",
+                    contents: "지금 팀원들과 함께 회고를 진행해보세요",
+                    overrideActionElements: (
+                      <Fragment>
+                        <SocialLoginArea
+                          css={css`
+                            width: 100%;
+                          `}
+                          onlyContainerStyle={css`
+                            padding: 1rem 0;
+                          `}
+                        />
+                        <Button
+                          onClick={() => {
+                            Cookies.remove(COOKIE_VALUE_SAVE_SPACE_ID_PHASE);
+                            close();
+                          }}
+                        >
+                          다음에 하기
+                        </Button>
+                      </Fragment>
+                    ),
+                  });
+                }
+              },
+            })
+          }
+        >
+          수락하기
+        </ButtonProvider.Primary>
+      </ButtonProvider>
     </>
   );
 }


### PR DESCRIPTION
> ### 회고 초대장의 스크롤이 길어 버튼이 노출되지 않는 현상 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 회고 초대장의 스크롤이 길어 버튼이 노출되지 않는 현상 수정을 진행했어요

### 🫨 Describe your Change (변경사항)
- apps/web/src/app/desktop/space/members/JoinSpacePage.tsx
apps/web/src/app/mobile/space/JoinSpacePage.tsx
apps/web/src/component/space/join/JoinSpace.tsx
  - 회고 초대장 레이아웃 구조 일부 수정
-  apps/web/src/component/common/button/ButtonProvider.tsx
   - `ButtonProvider`의 백그라운드 컬러를 투명하게 변경 

### 🧐 Issue number and link (참고)
- #606 

### 📚 Reference (참조)
<img width="1462" height="1061" alt="스크린샷 2025-10-23 오후 11 09 33" src="https://github.com/user-attachments/assets/f9ea40ae-87a6-4de1-af4c-0df5d732083e" />

