### PR TITLE
fix: #748 회고 카드의 마감 안내 메시지 개선

### DIFF
--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -138,7 +138,7 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
         `}
       >
         <Typography variant="body12SemiBold" color="gray500">
-          {deadline ? `마감 예정 | ${formatDateAndTime(deadline)}` : "모든 인원 제출 시 마감"}
+          {deadline ? `${retrospectStatus === "DONE" ? "마감일" : "마감 예정"} | ${formatDateAndTime(deadline)}` : "모든 인원 제출 시 마감"}
         </Typography>
 
         <div


### PR DESCRIPTION
> ### 마감 안내 메시지 수정 - 마감일이 없을 경우 모든 인원 제출 시 마감으로 변경
---

### 🏄🏼‍♂️‍ Summary (요약)

- 회고 카드의 마감일에 대한 UX writing을 개선합니다.

### 🫨 Describe your Change (변경사항)

- 마감일 없는 카드 마감명 → 모든 인원 제출 시 마감 
- 마감 완료된 카드 마감명 → 마감일 | {마감날짜} 

### 🧐 Issue number and link (참고)
- close #748 

### 📚 Reference (참조)

<img width="308" height="133" alt="image" src="https://github.com/user-attachments/assets/8bfe5b99-7a47-4589-bcbb-8e88bba56fb9" />

<img width="326" height="182" alt="image" src="https://github.com/user-attachments/assets/c1d2987d-7819-4d9e-83cc-d655a16b6a68" />
