### PR TITLE
불필요한 theme-color 메타 태그 제거

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -24,7 +24,6 @@
     />
     <meta name="author" content="Layer Team" />
     <meta name="robots" content="index, follow" />
-    <meta name="theme-color" content="#009BFF" />
     <link rel="canonical" href="https://www.layerapp.io/" />
 
     <!-- PWA Meta Tags -->


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 웹 앱의 `index.html`에서 불필요한 `theme-color` 메타 태그를 제거했습니다.
- 해당 태그는 현재 서비스에 사용되지 않아 삭제되었습니다.

### 🫨 Describe your Change (변경사항)

- `apps/web/index.html` 파일에서 `<meta name="theme-color" content="#009BFF" />` 라인을 삭제했습니다.

### 🧐 Issue number and link (참고)

-

### 📚 Reference (참조)

-