### PR TITLE
fix: 스페이스의 회고 템플릿 영역에 긴 문자열이 들어오면 너비가 깨지는 현상 수정

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
@@ -133,11 +133,25 @@ export default function AnalysisOverviewHeader() {
             background-color: ${DESIGN_TOKEN_COLOR.white};
             flex: 1;
             cursor: pointer;
+
+            svg {
+              flex-shrink: 0;
+            }
           `}
           onClick={handleMoveToListTemplate}
         >
           <Icon icon={"ic_document_color"} size={2.0} color={DESIGN_TOKEN_COLOR.gray00} />
-          <Typography variant="body14SemiBold" color="gray600">
+          <Typography
+            variant="body14SemiBold"
+            color="gray600"
+            css={css`
+              display: -webkit-box;
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 1;
+              overflow: hidden;
+            `}
+            title={formTag ?? ""}
+          >
             {formTag}
           </Typography>
           <Icon icon={"ic_chevron_down"} size={1.4} color={DESIGN_TOKEN_COLOR.gray600} />


### PR DESCRIPTION
> ### 스페이스의 회고 템플릿 영역에 긴 문자열이 들어오면 너비가 깨지는 현상 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 스페이스의 회고 템플릿 영역에 긴 문자열이 들어오면 너비가 깨지는 현상을 수정합니다.

### 🫨 Describe your Change (변경사항)
- apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
  - 2줄이 넘으면 `...` 말 줄임 처리를 추가했어요 

### 🧐 Issue number and link (참고)
- closes: #646 

### 📚 Reference (참조)
<img width="348" height="141" alt="스크린샷 2025-11-06 오후 10 17 06" src="https://github.com/user-attachments/assets/33020746-57e7-4689-9cd4-6f98934e9e45" />

- 스크린샷에 나오는 툴팁은 템플릿 원래 이름이 `무제` 라서 그래요!
