### PR TITLE
feat: 작성 진입 단계 인터랙션 노출 플로우 수정

### DIFF
--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -39,15 +39,19 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
   const isSelected = urlRetrospectId && parseInt(urlRetrospectId) === retrospectId;
 
   const handleCardClick = () => {
-    // TODO: spaceId가 없는 경우 처리(예: 홈 화면 최상단의 카드 클릭 시)
-
     // 진행중인 회고 클릭 시
     if (targetSpaceId && retrospectStatus === "PROCEEDING") {
-      openFunnelModal({
-        title: "",
-        step: "retrospectWrite",
-        contents: <Prepare spaceId={Number(targetSpaceId)} retrospectId={retrospect.retrospectId} title={title} introduction={introduction} />,
-      });
+      if (writeStatus === "NOT_STARTED") {
+        // 아직 시작 안 한 경우 → 시작 화면 모달
+        openFunnelModal({
+          title: "",
+          step: "retrospectWrite",
+          contents: <Prepare spaceId={Number(targetSpaceId)} retrospectId={retrospectId} title={title} introduction={introduction} />,
+        });
+      } else {
+        // 작성 중인 경우 → 바로 작성 페이지로
+        navigate(PATHS.retrospectWrite(String(targetSpaceId), retrospectId, title, introduction));
+      }
     }
 
     // 마감된 회고 클릭 시

--- a/apps/web/src/app/desktop/component/retrospectWrite/prepare/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectWrite/prepare/index.tsx
@@ -11,8 +11,6 @@ import { useNavigate } from "react-router-dom";
 import { PATHS } from "@layer/shared";
 import { useGetQuestions } from "@/hooks/api/write/useGetQuestions";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
-import { retrospectWriteAtom } from "@/store/retrospect/retrospectWrite";
-import { useSetAtom } from "jotai";
 
 interface PrepareProps {
   spaceId: number;
@@ -26,17 +24,6 @@ export function Prepare({ spaceId, retrospectId, title, introduction }: PrepareP
   const { closeFunnelModal } = useFunnelModal();
   const navigate = useNavigate();
   const { track } = useMixpanel();
-  const setRetrospectWriteValue = useSetAtom(retrospectWriteAtom);
-
-  const handSaveInfo = () => {
-    setRetrospectWriteValue((prev) => ({
-      ...prev,
-      spaceId,
-      retrospectId,
-      title,
-      introduction,
-    }));
-  };
 
   if (isLoading) return <LoadingModal purpose={"회고 작성을 위한 데이터를 가져오고 있어요"} />;
 
@@ -113,7 +100,6 @@ export function Prepare({ spaceId, retrospectId, title, introduction }: PrepareP
           colorSchema={"white"}
           onClick={() => {
             closeFunnelModal();
-            handSaveInfo();
             navigate(PATHS.retrospectWrite(String(spaceId), retrospectId, title, introduction));
             track("WRITE_START", {
               spaceId,

--- a/apps/web/src/store/retrospect/retrospectWrite.ts
+++ b/apps/web/src/store/retrospect/retrospectWrite.ts
@@ -1,9 +1,0 @@
-import { RetrospectWriteType } from "@/types/write";
-import { atom } from "jotai";
-
-export const retrospectWriteAtom = atom<RetrospectWriteType>({
-  spaceId: -1,
-  retrospectId: -1,
-  title: "",
-  introduction: "",
-});


### PR DESCRIPTION
> ### 작성 진입 단계 인터랙션 노출 플로우 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 작성 진입 단계 인터랙션 노출 플로우 수정을 진행했습니다.
- 회고 카드 클릭 시 writeStatus로 분기처리를 진행했습니다
- 기존 불필요하던 retrospectWriteAtom를 제거했습니다.

### 🫨 Describe your Change (변경사항)

-

### 🧐 Issue number and link (참고)

-
### 📚 Reference (참조)

https://github.com/user-attachments/assets/535782c8-025a-4782-9863-080bacb31816


