### PR TITLE
fix: #865 회고 작성 시, 템플릿의 값이 누락되는 케이스 수정

### DIFF
--- a/apps/web/src/app/desktop/retrospectSpace/RetroSpectSpacePage.tsx
+++ b/apps/web/src/app/desktop/retrospectSpace/RetroSpectSpacePage.tsx
@@ -48,7 +48,7 @@ export default function RetroSpectSpacePage() {
         name: spaceData.name,
         introduction: spaceData.introduction,
         formId: spaceData.formId ?? prev?.formId ?? 0,
-        formTag: prev?.formTag ?? null,
+        formTag: spaceData.formTag ?? prev?.formTag ?? null,
         bannerUrl: spaceData.bannerUrl,
         memberCount: spaceData.memberCount,
         leader: spaceData.leader,

--- a/apps/web/src/hooks/api/space/useApiGetSpace.ts
+++ b/apps/web/src/hooks/api/space/useApiGetSpace.ts
@@ -8,6 +8,7 @@ type SpaceResponse = {
   category: ProjectType;
   fieldList: FieldType[];
   formId: number | null;
+  formTag: string | null;
   id: number;
   introduction: string;
   memberCount: number;


### PR DESCRIPTION
> ### 회고 작성 시 템플릿 필터의 formTag 값이 올바르게 설정되도록 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 회고 작성 시, 템플릿의 formTag 값이 누락되는 이슈가 있어 수정을 진행했습니다. 

### 🫨 Describe your Change (변경사항)

- 스페이스 상세 조회의 응답 값을 활용하도록 수정

### 🧐 Issue number and link (참고)
- close #865 

### 📚 Reference (참조)

- n/a
