### PR TITLE
feat: 회고 분석 화면에서 전체 및 개별 질문 스크롤 개선

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualTab.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualTab.tsx
@@ -14,11 +14,38 @@ export default function AnalysisIndividualTab({ individuals }: AnalysisIndividua
 
     switch (questionType) {
       case "number":
-        return <CSatisfactionTemplate key={index} question={questionContent} index={parseInt(answerContent)} />;
+        return (
+          <CSatisfactionTemplate
+            key={index}
+            question={questionContent}
+            index={parseInt(answerContent)}
+            customCss={css`
+              margin-top: 0;
+            `}
+          />
+        );
       case "range":
-        return <CAchievementTemplate key={index} question={questionContent} index={parseInt(answerContent)} />;
+        return (
+          <CAchievementTemplate
+            key={index}
+            question={questionContent}
+            index={parseInt(answerContent)}
+            customCss={css`
+              margin-top: 0;
+            `}
+          />
+        );
       case "plain_text":
-        return <CDescriptiveTemplate key={index} question={questionContent} answer={answerContent} />;
+        return (
+          <CDescriptiveTemplate
+            key={index}
+            question={questionContent}
+            answer={answerContent}
+            customCss={css`
+              margin-top: 0;
+            `}
+          />
+        );
       default:
         return null;
     }
@@ -32,7 +59,7 @@ export default function AnalysisIndividualTab({ individuals }: AnalysisIndividua
           display: flex;
           justify-content: center;
           align-items: center;
-          min-height: 80vh;
+          min-height: 80dvh;
         `}
       >
         <Typography variant="title20Bold" color="gray500">
@@ -49,8 +76,10 @@ export default function AnalysisIndividualTab({ individuals }: AnalysisIndividua
         display: flex;
         gap: 2rem;
         overflow-x: auto;
-        overflow-y: auto;
-        min-height: 80vh;
+        height: calc(100% - 12.8rem);
+        padding-top: 2rem;
+        scroll-behavior: smooth;
+        scroll-snap-type: x mandatory;
       `}
     >
       {individuals.map((individual: IndividualsType, individualIndex: number) => (
@@ -62,17 +91,32 @@ export default function AnalysisIndividualTab({ individuals }: AnalysisIndividua
             height: 100%;
             background-color: ${DESIGN_TOKEN_COLOR.gray100};
             border-radius: 1.2rem;
-            margin-top: 2rem;
-            padding: 2rem 1.6rem;
+            padding-inline: 1.6rem;
+            padding-top: 2rem;
+            padding-bottom: 2rem;
+            box-sizing: border-box;
           `}
         >
           <Typography variant="body15Normal" color="gray900">
             {individual.name}
           </Typography>
-
-          {individual.answers.map((answer, index) => (
-            <article key={index}>{renderQuestionComponent(answer, index)}</article>
-          ))}
+          <div
+            css={css`
+              overflow-y: auto;
+              height: 100%;
+              display: flex;
+              flex-direction: column;
+              row-gap: 1.6rem;
+              padding-top: 2rem;
+              padding-bottom: 2rem;
+              scroll-behavior: smooth;
+              scroll-snap-type: y mandatory;
+            `}
+          >
+            {individual.answers.map((answer, index) => (
+              <article key={index}>{renderQuestionComponent(answer, index)}</article>
+            ))}
+          </div>
         </article>
       ))}
     </section>

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisQuestionsTab.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisQuestionsTab.tsx
@@ -17,11 +17,41 @@ export default function AnalysisQuestionsTab({ questions }: AnalysisQuestionsTab
 
       switch (questionType) {
         case "number":
-          return <CSatisfactionTemplate key={index} name={name} index={parseInt(answerContent)} />;
+          return (
+            <CSatisfactionTemplate
+              key={index}
+              name={name}
+              index={parseInt(answerContent)}
+              customCss={css`
+                margin-top: 0;
+                min-height: initial;
+              `}
+            />
+          );
         case "range":
-          return <CAchievementTemplate key={index} name={name} index={parseInt(answerContent)} />;
+          return (
+            <CAchievementTemplate
+              key={index}
+              name={name}
+              index={parseInt(answerContent)}
+              customCss={css`
+                margin-top: 0;
+                min-height: initial;
+              `}
+            />
+          );
         case "plain_text":
-          return <CDescriptiveTemplate key={index} name={name} answer={answerContent} />;
+          return (
+            <CDescriptiveTemplate
+              key={index}
+              name={name}
+              answer={answerContent}
+              customCss={css`
+                margin-top: 0;
+                min-height: initial;
+              `}
+            />
+          );
         default:
           return null;
       }
@@ -36,7 +66,7 @@ export default function AnalysisQuestionsTab({ questions }: AnalysisQuestionsTab
           display: flex;
           justify-content: center;
           align-items: center;
-          min-height: 80vh;
+          min-height: 80dvh;
         `}
       >
         <Typography variant="title20Bold" color="gray500">
@@ -53,8 +83,10 @@ export default function AnalysisQuestionsTab({ questions }: AnalysisQuestionsTab
         display: flex;
         gap: 2rem;
         overflow-x: auto;
-        overflow-y: auto;
-        min-height: 80vh;
+        height: calc(100% - 12.8rem);
+        padding-top: 2rem;
+        scroll-behavior: smooth;
+        scroll-snap-type: x mandatory;
       `}
     >
       {questions.map((question: QuestionsType, questionIndex: number) => (
@@ -66,15 +98,30 @@ export default function AnalysisQuestionsTab({ questions }: AnalysisQuestionsTab
             height: 100%;
             background-color: ${DESIGN_TOKEN_COLOR.gray100};
             border-radius: 1.2rem;
-            margin-top: 2rem;
-            padding: 2rem 1.6rem;
+            padding-inline: 1.6rem;
+            padding-top: 2rem;
+            padding-bottom: 2rem;
+            box-sizing: border-box;
           `}
         >
           <Typography variant="body15Normal" color="gray900">
             {question.questionContent}
           </Typography>
-
-          <article>{renderQuestionComponent(question)}</article>
+          <article
+            css={css`
+              overflow-y: auto;
+              height: 100%;
+              display: flex;
+              flex-direction: column;
+              row-gap: 1.6rem;
+              padding-top: 2rem;
+              padding-bottom: 2rem;
+              scroll-behavior: smooth;
+              scroll-snap-type: y mandatory;
+            `}
+          >
+            {renderQuestionComponent(question)}
+          </article>
         </article>
       ))}
     </section>

--- a/apps/web/src/component/write/template/complete/Descriptive.tsx
+++ b/apps/web/src/component/write/template/complete/Descriptive.tsx
@@ -1,4 +1,4 @@
-import { css } from "@emotion/react";
+import { css, SerializedStyles } from "@emotion/react";
 
 import { ResultContainer } from "@/component/write/template/complete/ResultContainer.tsx";
 import { getDeviceType } from "@/utils/deviceUtils";
@@ -8,11 +8,11 @@ type DescriptiveTemplateProps =
   | { question: string; name?: never; answer: string }
   | { question?: never; name?: never; answer: string };
 
-export function CDescriptiveTemplate({ name, question, answer }: DescriptiveTemplateProps) {
+export function CDescriptiveTemplate({ name, question, answer, customCss }: DescriptiveTemplateProps & { customCss?: SerializedStyles }) {
   const { isDesktop, isMobile } = getDeviceType();
 
   return (
-    <ResultContainer question={question} name={name}>
+    <ResultContainer question={question} name={name} css={customCss}>
       {/*  FIXME: SPACE 컴포넌트 넣기 */}
       <div
         css={css`


### PR DESCRIPTION
> ### 회고 분석 화면에서 전체 및 개별 질문 스크롤 개선
---

### 🏄🏼‍♂️‍ Summary (요약)
- 회고 분석 화면에서 전체 및 개별 질문에 대한 스크롤 개선 (Y축, X축)

### 🫨 Describe your Change (변경사항)
- apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisIndividualTab.tsx
  - 질문 탭의 세로 스크롤 처리 개선
- apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisQuestionsTab.tsx
  - 개별 탭의 세로 스크롤 처리 개선

### 🧐 Issue number and link (참고)
- #743 

### 📚 Reference (참조)
![화면 기록 2025-12-28 오후 4 17 58](https://github.com/user-attachments/assets/5207a6e2-df75-46b7-a071-f8501fe1178c)

