### PR TITLE
회고 이름 및 설명 입력 길이 확장

### DIFF
--- a/apps/web/src/app/desktop/component/retrospectCreate/steps/MainInfo.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/steps/MainInfo.tsx
@@ -29,14 +29,14 @@ export function MainInfo() {
 
       <InputLabelContainer id="name">
         <Label>회고 이름</Label>
-        <Input value={title} onChange={handleNameChange} maxLength={10} count placeholder="회고 이름을 적어주세요" />
+        <Input value={title} onChange={handleNameChange} maxLength={30} count placeholder="회고 이름을 적어주세요" />
       </InputLabelContainer>
 
       <Spacing size={4} />
 
       <InputLabelContainer id="name">
         <Label>한 줄 설명</Label>
-        <TextArea value={introduction} onChange={handleDescriptionChange} maxLength={20} count placeholder="회고에 대한 한 줄 설명을 적어주세요" />
+        <TextArea value={introduction} onChange={handleDescriptionChange} maxLength={50} count placeholder="회고에 대한 한 줄 설명을 적어주세요" />
       </InputLabelContainer>
 
       <TipCard

--- a/apps/web/src/app/test/Staging.tsx
+++ b/apps/web/src/app/test/Staging.tsx
@@ -80,12 +80,12 @@ export default function Staging() {
       <br />
       <InputLabelContainer id={"retro"}>
         <Label order={1}>회고 이름</Label>
-        <Input ref={inputRef} onChange={handleChangeName} value={layerName} maxLength={10} count validations={["NO_SPECIAL_CHARS"]} />
+        <Input ref={inputRef} onChange={handleChangeName} value={layerName} maxLength={30} count validations={["NO_SPECIAL_CHARS"]} />
       </InputLabelContainer>
 
       <InputLabelContainer id={"description"}>
         <Label>한 줄 설명</Label>
-        <TextArea onChange={handleChangeDescription} value={description} maxLength={20} count validations={["NO_SPECIAL_CHARS"]} />
+        <TextArea onChange={handleChangeDescription} value={description} maxLength={50} count validations={["NO_SPECIAL_CHARS"]} />
       </InputLabelContainer>
 
       <BottomSheet

--- a/apps/web/src/component/common/Tooltip/index.tsx
+++ b/apps/web/src/component/common/Tooltip/index.tsx
@@ -59,7 +59,7 @@ const Tooltip = ({ children, placement = "top", delay = 200, disabled = false }:
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timeoutRef = useRef<number | null>(null);
 
   const open = useCallback(() => {
     if (disabled) return;

--- a/apps/web/src/component/common/Tooltip/index.tsx
+++ b/apps/web/src/component/common/Tooltip/index.tsx
@@ -66,7 +66,7 @@ const Tooltip = ({ children, placement = "top", delay = 200, disabled = false }:
     if (timeoutRef.current !== null) {
       clearTimeout(timeoutRef.current);
     }
-    timeoutRef.current = setTimeout(() => {
+    timeoutRef.current = window.setTimeout(() => {
       setIsOpen(true);
     }, delay);
   }, [disabled, delay]);

--- a/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
@@ -259,7 +259,7 @@ export function ModifyRetrospect(props: {
           name="introduction"
           value={introduction}
           onChange={handleChangeIntroduction}
-          maxLength={20}
+          maxLength={50}
           count
           placeholder="회고에 대한 한 줄 설명을 적어주세요"
         />

--- a/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
@@ -250,7 +250,7 @@ export function ModifyRetrospect(props: {
       <Spacing size={2} />
       <InputLabelContainer id="title">
         <Label>회고 명</Label>
-        <Input name="title" value={title} onChange={handleChangeTitle} maxLength={10} count placeholder="회고 이름을 적어주세요" />
+        <Input name="title" value={title} onChange={handleChangeTitle} maxLength={30} count placeholder="회고 이름을 적어주세요" />
       </InputLabelContainer>
       <Spacing size={3} />
       <InputLabelContainer id="introduction">

--- a/apps/web/src/component/retrospectCreate/steps/MainInfo.tsx
+++ b/apps/web/src/component/retrospectCreate/steps/MainInfo.tsx
@@ -40,7 +40,7 @@ export function MainInfo() {
       >
         <InputLabelContainer id="name">
           <Label>회고 명</Label>
-          <Input value={title} onChange={handleNameChange} maxLength={10} count placeholder="회고 이름을 적어주세요" />
+          <Input value={title} onChange={handleNameChange} maxLength={30} count placeholder="회고 이름을 적어주세요" />
         </InputLabelContainer>
 
         <div>

--- a/apps/web/src/component/retrospectCreate/steps/MainInfo.tsx
+++ b/apps/web/src/component/retrospectCreate/steps/MainInfo.tsx
@@ -49,7 +49,7 @@ export function MainInfo() {
             <TextArea
               value={introduction}
               onChange={handleDescriptionChange}
-              maxLength={20}
+              maxLength={50}
               count
               placeholder="회고에 대한 한 줄 설명을 적어주세요"
             />

--- a/apps/web/src/component/space/view/RetrospectEditModal.tsx
+++ b/apps/web/src/component/space/view/RetrospectEditModal.tsx
@@ -80,7 +80,7 @@ export function RetrospectEditModal({ spaceId, retrospectId, defaultValue, isAna
                 onChange={handleIntroductionChange}
                 placeholder="회고에 대한 한 줄 설명을 적어주세요"
                 count
-                maxLength={20}
+                maxLength={50}
               />
             </InputLabelContainer>
             {!isAnalyzed ? (

--- a/apps/web/src/component/space/view/RetrospectEditModal.tsx
+++ b/apps/web/src/component/space/view/RetrospectEditModal.tsx
@@ -71,7 +71,7 @@ export function RetrospectEditModal({ spaceId, retrospectId, defaultValue, isAna
           >
             <InputLabelContainer id={`retro-title-${retrospectId}`}>
               <Label>회고 명</Label>
-              <Input value={title} onChange={handleTitleChange} count maxLength={10} />
+              <Input value={title} onChange={handleTitleChange} count maxLength={30} />
             </InputLabelContainer>
             <InputLabelContainer id={`retro-intro-${retrospectId}`}>
               <Label>한 줄 설명</Label>


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 이름과 한 줄 설명 입력 필드의 최대 길이를 늘려 사용자가 더 풍부한 정보를 작성할 수 있도록 개선했습니다.
- 회고 생성, 수정, 템플릿 관리 등 관련된 여러 컴포넌트에 일관된 길이 제한을 적용했습니다.

### 🫨 Describe your Change (변경사항)

- 회고 이름 입력 필드의 최대 길이를 10자에서 30자로 확장했습니다.
- 회고 한 줄 설명 입력 필드의 최대 길이를 20자에서 50자로 확장했습니다.
- 회고 생성 및 수정 관련 컴포넌트 전반에 걸쳐 입력 길이 제한을 업데이트했습니다.
- Tooltip 컴포넌트에서 setTimeout 호출 방식을 window.setTimeout으로 변경하여 타입 안정성을 개선했습니다.

### 🧐 Issue number and link (참고)

closes: #842

### 📚 Reference (참조)

-