### PR TITLE
chore: #814 계정 설정 완료 버튼 disabled 상태 추가, 계정탈퇴 ui 변경

### DIFF
--- a/apps/web/src/component/common/Modal/UserSetting/AccountSettingsModal.tsx
+++ b/apps/web/src/component/common/Modal/UserSetting/AccountSettingsModal.tsx
@@ -151,9 +151,40 @@ export function AccountSettingsModal({ isOpen, onClose }: AccountSettingsModalPr
               padding: 2.4rem;
             `}
           >
-            <Typography variant="subtitle18SemiBold" color="gray900">
-              {modalView === "settings" ? "계정 설정" : "계정 탈퇴"}
-            </Typography>
+            <div
+              css={css`
+                display: flex;
+                align-items: center;
+                gap: 1.2rem;
+              `}
+            >
+              {modalView === "deleteAccount" && (
+                <button
+                  css={css`
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 3.2rem;
+                    height: 3.2rem;
+                    border: none;
+                    background: transparent;
+                    border-radius: 0.4rem;
+                    cursor: pointer;
+                    transition: background-color 0.2s ease;
+
+                    &:hover {
+                      background-color: ${DESIGN_TOKEN_COLOR.gray100};
+                    }
+                  `}
+                  onClick={() => setModalView("settings")}
+                >
+                  <Icon icon="ic_arrow_left" size={2.0} color={DESIGN_TOKEN_COLOR.gray900} />
+                </button>
+              )}
+              <Typography variant="subtitle18SemiBold" color="gray900">
+                {modalView === "settings" ? "계정 설정" : "계정 탈퇴"}
+              </Typography>
+            </div>
             <button
               css={css`
                 display: flex;
@@ -365,23 +396,19 @@ export function AccountSettingsModal({ isOpen, onClose }: AccountSettingsModalPr
                 gap: 1.2rem;
               `}
             >
-              <Button
-                colorSchema="gray"
-                css={css`
-                  flex: 1;
-                `}
-                onClick={() => {
-                  if (modalView === "deleteAccount") {
-                    setModalView("settings");
-                  } else {
-                    onClose();
-                  }
-                }}
-              >
-                <Typography variant="subtitle16SemiBold" color="gray700">
-                  {modalView === "deleteAccount" ? "취소" : "취소"}
-                </Typography>
-              </Button>
+              {modalView === "settings" && (
+                <Button
+                  colorSchema="gray"
+                  css={css`
+                    flex: 1;
+                  `}
+                  onClick={onClose}
+                >
+                  <Typography variant="subtitle16SemiBold" color="gray700">
+                    취소
+                  </Typography>
+                </Button>
+              )}
               <Button
                 colorSchema={modalView === "deleteAccount" ? (hasSelectedReason ? "primary" : "gray") : hasChanges ? "primary" : "gray"}
                 disabled={(modalView === "settings" && !hasChanges) || (modalView === "deleteAccount" && !hasSelectedReason)}


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)
- 이름 혹은 프로필 사진 변경이 없다면 disabled 적용
- 계정탈퇴 ui 변경 (하단 취소버튼 제거, 상단왼쪽 뒤로가기 아이콘 추가)

### 🫨 Describe your Change (변경사항)

[변경 후]
<img width="581" height="552" alt="image" src="https://github.com/user-attachments/assets/41830a23-cbd8-4bd7-82ef-6ee06bce5d30" />
<img width="565" height="536" alt="image" src="https://github.com/user-attachments/assets/b4382b79-94a8-49a8-a59b-bdcf99a1e9a3" />
<img width="563" height="605" alt="image" src="https://github.com/user-attachments/assets/add941a0-9af0-4064-889f-375b43a4da18" />



### 🧐 Issue number and link (참고)
#814 


