### PR TITLE
회고 생성 완료 페이지 내비게이션 훅 분리

### DIFF
--- a/apps/web/src/app/mobile/retrospectCreate/RetrospectCreateComplete.tsx
+++ b/apps/web/src/app/mobile/retrospectCreate/RetrospectCreateComplete.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { PATHS } from "@layer/shared";
 import Lottie from "lottie-react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import retrospect_create_complete_lottie from "@/assets/lottie/retropsect/create/book_start.json";
 import { ButtonProvider } from "@/component/common/button";
@@ -11,7 +11,8 @@ import { DefaultLayout } from "@/layout/DefaultLayout";
 import { useTestNavigate } from "@/lib/test-natigate";
 
 export function RetrospectCreateComplete() {
-  const navigate = useTestNavigate();
+  const testNavigate = useTestNavigate();
+  const navigate = useNavigate();
   const locationState = useLocation().state as { spaceId: number; retrospectId: number; title: string; introduction: string };
   const { spaceId, retrospectId, title, introduction } = locationState;
   return (
@@ -31,7 +32,7 @@ export function RetrospectCreateComplete() {
       <ButtonProvider sort="horizontal">
         <ButtonProvider.Gray
           onClick={() => {
-            navigate(PATHS.spaceDetail(spaceId.toString()));
+            testNavigate(PATHS.spaceDetail(spaceId.toString()));
           }}
         >
           끝내기


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- RetrospectCreateComplete 컴포넌트의 내비게이션 훅 사용 방식을 개선했습니다.
- useTestNavigate와 useNavigate를 명확히 구분하여 사용하도록 변경했습니다.

### 🫨 Describe your Change (변경사항)

- react-router-dom에서 useNavigate 훅을 추가로 임포트했습니다.
- 기존 useTestNavigate의 결과를 testNavigate 변수에 할당하도록 변경했습니다.
- react-router-dom의 useNavigate를 사용하여 새로운 navigate 변수를 선언했습니다.
- 스페이스 상세 페이지로 이동하는 로직에서 testNavigate를 사용하도록 수정했습니다.

### 🧐 Issue number and link (참고)

closes: #408

### 📚 Reference (참조)

-