### PR TITLE
fix: 추가 선택 시, 선택한 목록과 드롭다운의 목록이 다른 이슈

### DIFF
--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
@@ -14,10 +14,11 @@ import { useToast } from "@/hooks/useToast";
 
 type ActionItemAddSectionProps = {
   spaceId: string;
+  retrospectId: number;
   onClose: () => void;
 };
 
-export default function ActionItemAddSection({ spaceId, onClose }: ActionItemAddSectionProps) {
+export default function ActionItemAddSection({ spaceId, retrospectId, onClose }: ActionItemAddSectionProps) {
   const queryClient = useQueryClient();
 
   const { toast } = useToast();
@@ -116,9 +117,10 @@ export default function ActionItemAddSection({ spaceId, onClose }: ActionItemAdd
 
   useEffect(() => {
     if (completedRetrospects.length > 0 && !selectedRetrospect) {
-      setSelectedRetrospect(completedRetrospects[0]);
+      const initialRetrospect = completedRetrospects.find((option) => option.retrospectId === retrospectId);
+      setSelectedRetrospect(initialRetrospect || completedRetrospects[0]);
     }
-  }, [completedRetrospects, selectedRetrospect]);
+  }, [completedRetrospects, selectedRetrospect, retrospectId]);
 
   return (
     <>

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
@@ -49,7 +49,7 @@ export default function ActionItemCard({ spaceId, retrospectId, title, todoList,
   const handleAddActionItem = () => {
     openDesktopModal({
       title: "실행목표 추가",
-      contents: <ActionItemAddSection spaceId={spaceId} onClose={close} />,
+      contents: <ActionItemAddSection spaceId={spaceId} retrospectId={retrospectId} onClose={close} />,
       onClose: close,
       options: {
         enableFooter: false,


### PR DESCRIPTION
> ### 추가 선택 시, 선택한 목록과 드롭다운의 목록이 다른 이슈
---

### 🏄🏼‍♂️‍ Summary (요약)
- 추가 선택한 회고가 첫 번째 드롭다운 옵션으로 뜨도록 수정했습니다.

### 🫨 Describe your Change (변경사항)
- `ActionItemAddSection`에 `retrospectId` prop 추가 및 초기 선택 로직 수정

### 🧐 Issue number and link (참고)
- close #708

### 📚 Reference (참조)

https://github.com/user-attachments/assets/90f9d764-c04f-4fff-84e2-d992550107cb


