### PR TITLE
fix: 회고 스페이스 '진행 중' 오탈자 수정

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/ActionItems.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/ActionItems.tsx
@@ -8,9 +8,9 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { useApiOptionsGetTeamActionItemList } from "@/hooks/api/actionItem/useApiOptionsGetTeamActionItemList";
 import ActionItemCard from "@/component/retrospect/space/actionItems/ActionItemCard";
 
-type TabType = "진행중" | "지난";
+type TabType = "진행 중" | "지난";
 
-const ACTION_ITEMS_TAB_NAMES = ["진행중", "지난"] as const;
+const ACTION_ITEMS_TAB_NAMES = ["진행 중", "지난"] as const;
 
 const ActionItemsContext = createContext<{
   currentTab: TabType;
@@ -24,7 +24,7 @@ const useActionItemsContext = () => {
 };
 
 function ActionItems({ children }: { children: ReactNode }) {
-  const [currentTab, setCurrentTab] = useState<TabType>("진행중");
+  const [currentTab, setCurrentTab] = useState<TabType>("진행 중");
 
   return (
     <ActionItemsContext.Provider value={{ currentTab, setCurrentTab }}>
@@ -101,7 +101,7 @@ function List() {
 
   const inProgressActionItems = data?.teamActionItemList.filter((goal) => goal.status === "PROCEEDING");
   const doneActionItems = data?.teamActionItemList.filter((goal) => goal.status === "DONE");
-  const currentActionItems = currentTab === "진행중" ? inProgressActionItems : doneActionItems;
+  const currentActionItems = currentTab === "진행 중" ? inProgressActionItems : doneActionItems;
 
   return (
     <div

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -14,7 +14,7 @@ export default function AnalysisOverview({ spaceId }: AnalysisOverviewProps) {
   // * 스페이스 회고 목록 조회
   const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId || undefined));
 
-  // * 진행중인 회고 필터링
+  // * 진행 중인 회고 필터링
   const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);
 
   // * 마감된 회고 필터링
@@ -41,10 +41,10 @@ export default function AnalysisOverview({ spaceId }: AnalysisOverviewProps) {
         `}
       >
         <RetrospectSection
-          title="진행중인 회고"
+          title="진행 중인 회고"
           isPending={isRetrospectsPending}
           retrospects={proceedingRetrospects}
-          emptyMessage={`진행중인 회고가 비어있어요 \n 회고를 작성해 보세요!`}
+          emptyMessage={`진행 중인 회고가 비어있어요 \n 회고를 작성해 보세요!`}
           spaceId={spaceId}
           needRetrospectAddButton
           enableScroll={false}

--- a/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
@@ -60,7 +60,7 @@ export default function ActionItemsWrapper() {
           실행목표
         </Typography>
         <Typography variant="body15SemiBold" color="gray800">
-          {myActionItems?.length ?? 0}개의 실행목표가 진행중이에요
+          {myActionItems?.length ?? 0}개의 실행목표가 진행 중이에요
         </Typography>
       </section>
 

--- a/apps/web/src/app/desktop/component/home/AnalyticsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/AnalyticsWrapper/index.tsx
@@ -115,7 +115,7 @@ export default function AnalyticsWrapper() {
           분석
         </Typography>
         <Typography variant="body15SemiBold" color="gray800">
-          {myAnalysis?.recentAnalyzes.length ?? 0}개의 회고가 진행중이에요!
+          {myAnalysis?.recentAnalyzes.length ?? 0}개의 회고가 진행 중이에요!
         </Typography>
       </section>
 

--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -39,7 +39,7 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
   const isSelected = urlRetrospectId && parseInt(urlRetrospectId) === retrospectId;
 
   const handleCardClick = () => {
-    // 진행중인 회고 클릭 시
+    // 진행 중인 회고 클릭 시
     if (targetSpaceId && retrospectStatus === "PROCEEDING") {
       if (writeStatus === "NOT_STARTED") {
         // 아직 시작 안 한 경우 → 시작 화면 모달

--- a/apps/web/src/app/mobile/space/SpaceViewPage.tsx
+++ b/apps/web/src/app/mobile/space/SpaceViewPage.tsx
@@ -176,7 +176,7 @@ export function SpaceViewPage() {
               gap: 0.6rem;
             `}
           >
-            <Typography variant="title18Bold">진행중인 회고</Typography>
+            <Typography variant="title18Bold">진행 중인 회고</Typography>
             <Typography variant="title16Bold" color="gray600">
               {proceedingRetrospects?.length}
             </Typography>

--- a/apps/web/src/component/retrospect/analysis/Analysis.tsx
+++ b/apps/web/src/component/retrospect/analysis/Analysis.tsx
@@ -29,7 +29,7 @@ export function AnalysisContainer({ spaceId, retrospectId, hasAIAnalyzed }: Anal
     return <LoadingModal />;
   }
 
-  // * 분석이 진행중일 때
+  // * 분석이 진행 중일 때
   if (hasAIAnalyzed === false) {
     return <AnalyzingComp />;
   }

--- a/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
@@ -82,7 +82,7 @@ export default function InProgressRetrospects() {
         min-width: 30rem;
       `}
     >
-      <Typography variant="title16Bold">진행중인 회고 {proceedingRetrospects.length}</Typography>
+      <Typography variant="title16Bold">진행 중인 회고 {proceedingRetrospects.length}</Typography>
 
       {proceedingRetrospects.length === 0 ? (
         <div
@@ -101,7 +101,7 @@ export default function InProgressRetrospects() {
         >
           <Icon icon="ic_new_clock" size={7.2} color={DESIGN_TOKEN_COLOR.gray500} />
           <Typography variant="body16Medium" color="gray500">
-            진행중인 회고가 비어있어요 <br />
+            진행 중인 회고가 비어있어요 <br />
             회고를 작성해 보세요!
           </Typography>
           <button

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItems.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItems.tsx
@@ -10,11 +10,11 @@ import ActionItemsList from "./ActionItemsList";
 import ActionItemsTooltip from "./ActionItemsTooltip";
 
 interface ActionItemsProps {
-  currentTab: "진행중" | "지난";
+  currentTab: "진행 중" | "지난";
 }
 
 export default function ActionItems() {
-  const [currentTab, setCurrentTab] = useState<ActionItemsProps["currentTab"]>("진행중");
+  const [currentTab, setCurrentTab] = useState<ActionItemsProps["currentTab"]>("진행 중");
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
   const handleCurrentTabClick = (tab: ActionItemsProps["currentTab"]) => {

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
@@ -10,7 +10,7 @@ import { useApiOptionsGetTeamActionItemList } from "@/hooks/api/actionItem/useAp
 import ActionItemCard from "./ActionItemCard";
 
 type ActionItemsListProps = {
-  currentTab: "진행중" | "지난";
+  currentTab: "진행 중" | "지난";
 };
 
 export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
@@ -22,7 +22,7 @@ export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
 
   const inProgressActionItems = data?.teamActionItemList.filter((goal) => goal.status === "PROCEEDING");
   const doneActionItems = data?.teamActionItemList.filter((goal) => goal.status === "DONE");
-  const currentActionItems = currentTab === "진행중" ? inProgressActionItems : doneActionItems;
+  const currentActionItems = currentTab === "진행 중" ? inProgressActionItems : doneActionItems;
 
   return (
     <section

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsTab.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsTab.tsx
@@ -3,11 +3,11 @@ import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
 type ActionItemsTabProps = {
-  currentTab: "진행중" | "지난";
-  handleCurrentTabClick: (tab: "진행중" | "지난") => void;
+  currentTab: "진행 중" | "지난";
+  handleCurrentTabClick: (tab: "진행 중" | "지난") => void;
 };
 
-const ACTION_ITEMS_TAB_NAMES = ["진행중", "지난"] as const;
+const ACTION_ITEMS_TAB_NAMES = ["진행 중", "지난"] as const;
 
 export default function ActionItemsTab({ currentTab, handleCurrentTabClick }: ActionItemsTabProps) {
   return (

--- a/apps/web/src/component/space/view/EmptyRetrospect.tsx
+++ b/apps/web/src/component/space/view/EmptyRetrospect.tsx
@@ -23,7 +23,7 @@ export function EmptyRetrospect() {
         `}
       >
         <Typography variant="body16Medium" color="gray500">
-          진행중인 회고가 비어있어요 <br />
+          진행 중인 회고가 비어있어요 <br />
           회고를 작성해 보세요!
         </Typography>
       </div>


### PR DESCRIPTION
> ### 회고 스페이스 '진행 중' 오탈자 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 회고 스페이스 '진행 중' 오탈자 수정을 진행했어요

### 🫨 Describe your Change (변경사항)
- apps/web/src/app/desktop/component/analysis/AnalysisOverview/ActionItems.tsx
apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
apps/web/src/app/desktop/component/home/AnalyticsWrapper/index.tsx
apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
apps/web/src/app/mobile/space/SpaceViewPage.tsxapps/web/src/component/retrospect/analysis/Analysis.tsx
apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
apps/web/src/component/retrospect/space/actionItems/ActionItems.tsx
apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
apps/web/src/component/retrospect/space/actionItems/ActionItemsTab.tsx
apps/web/src/component/space/view/EmptyRetrospect.tsx
  - '진행중' 텍스트를 모두 '진행 중' 텍스트로 일괄 수정

### 🧐 Issue number and link (참고)
- #692 
