### PR TITLE
chore: 실행목표 수정 api 변경사항 적용

### DIFF
--- a/apps/web/src/hooks/api/actionItem/usePatchActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/usePatchActionItemList.ts
@@ -2,10 +2,16 @@ import { useMutation } from "@tanstack/react-query";
 
 import { api } from "@/api";
 
+/**
+ * retrospectId에 해당하는 실행목표 리스트를 수정하는 API
+ *
+ * @param retrospectId 회고 ID (새로 추가한 실행목표인 경우, id 없이 보냅니다.)
+ * @param actionItems 실행목표 리스트
+ */
 export type retrospectIdProps = {
   retrospectId: number;
   actionItems: {
-    id: number;
+    id?: number;
     content: string;
   }[];
 };


### PR DESCRIPTION
> ### 실행목표 수정 api 변경사항 적용
---

### 🏄🏼‍♂️‍ Summary (요약)
- 실행목표 수정 모달에서 새로운 실행목표를 생성할 때, id를 없이 보내도록 수정합니다.

### 🫨 Describe your Change (변경사항)
- `usePatchActionItemList` type 수정 

### 🧐 Issue number and link (참고)
- close #724 

### 📚 Reference (참조)

https://github.com/user-attachments/assets/c778271e-5c03-4dcc-9c63-d1ef30f43c49


