### PR TITLE
fix: 스페이스의 내 회고 분석 결과 목표 달성률 튤팁 위치 수정

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualContents.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualContents.tsx
@@ -11,7 +11,6 @@ import { useSatisfactionData } from "@/hooks/useSatisfactionData";
 const EMOTIONS: IconType[] = ["ic_very_poor", "ic_poor", "ic_commonly", "ic_good", "ic_very_good"];
 
 const INDEX_OFFSET = 1; // 0-based index로 변환하기 위한 오프셋
-const PADDING_SUM = 8;
 
 type AnalysisIndividualContentsProps = {
   individualAnalysis?: IndividualAnalyzeType;
@@ -179,8 +178,8 @@ export default function AnalysisIndividualContents({ individualAnalysis }: Analy
                   css={css`
                     position: absolute;
                     top: -5rem;
-                    left: ${individualAnalysis.goalCompletionRate - PADDING_SUM}%; /* 비율에 따라 동적 위치 */
-                    transform: translateX(-50%); /* 중앙 정렬 */
+                    left: calc(6rem + ((100% - 12rem) * ${individualAnalysis.goalCompletionRate} / 100));
+                    transform: translateX(-50%);
                     background-color: white;
                     border-radius: 1.6rem;
                     padding: 0.4rem 0.8rem;


### PR DESCRIPTION
> ### 말풍선 위치 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 계산 로직이 정확하지 않았고, 이를 수정하여 정확한 위치에 툴팁이 오도록 수정했습니다.

### 🫨 Describe your Change (변경사항)
- left 계산값 방식 수정

### 🧐 Issue number and link (참고)
- close #694

### 📚 Reference (참조)
<img width="605" height="234" alt="image" src="https://github.com/user-attachments/assets/9150d41c-c58c-4131-bb0b-b4b0c7c937d5" />

