### PR TITLE
release 2.0.9

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "@layer/mobile",
   "main": "expo-router/entry",
   "types": "./bridge/native.ts",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -17,7 +17,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 
     <!-- Google tag -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_ID%"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%VITE_GOOGLE_ANALYTICS%"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -25,7 +25,7 @@
       }
       gtag("js", new Date());
 
-      gtag("config", "%VITE_GA_ID%");
+      gtag("config", "%VITE_GOOGLE_ANALYTICS%");
     </script>
 
     <!-- SEO Meta Tags -->

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -25,7 +25,7 @@
       }
       gtag("js", new Date());
 
-      gtag("config", "G-K1TVY9HFPP");
+      gtag("config", "%VITE_GA_ID%");
     </script>
 
     <!-- SEO Meta Tags -->

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -16,6 +16,18 @@
     <title>성장하는 당신을 위한 회고 서비스, Layer</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 
+    <!-- Google tag -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_ID%"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "G-K1TVY9HFPP");
+    </script>
+
     <!-- SEO Meta Tags -->
     <meta name="description" content="편리한 회고 작성부터 AI 분석까지 Layer에서 함께해요!" />
     <meta

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@layer/web",
   "private": true,
-  "version": "2.0.8",
+  "version": "2.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
@@ -85,7 +85,7 @@ export default function RetrospectSection({
         },
       });
     }
-    // 회고 추가 버튼 클릭 이벤트를 GA에 전송해요
+
     trackEvent(GA_EVENTS.RETROSPECT.ADD);
   };
 

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
@@ -14,6 +14,8 @@ import { useFunnelModal } from "@/hooks/useFunnelModal";
 import { useActionModal } from "@/hooks/useActionModal";
 import { RetrospectCreate } from "../../retrospectCreate";
 import { TemplateChoice } from "../../retrospect/choice";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 interface RetrospectSectionProps {
   title: string;
@@ -83,6 +85,8 @@ export default function RetrospectSection({
         },
       });
     }
+    // 회고 추가 버튼 클릭 이벤트를 GA에 전송해요
+    trackEvent(GA_EVENTS.RETROSPECT.ADD);
   };
 
   const contentMap = {

--- a/apps/web/src/app/desktop/component/retrospect/template/list/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/index.tsx
@@ -14,6 +14,8 @@ import { TemplateListItem } from "./TemplateListItem";
 import { TemplateListTab } from "./TemplateListTab";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { useSearchParams } from "react-router-dom";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 export const TemplateListPageContext = createContext<{
   spaceId: string;
@@ -48,6 +50,11 @@ export function TemplateList() {
       }
     }
   }, [spaceId]);
+
+  // 템플릿 리스트 퍼널 진입 시 GA 이벤트를 전송해요
+  useEffect(() => {
+    trackEvent(GA_EVENTS.RETROSPECT.FUNNEL_VIEW_LIST);
+  }, []);
 
   return (
     <>

--- a/apps/web/src/app/desktop/component/retrospect/template/recommend/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/recommend/index.tsx
@@ -19,7 +19,7 @@ import { useResetAtom } from "jotai/utils";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { RecommendSearch } from "./Search";
 import { trackEvent } from "@/lib/google_analytics";
-import { GA_EVENTS } from "@/lib/google_analytics/events";
+import { GA_FUNNEL_LABELS } from "@/lib/google_analytics/events";
 
 const LAST_PAGE = 2;
 
@@ -68,10 +68,16 @@ export function TemplateRecommend() {
     }
   };
 
