### PR TITLE
chore: #652 홈에서 실행목표분석 내 카드 선택시 해당 회고로 이동

### DIFF
--- a/apps/web/src/app/desktop/component/home/ActionItemBox/index.tsx
+++ b/apps/web/src/app/desktop/component/home/ActionItemBox/index.tsx
@@ -1,15 +1,24 @@
+import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { PersonalActionItemType } from "@/types/actionItem";
 import { formatOnlyDate } from "@/utils/date";
 import { css } from "@emotion/react";
+import { PATHS } from "@layer/shared";
+import { useNavigate } from "react-router-dom";
 
 type ActionItemBoxProps = {
   actionItem: PersonalActionItemType;
 };
 
 export default function ActionItemBox({ actionItem }: ActionItemBoxProps) {
-  const { retrospectTitle, spaceName, deadline, actionItemList } = actionItem;
+  const navigate = useNavigate();
+
+  const { retrospectTitle, spaceName, deadline, actionItemList, spaceId, retrospectId } = actionItem;
+
+  const handleRetrospectClick = () => {
+    navigate(PATHS.retrospectAnalysis(String(spaceId), retrospectId, retrospectTitle));
+  };
 
   return (
     <section
@@ -18,24 +27,61 @@ export default function ActionItemBox({ actionItem }: ActionItemBoxProps) {
       `}
     >
       {/* ---------- 회고 제목 ---------- */}
-      <div
+      <section
         css={css`
           display: flex;
-          flex-direction: column;
-          gap: 0.4rem;
+          align-items: center;
           background-color: ${DESIGN_TOKEN_COLOR.gray100};
           padding: 1.6rem;
           border-radius: 0.8rem;
-          flex: 1;
         `}
       >
-        <Typography variant="title16Bold" color="gray900">
-          {retrospectTitle}
-        </Typography>
-        <Typography variant="body14Medium" color="gray500">
-          {spaceName} | 회고 마감일 {deadline ? formatOnlyDate(deadline) : "없음"}
-        </Typography>
-      </div>
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+            flex: 1;
+            min-width: 0;
+          `}
+        >
+          <Typography variant="title16Bold" color="gray900">
+            {retrospectTitle}
+          </Typography>
+          <Typography
+            variant="body14Medium"
+            color="gray500"
+            css={css`
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            `}
+          >
+            {spaceName} | 회고 마감일 {deadline ? formatOnlyDate(deadline) : "없음"}
+          </Typography>
+        </div>
+        <div
+          css={css`
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 2.4rem;
+            height: 2.4rem;
+            border-radius: 50%;
+            cursor: pointer;
+            flex-shrink: 0;
+
+            transition: background-color 0.2s ease-in-out;
+
+            &:hover {
+              background-color: ${DESIGN_TOKEN_COLOR.gray300};
+            }
+          `}
+          onClick={handleRetrospectClick}
+        >
+          <Icon icon="ic_after" size={1.2} color={DESIGN_TOKEN_COLOR.gray800} />
+        </div>
+      </section>
 
       {/* ---------- 실행목표 리스트 ---------- */}
       {actionItemList && actionItemList.length > 0 ? (


### PR DESCRIPTION
> ### 홈화면 실행목표 분석 클릭 시, 회고 이동 적용
---

### 🏄🏼‍♂️‍ Summary (요약)
- 홈화면에서 실행목표 섹션에 특정 회고를 클릭 시, 해당 회고 분석 페이지로 이동합니다.

### 🫨 Describe your Change (변경사항)
- 화살표 아이콘 추가 요청 반영
- 회고 분석 페이지로 이동

### 🧐 Issue number and link (참고)
- close #652

### 📚 Reference (참조)

https://github.com/user-attachments/assets/c14d2433-7f63-4e33-b05c-e04b7ee61c47


