### PR TITLE
fix: 회고 분석 개인 회고에서 개인팀 토글 노출

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTab.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTab.tsx
@@ -8,7 +8,8 @@ import { useApiGetAnalysis } from "@/hooks/api/analysis/useApiGetAnalysis";
 import { useSearchParams } from "react-router-dom";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { getAnalysisResponse } from "@/hooks/api/retrospect/analysis/useGetAnalysisAnswer";
-import { AnalysisingComp } from "@/component/retrospect/analysis/Analysis";
+import { AnalyzingComp } from "@/component/retrospect/analysis/Analysis";
+import { Spacing } from "@/component/common/Spacing";
 
 type ViewType = "개인" | "팀";
 
@@ -31,6 +32,8 @@ export default function AnalysisTab({ analysisData }: AnalysisTabProps) {
 
   const [selectedView, setSelectedView] = useState<ViewType>("개인");
 
+  const hasTeamAnalysis = analysisRetrospectsData?.teamAnalyze !== null;
+
   const handleToggle = (view: ViewType) => {
     setSelectedView(view);
   };
@@ -40,23 +43,20 @@ export default function AnalysisTab({ analysisData }: AnalysisTabProps) {
   }
 
   if (hasAIAnalyzed == false) {
-    return <AnalysisingComp />;
+    return <AnalyzingComp />;
   }
 
   return (
     <section
       css={css`
         flex: 1;
-        display: flex;
-        flex-direction: column;
-        gap: 2rem;
         overflow-x: auto;
         overflow-y: auto;
         min-height: 80vh;
       `}
     >
-      <TeamIndividualToggle selectedView={selectedView} handleToggle={handleToggle} />
-
+      {hasTeamAnalysis && <TeamIndividualToggle selectedView={selectedView} handleToggle={handleToggle} />}
+      <Spacing size={2} />
       <div
         css={css`
           flex: 1;

--- a/apps/web/src/component/retrospect/analysis/Analysis.tsx
+++ b/apps/web/src/component/retrospect/analysis/Analysis.tsx
@@ -31,7 +31,7 @@ export function AnalysisContainer({ spaceId, retrospectId, hasAIAnalyzed }: Anal
 
   // * 분석이 진행중일 때
   if (hasAIAnalyzed === false) {
-    return <AnalysisingComp />;
+    return <AnalyzingComp />;
   }
 
   return (
@@ -156,7 +156,7 @@ export function AnalysisContainer({ spaceId, retrospectId, hasAIAnalyzed }: Anal
   );
 }
 
-export function AnalysisingComp() {
+export function AnalyzingComp() {
   const { isDesktop } = getDeviceType();
 
   return (


### PR DESCRIPTION
> ### 회고 분석 개인 회고에서 개인팀 토글 노출
---

### 🏄🏼‍♂️‍ Summary (요약)
- 개인 회고에서 개인/팀을 선택할 수 있던 토글이 노출되는 이슈를 수정합니다.

### 🫨 Describe your Change (변경사항)
- `teamAnalyze`가 `null`인 경우 미표기
- `AnalysisingComp` -> `AnalyzingComp`로 네이밍 변경

### 🧐 Issue number and link (참고)
- close #630 
### 📚 Reference (참조)
<img width="1727" height="961" alt="스크린샷 2025-11-02 오후 9 50 25" src="https://github.com/user-attachments/assets/e5f514f4-5f9a-409d-b44b-194cb80d3a53" />
<img width="1728" height="960" alt="스크린샷 2025-11-02 오후 9 50 35" src="https://github.com/user-attachments/assets/b85c8cb6-ab5b-4402-b90a-1af70d31c5f8" />