-  // 템플릿 추천 퍼널 진입 시 GA 이벤트를 전송해요
+  // 템플릿 추천 퍼널 단계 변경 시 GA 이벤트를 전송해요
   useEffect(() => {
-    trackEvent(GA_EVENTS.RETROSPECT.FUNNEL_VIEW_RECOMMEND);
-  }, []);
+    if (templateValue.step > LAST_PAGE) return;
+
+    trackEvent({
+      action: "retrospect_recommend_funnel_view",
+      category: "retrospect",
+      label: GA_FUNNEL_LABELS.TEMPLATE_RECOMMEND[templateValue.step],
+    });
+  }, [templateValue.step]);
 
   useEffect(() => {
     if (templateValue.step === LAST_PAGE + 1) {

--- a/apps/web/src/app/desktop/component/retrospect/template/recommend/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/recommend/index.tsx
@@ -18,6 +18,8 @@ import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { useResetAtom } from "jotai/utils";
 import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { RecommendSearch } from "./Search";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 const LAST_PAGE = 2;
 
@@ -65,6 +67,11 @@ export function TemplateRecommend() {
       console.log(error);
     }
   };
+
+  // 템플릿 추천 퍼널 진입 시 GA 이벤트를 전송해요
+  useEffect(() => {
+    trackEvent(GA_EVENTS.RETROSPECT.FUNNEL_VIEW_RECOMMEND);
+  }, []);
 
   useEffect(() => {
     if (templateValue.step === LAST_PAGE + 1) {

--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -72,7 +72,7 @@ export function RetrospectCreate() {
             saveTemplateId: false,
           }));
 
-          trackEvent(GA_EVENTS.RETROSPECT.COMPLETE);
+          trackEvent(GA_EVENTS.RETROSPECT.ADD_COMPLETE);
         },
       },
     );

--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback } from "react";
+import { createContext, useCallback, useEffect } from "react";
 import { ProgressBar } from "@/component/common/ProgressBar";
 import { css } from "@emotion/react";
 import { useMultiStepForm } from "@/hooks/useMultiStepForm";
@@ -77,6 +77,11 @@ export function RetrospectCreate() {
       },
     );
   }, [retroCreateData.deadline]);
+
+  // 회고 생성 퍼널 진입 시 GA 이벤트를 전송해요
+  useEffect(() => {
+    trackEvent(GA_EVENTS.RETROSPECT.FUNNEL_VIEW_CREATE);
+  }, []);
 
   return (
     <RetrospectCreateContext.Provider value={{ ...pageState, isMutatePending: isPending }}>

--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -16,7 +16,7 @@ import { useFunnelModal } from "@/hooks/useFunnelModal";
 import { useToast } from "@/hooks/useToast";
 import { queryClient } from "@/lib/tanstack-query/queryClient";
 import { trackEvent } from "@/lib/google_analytics";
-import { GA_EVENTS } from "@/lib/google_analytics/events";
+import { GA_EVENTS, GA_FUNNEL_LABELS } from "@/lib/google_analytics/events";
 
 const PAGE_STEPS = ["confirmTemplate", "mainInfo", "dueDate"] as const;
 const CUSTOM_TEMPLATE_STEPS = ["confirmDefaultTemplate", "editQuestions", "confirmEditTemplate"] as const;
@@ -78,10 +78,14 @@ export function RetrospectCreate() {
     );
   }, [retroCreateData.deadline]);
 
-  // 회고 생성 퍼널 진입 시 GA 이벤트를 전송해요
+  // 회고 생성 퍼널 단계 변경 시 GA 이벤트를 전송해요
   useEffect(() => {
-    trackEvent(GA_EVENTS.RETROSPECT.FUNNEL_VIEW_CREATE);
-  }, []);
+    trackEvent({
+      action: "retrospect_create_funnel_view",
+      category: "retrospect",
+      label: GA_FUNNEL_LABELS.RETROSPECT_CREATE[pageState.currentStep],
+    });
+  }, [pageState.currentStep]);
 
   return (
     <RetrospectCreateContext.Provider value={{ ...pageState, isMutatePending: isPending }}>

--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -15,6 +15,8 @@ import { useNavigate } from "react-router-dom";
 import { useFunnelModal } from "@/hooks/useFunnelModal";
 import { useToast } from "@/hooks/useToast";
 import { queryClient } from "@/lib/tanstack-query/queryClient";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 const PAGE_STEPS = ["confirmTemplate", "mainInfo", "dueDate"] as const;
 const CUSTOM_TEMPLATE_STEPS = ["confirmDefaultTemplate", "editQuestions", "confirmEditTemplate"] as const;
@@ -69,6 +71,8 @@ export function RetrospectCreate() {
             tempTemplateId: "",
             saveTemplateId: false,
           }));
