### PR TITLE
#729 팀원 확인 드롭다운 열림 시 화살표 아이콘이 위로 회전하도록 개선

### DIFF
--- a/apps/web/src/component/retrospect/space/members/MemberManagement.tsx
+++ b/apps/web/src/component/retrospect/space/members/MemberManagement.tsx
@@ -155,7 +155,7 @@ export default function MemberManagement({ spaceId }: { spaceId: string }) {
         display: inline-block;
       `}
     >
-      <MemberManagementButton onClick={handleClick} memberCount={memberCount} />
+      <MemberManagementButton onClick={handleClick} memberCount={memberCount} isOpen={isOpen} />
 
       {isOpen && (
         <MemberManagementDropdown>

--- a/apps/web/src/component/retrospect/space/members/MemberManagementButton.tsx
+++ b/apps/web/src/component/retrospect/space/members/MemberManagementButton.tsx
@@ -7,9 +7,10 @@ import { css } from "@emotion/react";
 interface MemberManagementButtonProps {
   onClick: (e: React.MouseEvent) => void;
   memberCount?: number;
+  isOpen?: boolean;
 }
 
-export function MemberManagementButton({ onClick, memberCount }: MemberManagementButtonProps) {
+export function MemberManagementButton({ onClick, memberCount, isOpen = false }: MemberManagementButtonProps) {
   return (
     <div
       onClick={onClick}
@@ -29,7 +30,15 @@ export function MemberManagementButton({ onClick, memberCount }: MemberManagemen
       <Typography variant="body14SemiBold" color="gray600">
         {memberCount}
       </Typography>
-      <Icon icon={"ic_chevron_down"} size={1.6} color={DESIGN_TOKEN_COLOR.gray600} />
+      <Icon
+        icon={"ic_chevron_down"}
+        size={1.6}
+        color={DESIGN_TOKEN_COLOR.gray600}
+        css={css`
+          transform: rotate(${isOpen ? "180deg" : "0deg"});
+          transition: transform 0.2s ease;
+        `}
+      />
     </div>
   );
 }


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)
팀원 확인 드롭다운 열림 시 화살표 아이콘이 위로 회전하도록 개선 했습니다.

### 🧐 Issue number and link (참고)
#728 

### 📚 Reference (참조)
https://github.com/user-attachments/assets/db9f0574-d60b-4cf3-b3d5-3cbb5ff853e4

