### PR TITLE
fix: #818 회고 작성 질문 전체보기의 컨텐츠 wrap 영역 없이 무제한 펼쳐져 아래 버튼들과 겹치는 이슈 해결

### DIFF
--- a/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/QuestionsOverview.tsx
+++ b/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/QuestionsOverview.tsx
@@ -34,12 +34,17 @@ export function QuestionsOverview({ isAnswerFilled, hasChanges, onSaveTemporary,
         display: flex;
         flex-direction: column;
         width: 29.4rem;
+        height: 100%;
       `}
     >
       <div
         css={css`
           border: 0.1rem solid ${DESIGN_TOKEN_COLOR.opacity8};
           border-radius: 1.8rem;
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+          min-height: 0;
         `}
       >
         {/* -------- 질믄 전체보기 상단 UI------- */}
@@ -49,6 +54,7 @@ export function QuestionsOverview({ isAnswerFilled, hasChanges, onSaveTemporary,
             justify-content: space-between;
             align-items: center;
             padding: 1.6rem 1.6rem 0.8rem;
+            flex-shrink: 0;
           `}
         >
           <Typography variant="subtitle14Strong" color="gray800" as="p">
@@ -68,6 +74,9 @@ export function QuestionsOverview({ isAnswerFilled, hasChanges, onSaveTemporary,
         <ul
           css={css`
             padding: 0 0.8rem 0.8rem;
+            flex: 1;
+            overflow-y: auto;
+            min-height: 0;
           `}
         >
           {data?.questions.map((question, index) => {
@@ -121,6 +130,7 @@ export function QuestionsOverview({ isAnswerFilled, hasChanges, onSaveTemporary,
           display: flex;
           align-items: center;
           gap: 1.2rem;
+          flex-shrink: 0;
         `}
       >
         <button

--- a/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/index.tsx
@@ -319,7 +319,7 @@ export function WriteDialog({ isOverviewVisible, handleToggleOverview }: WriteDi
           css={css`
             display: flex;
             flex: 1;
-            height: 100%;
+            min-height: 0;
             padding: 2.4rem 0 0 5.6rem;
           `}
         >


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)
스크롤 이슈 해결했습니다.


### 🫨 Describe your Change (변경사항)
[적용 전]
<img width="2048" height="1397" alt="image" src="https://github.com/user-attachments/assets/da83f76a-685f-449d-bc30-aa7ba8819749" />


[적용 후]

https://github.com/user-attachments/assets/09e9c87f-f8df-40b8-84ef-9f62be9e973c




### 🧐 Issue number and link (참고)
#818 