+
+          trackEvent(GA_EVENTS.RETROSPECT.COMPLETE);
         },
       },
     );

--- a/apps/web/src/app/desktop/component/retrospectWrite/complete/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectWrite/complete/index.tsx
@@ -11,6 +11,8 @@ import { useApiGetSpacePrivate } from "@/hooks/api/space/useGetSpace.ts";
 import { ANIMATION } from "@/style/common/animation.ts";
 import { PATHS } from "@layer/shared";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 type UserInfoType = {
   isLogin: boolean;
@@ -206,6 +208,7 @@ export function RetrospectWriteComplete() {
             onClick={() => {
               close();
               navigate(PATHS.spaceDetail(String(spaceId)));
+              trackEvent(GA_EVENTS.RETROSPECT.WRITE_SUBMIT_DONE);
             }}
           >
             완료

--- a/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/WriteDialogHeader.tsx
+++ b/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/WriteDialogHeader.tsx
@@ -8,6 +8,8 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { PhaseContext } from "..";
 import { useModal } from "@/hooks/useModal";
 import { useNavigation } from "@/component/common/LocalNavigationBar/context/NavigationContext";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 interface WriteDialogHeaderProps {
   isOverviewVisible: boolean;
@@ -57,6 +59,8 @@ export function WriteDialogHeader({
       },
       onConfirm: onSubmitWriteDone,
     });
+
+    trackEvent(GA_EVENTS.RETROSPECT.WRITE_SUBMIT_OPEN);
   };
 
   return (

--- a/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectWrite/writeDialog/index.tsx
@@ -22,6 +22,8 @@ import { useTemporarySave } from "@/hooks/useTemporarySave";
 import { useSetAtom } from "jotai";
 import { isRetrospectModifiedAtom } from "@/store/retrospect/retrospectWrite";
 import { useBlocker } from "react-router-dom";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 interface WriteDialogProps {
   isOverviewVisible: boolean;
@@ -172,6 +174,8 @@ export function WriteDialog({ isOverviewVisible, handleToggleOverview }: WriteDi
             answerLengths,
             averageAnswerLength: Math.round((answerLengths.reduce((acc, length) => acc + length, 0) / plainTextAnswers.length) * 100) / 100,
           });
+
+          trackEvent(GA_EVENTS.RETROSPECT.WRITE_SUBMIT_CONFIRM);
         },
       },
     );

