### PR TITLE
fix: #793 질문 추가 기능 개선 및 버튼 비활성화 로직 추가

### DIFF
--- a/apps/web/src/app/desktop/component/retrospectCreate/QuestionEditSection/AddQuestionView.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/QuestionEditSection/AddQuestionView.tsx
@@ -14,12 +14,11 @@ import { useToast } from "@/hooks/useToast";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
 type AddQuestionViewProps = {
-  onAddQuestion: (content: string) => void;
-  onAddMultipleQuestions: (contents: string[]) => void;
+  onAddQuestions: (contents: string[]) => void;
   maxCount: number;
 };
 
-export default function AddQuestionView({ onAddQuestion, onAddMultipleQuestions, maxCount }: AddQuestionViewProps) {
+export default function AddQuestionView({ onAddQuestions, maxCount }: AddQuestionViewProps) {
   const { toast } = useToast();
   const { tabs, curTab, selectTab } = useTabs(["직접작성", "추천질문"] as const);
   const { value: customQuestion, handleInputChange: handleCustomChange, resetInput } = useInput();
@@ -44,11 +43,7 @@ export default function AddQuestionView({ onAddQuestion, onAddMultipleQuestions,
       questionsToAdd.push(...selectedValues);
     }
 
-    if (questionsToAdd.length === 1) {
-      onAddQuestion(questionsToAdd[0]);
-    } else {
-      onAddMultipleQuestions(questionsToAdd);
-    }
+    onAddQuestions(questionsToAdd);
 
     if (hasCustomQuestion) {
       resetInput();

--- a/apps/web/src/app/desktop/component/retrospectCreate/QuestionEditSection/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/QuestionEditSection/index.tsx
@@ -121,10 +121,14 @@ export default function QuestionEditSection({ onClose }: QuestionEditSectionProp
   };
 
   /**
-   * 질문 추가 완료 핸들러 (단일)
+   * 질문 추가 완료 핸들러
    */
-  const handleAddQuestionComplete = (content: string) => {
-    const newQuestions = [...questions, { questionType: "plain_text" as const, questionContent: content }];
+  const handleAddQuestions = (contents: string[]) => {
+    const newQuestionObjects = contents.map((content) => ({
+      questionType: "plain_text" as const,
+      questionContent: content,
+    }));
+    const newQuestions = [...questions, ...newQuestionObjects];
     setEditingQuestions(newQuestions);
 
     // 원래 모드로 돌아가고 모달 제목 복원
@@ -140,28 +144,6 @@ export default function QuestionEditSection({ onClose }: QuestionEditSectionProp
     }));
 
     toast.success("질문이 추가되었어요!");
-  };
-
-  /**
-   * 질문 추가 완료 핸들러 (복수)
-   */
-  const handleAddMultipleQuestions = (contents: string[]) => {
-    const newQuestionObjects = contents.map((content) => ({
-      questionType: "plain_text" as const,
-      questionContent: content,
-    }));
-    const newQuestions = [...questions, ...newQuestionObjects];
-    setEditingQuestions(newQuestions);
-
-    // 원래 모드로 돌아가고 모달 제목 복원
-    setIsAddMode(false);
-    setModalDataState((prev) => ({
-      ...prev,
-      title: "질문 리스트",
-      enableFooter: false,
-    }));
-
-    toast.success(`${contents.length}개의 질문이 추가되었어요!`);
   };
 
   /**
@@ -279,11 +261,7 @@ export default function QuestionEditSection({ onClose }: QuestionEditSectionProp
   return (
     <>
       {isAddMode ? (
-        <AddQuestionView
-          onAddQuestion={handleAddQuestionComplete}
-          onAddMultipleQuestions={handleAddMultipleQuestions}
-          maxCount={10 - questions.length}
-        />
+        <AddQuestionView onAddQuestions={handleAddQuestions} maxCount={10 - questions.length} />
       ) : (
         <>
           <section


### PR DESCRIPTION
> ### 질문 추가 기능 개선 및 버튼 비활성화 로직 추가
---

### 🏄🏼‍♂️‍ Summary (요약)

- 템플릿 질문 추가 화면(AddQuestionView)의 UX를 개선하여 사용자가 직접 작성한 질문과 추천 질문을 함께 추가할 수 있도록 수정했습니다

### 🫨 Describe your Change (변경사항)

- 직접작성 탭에서 입력 없이 버튼 비활성화 기능 추가                                                                                               
- 직접작성 질문과 추천질문을 동시에 추가할 수 있도록 통합 핸들러 구현                                                                             
- 질문 추가 후 자동으로 입력 필드 및 선택 상태 초기화 

### 🧐 Issue number and link (참고)

- close #793 

### 📚 Reference (참조)


https://github.com/user-attachments/assets/731bf58e-bc64-47bb-ab36-4bdf392ac2c4


