### PR TITLE
fix: #701 실행목표 편집 모달에서 뒤로가기 버튼 필요 여부 수정

### DIFF
--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
@@ -59,7 +59,7 @@ export default function ActionItemManageToggleMenu({
       onClose: close,
       options: {
         enableFooter: false,
-        needsBackButton: true,
+        needsBackButton: false,
         backButtonCallback: () => close(),
       },
     });


### PR DESCRIPTION
> ### 실행목표 편집 모달에서 뒤로가기 버튼 제거
---

### 🏄🏼‍♂️‍ Summary (요약)
- 실행목표 편집 모달에서 뒤로가기 버튼 제거

### 🫨 Describe your Change (변경사항)
- 실행목표 편집 모달에서 뒤로가기 버튼 제거

### 🧐 Issue number and link (참고)
- close #701

### 📚 Reference (참조)
<img width="1415" height="917" alt="image" src="https://github.com/user-attachments/assets/0bd98c53-2b45-41c9-941a-1a08eefb9e0f" />

