### PR TITLE
fix: #764 메인 페이지 분석 요약 박스에서 포인트 표시 로직 수정

### DIFF
--- a/apps/web/src/app/desktop/component/home/AnalyticsBox/AnalyticsSummaryBox.tsx
+++ b/apps/web/src/app/desktop/component/home/AnalyticsBox/AnalyticsSummaryBox.tsx
@@ -18,6 +18,19 @@ export default function AnalyticsSummaryBox({ type, analysis }: AnalyticsSummary
 
   const config = getAnalysisConfig(type);
 
+  const getPointByType = () => {
+    if ("goodPoint" in analysis) {
+      return analysis.goodPoint || "없음";
+    }
+    if ("badPoint" in analysis) {
+      return analysis.badPoint || "없음";
+    }
+    if ("improvementPoint" in analysis) {
+      return analysis.improvementPoint || "없음";
+    }
+    return "없음";
+  };
+
   const handleAnalysisClick = () => {
     navigate(PATHS.retrospectAnalysis(String(spaceId), retrospectId, retrospectTitle));
   };
@@ -52,7 +65,7 @@ export default function AnalyticsSummaryBox({ type, analysis }: AnalyticsSummary
           `}
         >
           <Typography variant="subtitle14SemiBold" color="gray800">
-            {config.title}
+            {getPointByType()}
           </Typography>
           <Typography
             variant="body12SemiBold"


### PR DESCRIPTION
> ### 메인 페이지 분석 요약 박스에서 포인트 표시 로직 수정
---

### 🏄🏼‍♂️‍ Summary (요약)
- 분석 컨텐츠에 잘못된 텍스트가 표기되어있던 것을 수정합니다.

### 🫨 Describe your Change (변경사항)
- 분석 데이터를 활용합니다.

### 🧐 Issue number and link (참고)
- close #764 

### 📚 Reference (참조)

<img width="991" height="663" alt="image" src="https://github.com/user-attachments/assets/97bea5df-44d0-42af-bb82-423e84414258" />

