### PR TITLE
chore: 스페이스 항목에 카테고리 속성 표기 추가

### DIFF
--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpaceItem.tsx
@@ -177,7 +177,7 @@ export default function SpaceItem({ space }: SpaceItemProps) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { isCollapsed } = useNavigation();
-  const { id: spaceId, name, leader } = space;
+  const { id: spaceId, name, leader, category } = space;
   const isLeader = isSpaceLeader(leader?.id);
 
   const [currentSpace, setCurrentSpace] = useAtom(currentSpaceState);
@@ -243,9 +243,21 @@ export default function SpaceItem({ space }: SpaceItemProps) {
                 gap: 0.1rem;
               `}
             >
-              <Typography variant="caption10Medium" color="gray500">
-                스페이스
-              </Typography>
+              <div
+                css={css`
+                  display: flex;
+                  align-items: center;
+                  gap: 0.2rem;
+                `}
+              >
+                <Typography variant="caption10Medium" color="gray500">
+                  {category === "INDIVIDUAL" && "개인"}
+                  {category === "TEAM" && "팀"}
+                </Typography>
+                <Typography variant="caption10Medium" color="gray500">
+                  스페이스
+                </Typography>
+              </div>
               <Typography variant="body12Strong" color="gray00">
                 {name}
               </Typography>


### PR DESCRIPTION
> ### 툴팁에 스페이스의 카테고리 표기 작업
---

### 🏄🏼‍♂️‍ Summary (요약)
- hover 했을 때, 나타내는 툴팁에 스페이스가 `팀`인지 `개인`인지 구분이 가능하도록 카테고리를 추가했습니다.

### 🫨 Describe your Change (변경사항)
- 카테고리 추가

### 🧐 Issue number and link (참고)
- close #660 

### 📚 Reference (참조)

<img width="197" height="321" alt="image" src="https://github.com/user-attachments/assets/782b21a2-4abd-4ae0-838b-f3d2f2527517" />