--- a/apps/web/src/app/desktop/login/DesktopLoginPage.tsx
+++ b/apps/web/src/app/desktop/login/DesktopLoginPage.tsx
@@ -71,7 +71,7 @@ function SwiperSlideOnboardingImage({
         flex-direction: column;
         justify-content: flex-start;
         align-items: center;
-        padding-top: 6.6rem;
+        justify-content: center;
       `}
     >
       <div

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -60,6 +60,8 @@ import { DesktopDateTimeInput } from "../../component/retrospectCreate/DesktopDa
 import { queryClient } from "@/lib/tanstack-query/queryClient";
 import TemplateListDetailItem from "../../component/retrospect/template/list/TemplateListDetailItem";
 import { PATHS } from "@layer/shared";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS, GA_FUNNEL_LABELS } from "@/lib/google_analytics/events";
 
 type flowType = "INFO" | "RECOMMEND" | "RECOMMEND_PROGRESS" | "CREATE" | "COMPLETE";
 type templateType = { id: number; title: string; imageUrl: string; templateName: string };
@@ -978,6 +980,7 @@ function CompleteCreateSpace() {
     closeModalDesktop();
     resetRetrospectInfo();
     resetSpaceInfo();
+    trackEvent(GA_EVENTS.SPACE.ADD_DONE);
   };
 
   useEffect(() => {
@@ -1063,7 +1066,7 @@ function CompleteCreateSpace() {
       )}
       <ButtonProvider>
         <ButtonProvider.Primary onClick={handleComplete} disabled={spaceData!.category === ProjectType.Individual ? false : !animate}>
-          다음
+          완료
         </ButtonProvider.Primary>
       </ButtonProvider>
     </div>
@@ -1139,6 +1142,15 @@ export default function AddSpacePage() {
     return true;
   })();
   const CurrentComponent = FLOW_COMPONENTS[flow][phase as keyof (typeof FLOW_COMPONENTS)[typeof flow]];
+
+  // 스페이스 생성 퍼널 단계 변경 시 GA 이벤트를 전송해요
+  useEffect(() => {
+    trackEvent({
+      action: "space_create_funnel_view",
+      category: "space",
+      label: GA_FUNNEL_LABELS.SPACE_CREATE[flow]?.[phase],
+    });
+  }, [flow, phase]);
 
   return (
     <PhaseContext.Provider

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/HeaderSpaceAddButton.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/HeaderSpaceAddButton.tsx
@@ -9,6 +9,8 @@ import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
 import { useRetrospectCreateReset } from "@/hooks/store/useRetrospectCreateReset";
 import { useSpaceCreateReset } from "@/hooks/store/useSpaceCreateReset";
 import Tooltip from "@/component/common/Tooltip";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 export default function HeaderSpaceAddButton() {
   const { isCollapsed } = useNavigation();
@@ -28,6 +30,9 @@ export default function HeaderSpaceAddButton() {
         resetSpaceInfo();
       },
     });
+
+    // 스페이스 추가 버튼 클릭 이벤트를 GA에 전송해요
+    trackEvent(GA_EVENTS.SPACE.ADD_ICON);
   };
 
   return (

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/HeaderSpaceAddButton.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/HeaderSpaceAddButton.tsx
@@ -31,7 +31,6 @@ export default function HeaderSpaceAddButton() {
       },
     });
 
-    // 스페이스 추가 버튼 클릭 이벤트를 GA에 전송해요
     trackEvent(GA_EVENTS.SPACE.ADD_ICON);
   };
 

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -53,7 +53,6 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
       },
     });
 
-    // 스페이스 추가 버튼 클릭 이벤트를 GA에 전송해요
     trackEvent(GA_EVENTS.SPACE.ADD_BUTTON);
   };
 

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -17,6 +17,8 @@ import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Portal } from "@/component/common/Portal";
 import { useApiPostSpacesImpression } from "@/hooks/api/backoffice/useApiPostSpacesImpression";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 interface SpacesListProps {
   currentTab: "전체" | "개인" | "팀";
@@ -50,6 +52,9 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
         resetSpaceInfo();
       },
     });
+
+    // 스페이스 추가 버튼 클릭 이벤트를 GA에 전송해요
+    trackEvent(GA_EVENTS.SPACE.ADD_BUTTON);
   };
 
   useEffect(() => {

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
@@ -11,6 +11,8 @@ import { Retrospect } from "@/types/retrospect";
 import { useApiPostActionItem } from "@/hooks/api/actionItem/useApiPostActionItem";
 import { ExtendedActionItemType } from "@/types/actionItem";
 import { useToast } from "@/hooks/useToast";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 type ActionItemAddSectionProps = {
   spaceId: string;
@@ -108,6 +110,7 @@ export default function ActionItemAddSection({ spaceId, retrospectId, onClose }:
               queryClient.invalidateQueries({ queryKey: ["getTeamActionItemList", spaceId] });
             }
 
+            trackEvent(GA_EVENTS.ACTION_ITEM.ADD_DONE);
             onClose();
           },
         },

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
@@ -8,6 +8,8 @@ import ActionItemAddSection from "./ActionItemAddSection";
 import { useAtomValue } from "jotai";
 import { currentSpaceState } from "@/store/space/spaceAtom";
 import { isSpaceLeader } from "@/utils/userUtil";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 type ActionItemCardProps = {
   spaceId: string;
@@ -62,6 +64,8 @@ export default function ActionItemCard({ spaceId, retrospectId, title, todoList,
         enableFooter: false,
       },
     });
+
+    trackEvent(GA_EVENTS.ACTION_ITEM.ADD);
   };
 
   return (

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
@@ -8,6 +8,8 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import useToggleMenu from "@/hooks/useToggleMenu";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
 import ActionItemsEditSection from "./ActionItemsEditSection";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 type ActionItemManageToggleMenuProps = {
   spaceId: string;
@@ -64,6 +66,7 @@ export default function ActionItemManageToggleMenu({
       },
     });
     hideMenu();
+    trackEvent(GA_EVENTS.ACTION_ITEM.EDIT);
   };
 
   return (

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
@@ -13,6 +13,8 @@ import { ExtendedActionItemType } from "@/types/actionItem";
 import { useModal } from "@/hooks/useModal";
 import { useDeleteActionItemList } from "@/hooks/api/actionItem/useDeleteActionItemList";
 import { useToast } from "@/hooks/useToast";
+import { trackEvent } from "@/lib/google_analytics";
+import { GA_EVENTS } from "@/lib/google_analytics/events";
 
 type ActionItem = {
   actionItemId: string;
@@ -175,6 +177,7 @@ export default function ActionItemsEditSection({ spaceId, retrospectId, todoList
 
       await queryClient.invalidateQueries({ queryKey: ["getTeamActionItemList", spaceId] });
       toast.success("실행목표 편집이 완료되었어요!");
+      trackEvent(GA_EVENTS.ACTION_ITEM.EDIT_DONE);
       onClose();
     } catch (error) {
       toast.error("실행목표 편집에 실패했어요.");

--- a/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
@@ -15,7 +15,6 @@ import { queryClient } from "@/lib/tanstack-query/queryClient";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Retrospect } from "@/types/retrospect";
 import { css } from "@emotion/react";
-import { addMinutes, format } from "date-fns";
 import React, { useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 
@@ -184,8 +183,6 @@ export function ModifyRetrospect(props: {
   const [isChanged, setIsChanged] = useState(false);
 
   const isVisibleDueDate = !props.isAnalyzed && !!dueDate;
-  const due = new Date(dueDate);
-  const isPastDueDate = !Number.isNaN(due.getTime()) && due.getTime() < Date.now();
 
   const initialState = useRef({
     title: props.title,
@@ -212,17 +209,13 @@ export function ModifyRetrospect(props: {
   };
 
   const handleModifyRetrospect = async () => {
-    // 마감 일자가 지난 회고를 수정할 경우에는 마감 일자를 1분 뒤로 설정하여 저장되도록 함
-    const next = addMinutes(new Date(), 1);
-    const currentDate = format(next, "yyyy-MM-dd'T'HH:mm:ss");
-
     const { status } = await editRetrospect({
       spaceId: props.spaceId,
       retrospectId: props.retrospectId,
       data: {
         title,
         introduction,
-        deadline: isPastDueDate ? currentDate : dueDate,
+        deadline: dueDate,
       },
     });
     if (status === 200) {

--- a/apps/web/src/component/space/view/RetrospectEditModal.tsx
+++ b/apps/web/src/component/space/view/RetrospectEditModal.tsx
@@ -11,7 +11,6 @@ import { usePatchRetrospect } from "@/hooks/api/retrospect/edit/usePatchRetrospe
 import { useInput } from "@/hooks/useInput";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 import { Retrospect } from "@/types/retrospect";
-import { addMinutes, format } from "date-fns";
 
 type RetrospectEditProps = {
   spaceId: string;
@@ -28,16 +27,12 @@ export function RetrospectEditModal({ spaceId, retrospectId, defaultValue, isAna
   const [deadline, setDeadline] = useState(defaultValue.deadline);
 
   const isEdited = title !== defaultValue.title || introduction !== defaultValue.introduction || deadline !== defaultValue.deadline;
-  const isPastDueDate = deadline ? new Date(deadline) <= new Date() : false;
 
   const handleModifyRetrospect = async () => {
-    // 마감 일자가 지난 회고를 수정할 경우에는 마감 일자를 1분 뒤로 설정하여 저장되도록 함
-    const next = addMinutes(new Date(), 1);
-    const currentDate = format(next, "yyyy-MM-dd'T'HH:mm:ss");
     patchRetrospect({
       spaceId: +spaceId,
       retrospectId: +retrospectId,
-      data: { title, introduction, deadline: isPastDueDate ? currentDate : deadline },
+      data: { title, introduction, deadline: deadline },
     });
   };
 

--- a/apps/web/src/layout/DesktopGlobalLayout.tsx
+++ b/apps/web/src/layout/DesktopGlobalLayout.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { Modal } from "@/component/common/Modal";
@@ -9,11 +9,19 @@ import ChannelService from "@/lib/channel-talk/service";
 import DesktopFunnelModal from "@/component/common/Modal/DesktopFunnelModal";
 import DesktopActionModal from "@/component/common/Modal/DesktopActionModal";
 import DesktopModal from "@/component/common/Modal/DesktopModal/DesktopModal";
+import { trackPageView } from "@/lib/google_analytics";
 
 export default function DesktopGlobalLayout() {
+  const location = useLocation();
+
   useEffect(() => {
     ChannelService.hideChannelButton();
   }, []);
+
+  // 페이지 이동 시 GA에 페이지뷰를 전송해요
+  useEffect(() => {
+    trackPageView(location.pathname + location.search);
+  }, [location]);
 
   return (
     <div

--- a/apps/web/src/layout/MobileGlobalLayout.tsx
+++ b/apps/web/src/layout/MobileGlobalLayout.tsx
@@ -9,6 +9,7 @@ import { Modal } from "@/component/common/Modal";
 import { PreventExternalBrowser } from "@/helper/preventExternalBrowser.tsx";
 import { useBridge } from "@/lib/provider/bridge-provider";
 import { PATHS } from "@layer/shared";
+import { trackPageView } from "@/lib/google_analytics";
 
 const siteId = import.meta.env.VITE_HOTJAR_KEY as number;
 const hotjarVersion = import.meta.env.VITE_HOTJAR_VERSION as number;
@@ -27,6 +28,11 @@ export default function MobileGlobalLayout() {
     } else {
       ChannelService.hideChannelButton();
     }
+  }, [location]);
+
+  // 페이지 이동 시 GA에 페이지뷰를 전송해요
+  useEffect(() => {
+    trackPageView(location.pathname + location.search);
   }, [location]);
 
   return (

--- a/apps/web/src/lib/google_analytics/events.ts
+++ b/apps/web/src/lib/google_analytics/events.ts
@@ -1,0 +1,9 @@
+export const GA_EVENTS = {
+  SPACE: {
+    CLICK_ADD: {
+      action: "click_space_add",
+      category: "space",
+      label: "스페이스_추가버튼",
+    },
+  },
+} as const;

--- a/apps/web/src/lib/google_analytics/events.ts
+++ b/apps/web/src/lib/google_analytics/events.ts
@@ -11,10 +11,10 @@ export const GA_EVENTS = {
       category: "space",
       label: "스페이스_추가버튼_하단",
     },
-    ADD_MODAL_CLOSE: {
-      action: "space_add_modal_close",
+    ADD_DONE: {
+      action: "space_add_dome",
       category: "space",
-      label: "스페이스_추가모달_닫기버튼",
+      label: "스페이스_생성완료버튼",
     },
   },
 
@@ -49,18 +49,6 @@ export const GA_EVENTS = {
       action: "retrospect_write_submit_complete",
       category: "retrospect",
       label: "회고_작성_제출완료버튼",
-    },
-    // 회고 생성 퍼널 진입 시
-    FUNNEL_VIEW_CREATE: {
-      action: "retrospect_funnel_view",
-      category: "retrospect",
-      label: "회고생성_단계_진입",
-    },
-    // 템플릿 추천 퍼널 진입 시
-    FUNNEL_VIEW_RECOMMEND: {
-      action: "retrospect_funnel_view",
-      category: "retrospect",
-      label: "템플릿추천_단계_진입",
     },
     // 템플릿 리스트 퍼널 진입 시
     FUNNEL_VIEW_LIST: {
@@ -97,3 +85,26 @@ export const GA_EVENTS = {
     },
   },
 } as const;
+
+// 퍼널 단계 라벨 상수
+export const GA_FUNNEL_LABELS = {
+  RETROSPECT_CREATE: {
+    confirmTemplate: "템플릿_확인",
+    mainInfo: "기본정보_입력",
+    dueDate: "마감일_지정",
+  } as Record<string, string>,
+
+  TEMPLATE_RECOMMEND: {
+    0: "회고_패턴_선택",
+    1: "회고_주기_선택",
+    2: "회고_목적_선택",
+  } as Record<number, string>,
+
+  SPACE_CREATE: {
+    INFO: { 0: "프로젝트_유형_선택", 1: "프로젝트_정보_입력", 2: "템플릿_선택" },
+    RECOMMEND: { 0: "회고_패턴_선택", 1: "회고_주기_선택", 2: "회고_목적_선택" },
+    RECOMMEND_PROGRESS: { 0: "템플릿_추천_진행중", 1: "템플릿_추천_확정" },
+    CREATE: { 0: "질문_생성", 1: "마감일_지정" },
+    COMPLETE: { 0: "스페이스_생성_완료" },
+  } as Record<string, Record<number, string>>,
+};

--- a/apps/web/src/lib/google_analytics/events.ts
+++ b/apps/web/src/lib/google_analytics/events.ts
@@ -17,17 +17,65 @@ export const GA_EVENTS = {
       label: "스페이스_추가모달_닫기버튼",
     },
   },
+
   // 회고 관련 GA이벤트
   RETROSPECT: {
+    // 회고 추가 버튼 클릭 시
     ADD: {
       action: "retrospect_add",
       category: "retrospect",
       label: "회고_추가버튼",
     },
-    COMPLETE: {
+    // 회고 추가 완료 버튼 클릭 시
+    ADD_COMPLETE: {
       action: "retrospect_complete",
       category: "retrospect",
       label: "회고_완료버튼",
+    },
+    // 우상단 제출하기 버튼 (모달 오픈)
+    WRITE_SUBMIT_OPEN: {
+      action: "retrospect_write_submit_open",
+      category: "retrospect",
+      label: "회고_작성_제출하기버튼_상단",
+    },
+    // 팝업 안의 제출하기 버튼 (실제 제출)
+    WRITE_SUBMIT_CONFIRM: {
+      action: "retrospect_write_submit_confirm",
+      category: "retrospect",
+      label: "회고_작성_제출하기버튼_모달",
+    },
+    // 제출 완료 팝업의 완료 버튼
+    WRITE_SUBMIT_DONE: {
+      action: "retrospect_write_submit_complete",
+      category: "retrospect",
+      label: "회고_작성_제출완료버튼",
+    },
+  },
+  // 실행목표 관련 GA 이벤트
+  ACTION_ITEM: {
+    // 실행목표 추가 버튼 클릭 시
+    ADD: {
+      action: "action_item_add",
+      category: "action_item",
+      label: "실행목표_추가버튼",
+    },
+    // 실행목표 추가 완료 버튼 클릭 시
+    ADD_DONE: {
+      action: "action_item_add_done",
+      category: "action_item",
+      label: "실행목표_추가완료버튼",
+    },
+    // 실행목표 편집 버튼 클릭 시
+    EDIT: {
+      action: "action_item_edit",
+      category: "action_item",
+      label: "실행목표_편집버튼",
+    },
+    // 실행목표 편집 완료 버튼 클릭 시
+    EDIT_DONE: {
+      action: "action_item_edit_complete",
+      category: "action_item",
+      label: "실행목표_편집완료버튼",
     },
   },
 } as const;

--- a/apps/web/src/lib/google_analytics/events.ts
+++ b/apps/web/src/lib/google_analytics/events.ts
@@ -1,9 +1,33 @@
 export const GA_EVENTS = {
+  // 스페이스 관련 GA이벤트
   SPACE: {
-    CLICK_ADD: {
-      action: "click_space_add",
+    ADD_ICON: {
+      action: "space_add",
       category: "space",
-      label: "스페이스_추가버튼",
+      label: "스페이스_추가버튼_상단_아이콘",
+    },
+    ADD_BUTTON: {
+      action: "space_add",
+      category: "space",
+      label: "스페이스_추가버튼_하단",
+    },
+    ADD_MODAL_CLOSE: {
+      action: "space_add_modal_close",
+      category: "space",
+      label: "스페이스_추가모달_닫기버튼",
+    },
+  },
+  // 회고 관련 GA이벤트
+  RETROSPECT: {
+    ADD: {
+      action: "retrospect_add",
+      category: "retrospect",
+      label: "회고_추가버튼",
+    },
+    COMPLETE: {
+      action: "retrospect_complete",
+      category: "retrospect",
+      label: "회고_완료버튼",
     },
   },
 } as const;

--- a/apps/web/src/lib/google_analytics/events.ts
+++ b/apps/web/src/lib/google_analytics/events.ts
@@ -50,6 +50,24 @@ export const GA_EVENTS = {
       category: "retrospect",
       label: "회고_작성_제출완료버튼",
     },
+    // 회고 생성 퍼널 진입 시
+    FUNNEL_VIEW_CREATE: {
+      action: "retrospect_funnel_view",
+      category: "retrospect",
+      label: "회고생성_단계_진입",
+    },
+    // 템플릿 추천 퍼널 진입 시
+    FUNNEL_VIEW_RECOMMEND: {
+      action: "retrospect_funnel_view",
+      category: "retrospect",
+      label: "템플릿추천_단계_진입",
+    },
+    // 템플릿 리스트 퍼널 진입 시
+    FUNNEL_VIEW_LIST: {
+      action: "retrospect_funnel_view",
+      category: "retrospect",
+      label: "템플릿리스트_단계_진입",
+    },
   },
   // 실행목표 관련 GA 이벤트
   ACTION_ITEM: {

--- a/apps/web/src/lib/google_analytics/index.ts
+++ b/apps/web/src/lib/google_analytics/index.ts
@@ -1,0 +1,21 @@
+declare global {
+  interface Window {
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+const GA_ID = import.meta.env.VITE_GA_ID;
+const isProduction = import.meta.env.MODE === "production";
+
+export const trackPageView = (path: string) => {
+  if (!isProduction) return;
+  window.gtag("config", GA_ID, { page_path: path });
+};
+
+export const trackEvent = (params: { action: string; category: string; label?: string }) => {
+  if (!isProduction) return;
+  window.gtag("event", params.action, {
+    event_category: params.category,
+    event_label: params.label,
+  });
+};

--- a/apps/web/src/lib/google_analytics/index.ts
+++ b/apps/web/src/lib/google_analytics/index.ts
@@ -4,7 +4,7 @@ declare global {
   }
 }
 
-const GA_ID = import.meta.env.VITE_GA_ID;
+const GA_ID = import.meta.env.VITE_GOOGLE_ANALYTICS;
 const isProduction = import.meta.env.MODE === "production";
 
 export const trackPageView = (path: string) => {

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "packages/*",
     "apps/*"
   ],
-  "version": "2.0.8"
+  "version": "2.0.9"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "layer",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "private": true,
   "scripts": {
     "web": "pnpm -F @layer/web",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layer/shared",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "",
   "main": "index.ts",
   "types": "./index.ts",


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- Google Analytics를 웹 애플리케이션에 연동하여 사용자 행동 데이터를 수집합니다.
- 회고 생성, 실행 목표 관리, 스페이스 생성 등 주요 사용자 액션에 대한 이벤트를 추적합니다.
- 페이지 뷰 추적을 통해 사용자 흐름을 분석합니다.

### 🫨 Describe your Change (변경사항)

- 웹 애플리케이션의 `index.html`에 Google Analytics 스크립트를 추가했습니다.
- 회고 생성, 템플릿 추천/목록 조회, 회고 작성 완료 등 회고 관련 주요 이벤트 추적 로직을 추가했습니다.
- 스페이스 생성 및 추가 버튼 클릭 시 이벤트를 추적하도록 구현했습니다.
- 실행 목표 추가 및 편집 완료 시 이벤트를 추적하도록 구현했습니다.
- 데스크톱 및 모바일 레이아웃에 페이지 뷰 추적 로직을 추가했습니다.
- 회고 마감일 수정 시 불필요한 `addMinutes` 로직을 제거했습니다.
- 모든 `package.json` 파일의 버전을 2.0.9로 업데이트했습니다.

### 🧐 Issue number and link (참고)

closes: #2

### 📚 Reference (참조)

-