### PR TITLE
회고 마감일 자동 조정 로직 제거 및 UI 정렬 개선

### DIFF
--- a/apps/web/src/app/desktop/login/DesktopLoginPage.tsx
+++ b/apps/web/src/app/desktop/login/DesktopLoginPage.tsx
@@ -68,7 +68,7 @@ function SwiperSlideOnboardingImage({
         flex-direction: column;
         justify-content: flex-start;
         align-items: center;
-        padding-top: 6.6rem;
+        justify-content: center;
       `}
     >
       <div

--- a/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
@@ -15,7 +15,6 @@ import { queryClient } from "@/lib/tanstack-query/queryClient";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Retrospect } from "@/types/retrospect";
 import { css } from "@emotion/react";
-import { addMinutes, format } from "date-fns";
 import React, { useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 
@@ -184,8 +183,6 @@ export function ModifyRetrospect(props: {
   const [isChanged, setIsChanged] = useState(false);
 
   const isVisibleDueDate = !props.isAnalyzed && !!dueDate;
-  const due = new Date(dueDate);
-  const isPastDueDate = !Number.isNaN(due.getTime()) && due.getTime() < Date.now();
 
   const initialState = useRef({
     title: props.title,
@@ -212,17 +209,13 @@ export function ModifyRetrospect(props: {
   };
 
   const handleModifyRetrospect = async () => {
-    // 마감 일자가 지난 회고를 수정할 경우에는 마감 일자를 1분 뒤로 설정하여 저장되도록 함
-    const next = addMinutes(new Date(), 1);
-    const currentDate = format(next, "yyyy-MM-dd'T'HH:mm:ss");
-
     const { status } = await editRetrospect({
       spaceId: props.spaceId,
       retrospectId: props.retrospectId,
       data: {
         title,
         introduction,
-        deadline: isPastDueDate ? currentDate : dueDate,
+        deadline: dueDate,
       },
     });
     if (status === 200) {

--- a/apps/web/src/component/space/view/RetrospectEditModal.tsx
+++ b/apps/web/src/component/space/view/RetrospectEditModal.tsx
@@ -11,7 +11,6 @@ import { usePatchRetrospect } from "@/hooks/api/retrospect/edit/usePatchRetrospe
 import { useInput } from "@/hooks/useInput";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 import { Retrospect } from "@/types/retrospect";
-import { addMinutes, format } from "date-fns";
 
 type RetrospectEditProps = {
   spaceId: string;
@@ -28,16 +27,12 @@ export function RetrospectEditModal({ spaceId, retrospectId, defaultValue, isAna
   const [deadline, setDeadline] = useState(defaultValue.deadline);
 
   const isEdited = title !== defaultValue.title || introduction !== defaultValue.introduction || deadline !== defaultValue.deadline;
-  const isPastDueDate = deadline ? new Date(deadline) <= new Date() : false;
 
   const handleModifyRetrospect = async () => {
-    // 마감 일자가 지난 회고를 수정할 경우에는 마감 일자를 1분 뒤로 설정하여 저장되도록 함
-    const next = addMinutes(new Date(), 1);
-    const currentDate = format(next, "yyyy-MM-dd'T'HH:mm:ss");
     patchRetrospect({
       spaceId: +spaceId,
       retrospectId: +retrospectId,
-      data: { title, introduction, deadline: isPastDueDate ? currentDate : deadline },
+      data: { title, introduction, deadline: deadline },
     });
   };
 


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 수정 시 마감일이 지난 경우 자동으로 1분 뒤로 설정되던 로직을 제거했습니다.
- 데스크톱 로그인 페이지의 온보딩 이미지 정렬 방식을 개선했습니다.

### 🫨 Describe your Change (변경사항)

- TemplateCardManageToggleMenu.tsx 및 RetrospectEditModal.tsx에서 마감일 자동 조정 로직을 제거했습니다.
- 더 이상 사용되지 않는 date-fns의 addMinutes, format 유틸리티를 제거했습니다.
- DesktopLoginPage.tsx에서 온보딩 이미지의 정렬 방식을 padding-top에서 justify-content: center로 변경하여 중앙 정렬을 개선했습니다.

### 🧐 Issue number and link (참고)

closes: #830

### 📚 Reference (참조)

-