### PR TITLE
feat: 스페이스 · 회고 생성 시, 초기 자동 생성 회고명 시안 반영

### DIFF
--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -37,6 +37,7 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
 
   const urlRetrospectId = searchParams.get("retrospectId");
   const isSelected = urlRetrospectId && parseInt(urlRetrospectId) === retrospectId;
+  const isIntroduction = introduction?.trim();
 
   const handleCardClick = () => {
     // 진행 중인 회고 클릭 시
@@ -68,7 +69,8 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
         display: flex;
         flex-direction: column;
         width: 29.6rem;
-        height: 13.8rem;
+        height: fit-content;
+        max-height: 13.8rem;
         padding: 1.6rem;
         background-color: white;
         border-radius: 1.2rem;
@@ -104,25 +106,26 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
       </Typography>
 
       {/* ---------- 설명 ----------*/}
-      <div
-        css={css`
-          margin-top: 0.8rem;
-          flex: 1;
-        `}
-      >
-        <Typography
-          variant="body12SemiBold"
-          color="gray800"
+      {isIntroduction && (
+        <div
           css={css`
-            display: block;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+            margin-top: 0.4rem;
           `}
         >
-          {introduction}
-        </Typography>
-      </div>
+          <Typography
+            variant="body12SemiBold"
+            color="gray800"
+            css={css`
+              display: block;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            `}
+          >
+            {introduction}
+          </Typography>
+        </div>
+      )}
 
       {/* ---------- 하단 정보 ---------- */}
       <div
@@ -130,6 +133,7 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
           display: flex;
           justify-content: space-between;
           align-items: center;
+          margin-top: 0.8rem;
         `}
       >
         <Typography variant="body12SemiBold" color="gray500">

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -830,8 +830,8 @@ function CreateRetrospectDeadlineFunnel() {
 
     const createRetrospect = async (spaceId: number) => {
       const params = {
-        title: selectedRecommendTemplate!.title || `${title} 스페이스의 회고`,
-        introduction: selectedRecommendTemplate!.title || `${title} 스페이스의 회고`,
+        title: `${title}의 첫번째 회고`,
+        introduction: "",
         questions: [...DEFAULT_QUESTIONS, ...questions],
         deadline: deadLine,
         isNewForm: false,


### PR DESCRIPTION
> ### 스페이스 · 회고 생성 시, 초기 자동 생성 회고명 시안 반영
---

### 🏄🏼‍♂️‍ Summary (요약)
- 스페이스 · 회고 생성 시, 초기 자동 생성 회고명 시안 반영을 진행합니다.

### 🫨 Describe your Change (변경사항)
- apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
  - 회고 카드의 설명이 없을 때의 스타일 반영
- apps/web/src/app/desktop/space/add/AddSpacePage.tsx
  - 스페이스 ·회고 생성 시, 초기 자동 생성 회고명을 시안에 맞게 반영 진행  

### 🧐 Issue number and link (참고)
- #692 

### 📚 Reference (참조)
<img width="926" height="624" alt="image" src="https://github.com/user-attachments/assets/7cd25cfc-bfb1-43f9-8c45-416e967b801e" />