### PR TITLE
회고 생성 후, 이전 회고 생성 값이 유지되는 현상 수정 및 회고 리스트 업데이트 적용

### DIFF
--- a/apps/web/src/hooks/api/retrospect/create/usePostRetrospectCreate.ts
+++ b/apps/web/src/hooks/api/retrospect/create/usePostRetrospectCreate.ts
@@ -35,13 +35,14 @@ export const usePostRetrospectCreate = (spaceId?: number) => {
         spaceId: spaceId ?? -1,
       });
 
+      resetRetroCreateData();
+      queryClient.invalidateQueries({
+        queryKey: ["getRetrospects", String(spaceId)],
+      });
+
       if (isMobile) {
         navigate(PATHS.completeRetrospectCreate(), {
           state: { retrospectId, spaceId, title: variables?.body?.title, introduction: variables?.body?.introduction },
-        });
-        resetRetroCreateData();
-        queryClient.invalidateQueries({
-          queryKey: ["getRetrospects", String(spaceId)],
         });
       }
     },


### PR DESCRIPTION
> ### 회고 생성 후, 이전 회고 생성 값이 유지되는 현상 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 회고 생성 후, 이전 회고 생성 값이 유지되는 현상 수정을 진행했습니다.
- 네비게이션에 대한 부분만 조건문 처리
    - 회고 생성 데이터 초기화 적용
    - 회고 생성 시 회고 리스트 업데이트 적용

### 🫨 Describe your Change (변경사항)

- 

### 🧐 Issue number and link (참고)

-
### 📚 Reference (참조)

https://github.com/user-attachments/assets/1414ede2-a6ed-4733-87f6-bebeb67a0610


