### PR TITLE
GA 이벤트명 개선 및 내부 사용자 추적 제외

### DIFF
--- a/apps/web/src/lib/google-analytics/events.ts
+++ b/apps/web/src/lib/google-analytics/events.ts
@@ -12,14 +12,14 @@ export const GA_EVENTS = {
       label: "스페이스_추가버튼_하단",
     },
     ADD_DONE_A_LAYOUT: {
-      action: "space_add_done",
+      action: "space_add_done_A",
       category: "space",
-      label: "스페이스_추가_완료_A인",
+      label: "스페이스_추가_완료_A안",
     },
     ADD_DONE_B_LAYOUT: {
-      action: "space_add_done",
+      action: "space_add_done_B",
       category: "space",
-      label: "스페이스_추가_완료_B인",
+      label: "스페이스_추가_완료_B안",
     },
   },
 
@@ -33,12 +33,12 @@ export const GA_EVENTS = {
     },
     // 회고 추가 완료 버튼 클릭 시
     ADD_COMPLETE_A_LAYOUT: {
-      action: "retrospect_complete",
+      action: "retrospect_complete_A",
       category: "retrospect",
       label: "회고_추가_완료_A안",
     },
     ADD_COMPLETE_B_LAYOUT: {
-      action: "retrospect_complete",
+      action: "retrospect_complete_B",
       category: "retrospect",
       label: "회고_추가_완료_B안",
     },

--- a/apps/web/src/lib/google-analytics/index.ts
+++ b/apps/web/src/lib/google-analytics/index.ts
@@ -1,3 +1,5 @@
+import { isInternalUser } from "@/utils/userUtil";
+
 declare global {
   interface Window {
     gtag: (...args: unknown[]) => void;
@@ -13,7 +15,9 @@ export const trackPageView = (path: string) => {
 };
 
 export const trackEvent = (params: { action: string; category: string; label?: string }) => {
-  if (!isProduction) return;
+  if (!isProduction) return; // 실환경일 때만 추적
+  if (isInternalUser()) return; // 레이어 내부 팀원가 아닐 경우에만 추적
+
   window.gtag("event", params.action, {
     event_category: params.category,
     event_label: params.label,

--- a/apps/web/src/utils/userUtil.ts
+++ b/apps/web/src/utils/userUtil.ts
@@ -1,9 +1,16 @@
 import Cookies from "js-cookie";
 import { COOKIE_KEYS } from "@/config/storage-keys";
 
+const INTERNAL_TEAM_USER_IDS = [146, 147, 149, 150, 153, 156, 157, 158, 185, 260, 837, 845, 855, 917];
+
 function isSpaceLeader(spaceId: string | number | undefined) {
   const userId = Cookies.get(COOKIE_KEYS.memberId);
   return String(userId) === String(spaceId);
 }
 
-export { isSpaceLeader };
+function isInternalUser() {
+  const userId = Number(Cookies.get(COOKIE_KEYS.memberId));
+  return INTERNAL_TEAM_USER_IDS.includes(userId);
+}
+
+export { isSpaceLeader, isInternalUser };


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- GA A/B 테스트 이벤트명 명확화
- 내부 사용자 GA 추적 제외 로직 추가
- 내부 사용자 식별 유틸리티 함수 구현

### 🫨 Describe your Change (변경사항)

- GA_EVENTS 객체 내 `action` 및 `label` 필드에 A/B 테스트 구분을 위한 접미사 추가 및 오타 수정 (예: `_A`, `_B`, '인' → '안').
- `trackEvent` 함수에 `isInternalUser()` 체크 로직을 추가하여 내부 사용자의 이벤트 추적을 방지합니다.
- `userUtil.ts` 파일에 내부 팀원 ID 목록 `INTERNAL_TEAM_USER_IDS` 상수를 정의했습니다.
- `userUtil.ts` 파일에 현재 로그인한 사용자가 내부 팀원인지 확인하는 `isInternalUser` 함수를 추가했습니다.
- `isInternalUser` 함수를 `google-analytics/index.ts`에서 임포트하여 사용합니다.

### 🧐 Issue number and link (참고)

closes: #859

### 📚 Reference (참조)

-