### PR TITLE
fix: 홈 화면의 작성중인 회고 높이값 다른 이슈

### DIFF
--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -134,7 +134,7 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
           display: flex;
           justify-content: space-between;
           align-items: center;
-          margin-top: 0.8rem;
+          margin-top: auto;
         `}
       >
         <Typography variant="body12SemiBold" color="gray500">


### PR DESCRIPTION
> ### 홈 작성중인 회고 맨 끝 컨텐츠만 높이값 다른 이슈
---

### 🏄🏼‍♂️‍ Summary (요약)

- 설명이 없는 회고의 경우, 회고 카드의 높이 달라지는 문제가 있었습니다.

### 🫨 Describe your Change (변경사항)

- 높이를 고정된 값으로 변경하였습니다.

### 🧐 Issue number and link (참고)

- close #801

### 📚 Reference (참조)

<img width="636" height="216" alt="image" src="https://github.com/user-attachments/assets/b6e5b1cf-dcdb-4bb7-93fd-bdafb4d27071" />

