### PR TITLE
feat: 스페이스 · 회고 생성 시, 택일 질문 버튼이 미리 선택되지 않도록 스펙 개선

### DIFF
--- a/apps/web/src/store/space/spaceAtom.ts
+++ b/apps/web/src/store/space/spaceAtom.ts
@@ -26,8 +26,9 @@ const CREATE_SPACE_INIT_DESCRIPTION = atomWithReset<string>("");
 const CREATE_SPACE_INIT_PHASE = atomWithReset<number>(0);
 const CREATE_SPACE_INIT_PURPOSE = atomWithReset<string>("");
 const CREATE_SPACE_INIT_PERIOD = atomWithReset<string | null>(null);
-const CREATE_SPACE_INIT_PERIODIC = atomWithReset<"REGULAR" | "IRREGULAR">("REGULAR");
-const CREATE_SPACE_INIT_CATEGORY = atomWithReset<ProjectType>(ProjectType.Individual);
+const CREATE_SPACE_INIT_PERIODIC = atomWithReset<"REGULAR" | "IRREGULAR" | null>(null);
+const CREATE_SPACE_INIT_CATEGORY = atomWithReset<ProjectType | null>(null);
+const CREATE_SPACE_INIT_RECOMMEND_TEMPLATE_TYPE = atomWithReset<"recommendation" | "list" | null>(null);
 
 export const CREATE_SPACE_INIT_ATOM = {
   flow: CREATE_SPACE_INIT_FLOW,
@@ -38,6 +39,7 @@ export const CREATE_SPACE_INIT_ATOM = {
   period: CREATE_SPACE_INIT_PERIOD,
   periodic: CREATE_SPACE_INIT_PERIODIC,
   category: CREATE_SPACE_INIT_CATEGORY,
+  recommendTemplateType: CREATE_SPACE_INIT_RECOMMEND_TEMPLATE_TYPE,
 };
 
 // * 현재 선택된 스페이스 전역 상태


### PR DESCRIPTION
> ### 스페이스 · 회고 생성 시, 택일 질문 버튼이 미리 선택되지 않도록 스펙 개선
---

### 🏄🏼‍♂️‍ Summary (요약)
- 스페이스 · 회고 생성 시, 택일 질문 버튼이 미리 선택되지 않도록 스펙 개선을 진행합니다.

### Describe your Change (변경사항)
- apps/web/src/app/desktop/space/add/AddSpacePage.tsx
apps/web/src/store/space/spaceAtom.ts
  - 택일 질문의 `default` 값들을 `null`로 변경하는 작업을 진행했습니다.

### 🧐 Issue number and link (참고)
- #691 

### 📚 Reference (참조)
<img width="974" height="574" alt="image" src="https://github.com/user-attachments/assets/40a20116-baa7-4d90-a522-a3fac961c4db" />