### PR TITLE
fix: #870 템플릿 리스트보기 내에서 이벤트 클릭 시 발생하는 에러 수정

### DIFF
--- a/apps/web/src/api/backoffice/index.ts
+++ b/apps/web/src/api/backoffice/index.ts
@@ -1,4 +1,5 @@
 import { api } from "@/api";
+import { TemplateChoiceFormTag } from "@/types/template";
 
 /**
  * @description 템플릿 추천 클릭 이벤트 통계를 서버에 전송합니다.
@@ -18,9 +19,12 @@ export const postTemplateClickListView = async () => {
 
 /**
  * @description 템플릿 리스트 보기 내에서 선택 이벤트 통계를 서버에 전송합니다.
+ * @param formTag - 사용자가 선택한 템플릿 태그 (예: KPT, FIVE_F 등)
  */
-export const postTemplateChoiceListView = async () => {
-  const response = await api.post("/stats/template/choice/list-view");
+export const postTemplateChoiceListView = async (formTag: TemplateChoiceFormTag) => {
+  const response = await api.post("/stats/template/choice/list-view", null, {
+    params: { formTag },
+  });
   return response.data;
 };
 

--- a/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListItem/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListItem/index.tsx
@@ -10,7 +10,7 @@ import { retrospectInitialState } from "@/store/retrospect/retrospectInitial";
 import { TemplateListConform } from "../TemplateListConform";
 import { useSearchParams } from "react-router-dom";
 import { useApiPostTemplateChoiceListView } from "@/hooks/api/backoffice/useApiPostTemplateChoiceListView";
-import { TemplateChoiceFormTag } from "@/types/template";
+import { resolveFormTag } from "@/utils/template/resolveFormTag";
 
 export type DesktopTemplateListItemProps = {
   id: number;
@@ -19,21 +19,6 @@ export type DesktopTemplateListItemProps = {
   imageUrl?: string;
   date?: string;
 };
-
-/**
- * 화면에 보여주는 템플릿 태그 문자열을 백엔드 통계 API의 enum 값으로 매핑합니다.
- * 매핑되지 않은 케이스는 커스텀 템플릿(CUSTOM)으로 간주합니다.
- */
-const TEMPLATE_TAG_TO_FORM_TAG: Record<string, TemplateChoiceFormTag> = {
-  KPT: "KPT",
-  "5F": "FIVE_F",
-  "Mad Sad Glad": "MAD_SAD_GLAD",
-  SSC: "SSC",
-  PMI: "PMI",
-  무제: "UNTITLED",
-};
-
-const resolveFormTag = (tag: string): TemplateChoiceFormTag => TEMPLATE_TAG_TO_FORM_TAG[tag] ?? "CUSTOM";
 
 export function TemplateListItem({ id, title, tag, imageUrl }: DesktopTemplateListItemProps) {
   const { openFunnelModal, closeFunnelModal } = useFunnelModal();

--- a/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListItem/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListItem/index.tsx
@@ -10,6 +10,7 @@ import { retrospectInitialState } from "@/store/retrospect/retrospectInitial";
 import { TemplateListConform } from "../TemplateListConform";
 import { useSearchParams } from "react-router-dom";
 import { useApiPostTemplateChoiceListView } from "@/hooks/api/backoffice/useApiPostTemplateChoiceListView";
+import { TemplateChoiceFormTag } from "@/types/template";
 
 export type DesktopTemplateListItemProps = {
   id: number;
@@ -18,6 +19,21 @@ export type DesktopTemplateListItemProps = {
   imageUrl?: string;
   date?: string;
 };
+
+/**
+ * 화면에 보여주는 템플릿 태그 문자열을 백엔드 통계 API의 enum 값으로 매핑합니다.
+ * 매핑되지 않은 케이스는 커스텀 템플릿(CUSTOM)으로 간주합니다.
+ */
+const TEMPLATE_TAG_TO_FORM_TAG: Record<string, TemplateChoiceFormTag> = {
+  KPT: "KPT",
+  "5F": "FIVE_F",
+  "Mad Sad Glad": "MAD_SAD_GLAD",
+  SSC: "SSC",
+  PMI: "PMI",
+  무제: "UNTITLED",
+};
+
+const resolveFormTag = (tag: string): TemplateChoiceFormTag => TEMPLATE_TAG_TO_FORM_TAG[tag] ?? "CUSTOM";
 
 export function TemplateListItem({ id, title, tag, imageUrl }: DesktopTemplateListItemProps) {
   const { openFunnelModal, closeFunnelModal } = useFunnelModal();
@@ -121,7 +137,7 @@ export function TemplateListItem({ id, title, tag, imageUrl }: DesktopTemplateLi
               });
             }
 
-            templateChoiceClickMutation();
+            templateChoiceClickMutation(resolveFormTag(tag));
           }}
         >
           <Typography variant={"body12Bold"} color={"gray800"}>

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -77,6 +77,8 @@ import { TemplateTip } from "../../component/retrospect/template/list/TemplateLi
 import { TemplateQuestion } from "../../component/retrospect/template/list/TemplateListDetailItem/TemplateQuestion";
 import { splitTemplateIntroduction } from "@/utils/retrospect/splitTemplateIntroduction";
 import { useGetSimpleTemplateInfo } from "@/hooks/api/template/useGetSimpleTemplateInfo";
+import { resolveFormTag } from "@/component/retrospect/template/list/DefaultTemplateListItem";
+import { useApiPostTemplateChoiceListView } from "@/hooks/api/backoffice/useApiPostTemplateChoiceListView";
 
 type flowType = "INFO" | "RECOMMEND" | "RECOMMEND_PROGRESS" | "CREATE" | "COMPLETE";
 type templateType = { id: number; title: string; imageUrl: string; templateName: string };
@@ -312,6 +314,8 @@ function SelectRetrospectTemplateBranchFunnel() {
   };
 
   function TemplateListItem({ id, title, tag, imageUrl }: DesktopTemplateListItemProps) {
+    const { mutate: templateChoiceClickMutation } = useApiPostTemplateChoiceListView();
+
     return (
       <li
         css={css`
@@ -374,6 +378,7 @@ function SelectRetrospectTemplateBranchFunnel() {
           `}
           onClick={(event) => {
             event.stopPropagation();
+            templateChoiceClickMutation(resolveFormTag(tag));
             handleNextPhase({ id: id?.toString(), to: "result" });
           }}
         >
@@ -492,6 +497,7 @@ function DetailRetrospectTemplateBranchFunnel() {
   const { data } = useGetTemplateInfo({ templateId: selectedRecommendTemplateId! });
   const { heading, description } = splitTemplateIntroduction(data.introduction);
   const { updateState } = useDesktopBasicModal();
+  const { mutate: templateChoiceClickMutation } = useApiPostTemplateChoiceListView();
 
   const isFromConfirm = detailFrom === "confirm";
   const handleBack = () => {
@@ -539,7 +545,14 @@ function DetailRetrospectTemplateBranchFunnel() {
 
       {!isFromConfirm && (
         <ButtonProvider sort={"horizontal"}>
-          <ButtonProvider.Primary onClick={() => setFlow("INFO", 4)}>선택하기</ButtonProvider.Primary>
+          <ButtonProvider.Primary
+            onClick={() => {
+              setFlow("INFO", 4);
+              templateChoiceClickMutation(resolveFormTag(data.templateName));
+            }}
+          >
+            선택하기
+          </ButtonProvider.Primary>
         </ButtonProvider>
       )}
     </Fragment>

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -77,8 +77,8 @@ import { TemplateTip } from "../../component/retrospect/template/list/TemplateLi
 import { TemplateQuestion } from "../../component/retrospect/template/list/TemplateListDetailItem/TemplateQuestion";
 import { splitTemplateIntroduction } from "@/utils/retrospect/splitTemplateIntroduction";
 import { useGetSimpleTemplateInfo } from "@/hooks/api/template/useGetSimpleTemplateInfo";
-import { resolveFormTag } from "@/component/retrospect/template/list/DefaultTemplateListItem";
 import { useApiPostTemplateChoiceListView } from "@/hooks/api/backoffice/useApiPostTemplateChoiceListView";
+import { resolveFormTag } from "@/utils/template/resolveFormTag";
 
 type flowType = "INFO" | "RECOMMEND" | "RECOMMEND_PROGRESS" | "CREATE" | "COMPLETE";
 type templateType = { id: number; title: string; imageUrl: string; templateName: string };

--- a/apps/web/src/app/mobile/template/TemplatePage.tsx
+++ b/apps/web/src/app/mobile/template/TemplatePage.tsx
@@ -44,10 +44,11 @@ export function TemplatePage() {
         isOnlyTemplateStyle={
           !isProvidedTemplateSet &&
           css`
-          #header {
+            #header {
               min-height: var(--app-bar-height);
               background-color: transparent;
-        `
+            }
+          `
         }
       >
         <TemplateLayout.Header

--- a/apps/web/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
+++ b/apps/web/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
@@ -9,8 +9,8 @@ import { Tag } from "@/component/common/tag";
 import { Typography } from "@/component/common/typography";
 import { TemplateLottiePicture } from "@/component/template/TemplateLottiePicture.tsx";
 import { useApiPostTemplateChoiceListView } from "@/hooks/api/backoffice/useApiPostTemplateChoiceListView";
-import { TemplateChoiceFormTag } from "@/types/template";
 import { PATHS } from "@layer/shared";
+import { resolveFormTag } from "@/utils/template/resolveFormTag";
 
 type DefaultTemplateListItemProps = {
   id: number;
@@ -19,21 +19,6 @@ type DefaultTemplateListItemProps = {
   imageUrl?: string;
   date?: string;
 };
-
-/**
- * 화면에 보여주는 템플릿 태그 문자열을 백엔드 통계 API의 enum 값으로 매핑합니다.
- * 매핑되지 않은 케이스는 커스텀 템플릿(CUSTOM)으로 간주합니다.
- */
-const TEMPLATE_TAG_TO_FORM_TAG: Record<string, TemplateChoiceFormTag> = {
-  KPT: "KPT",
-  "5F": "FIVE_F",
-  "Mad Sad Glad": "MAD_SAD_GLAD",
-  SSC: "SSC",
-  PMI: "PMI",
-  무제: "UNTITLED",
-};
-
-export const resolveFormTag = (tag: string): TemplateChoiceFormTag => TEMPLATE_TAG_TO_FORM_TAG[tag] ?? "CUSTOM";
 
 export function DefaultTemplateListItem({ id, title, tag, imageUrl }: DefaultTemplateListItemProps) {
   const { spaceId, readOnly } = useContext(TemplateListPageContext);

--- a/apps/web/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
+++ b/apps/web/src/component/retrospect/template/list/DefaultTemplateListItem.tsx
@@ -8,6 +8,8 @@ import { Card } from "@/component/common/Card";
 import { Tag } from "@/component/common/tag";
 import { Typography } from "@/component/common/typography";
 import { TemplateLottiePicture } from "@/component/template/TemplateLottiePicture.tsx";
+import { useApiPostTemplateChoiceListView } from "@/hooks/api/backoffice/useApiPostTemplateChoiceListView";
+import { TemplateChoiceFormTag } from "@/types/template";
 import { PATHS } from "@layer/shared";
 
 type DefaultTemplateListItemProps = {
@@ -18,9 +20,25 @@ type DefaultTemplateListItemProps = {
   date?: string;
 };
 
+/**
+ * 화면에 보여주는 템플릿 태그 문자열을 백엔드 통계 API의 enum 값으로 매핑합니다.
+ * 매핑되지 않은 케이스는 커스텀 템플릿(CUSTOM)으로 간주합니다.
+ */
+const TEMPLATE_TAG_TO_FORM_TAG: Record<string, TemplateChoiceFormTag> = {
+  KPT: "KPT",
+  "5F": "FIVE_F",
+  "Mad Sad Glad": "MAD_SAD_GLAD",
+  SSC: "SSC",
+  PMI: "PMI",
+  무제: "UNTITLED",
+};
+
+export const resolveFormTag = (tag: string): TemplateChoiceFormTag => TEMPLATE_TAG_TO_FORM_TAG[tag] ?? "CUSTOM";
+
 export function DefaultTemplateListItem({ id, title, tag, imageUrl }: DefaultTemplateListItemProps) {
   const { spaceId, readOnly } = useContext(TemplateListPageContext);
   const navigate = useNavigate();
+  const { mutate: templateChoiceClickMutation } = useApiPostTemplateChoiceListView();
 
   const handleClickDetail = () => {
     navigate(PATHS.viewDetailTemplate(), {
@@ -65,6 +83,7 @@ export function DefaultTemplateListItem({ id, title, tag, imageUrl }: DefaultTem
             colorSchema={"outline"}
             onClick={(e) => {
               e.stopPropagation();
+              templateChoiceClickMutation(resolveFormTag(tag));
               navigate(PATHS.retrospectRecommendDone(), {
                 state: { spaceId, templateId: id },
               });

--- a/apps/web/src/hooks/api/backoffice/useApiPostTemplateChoiceListView.ts
+++ b/apps/web/src/hooks/api/backoffice/useApiPostTemplateChoiceListView.ts
@@ -1,8 +1,9 @@
 import { useMutation, UseMutationOptions } from "@tanstack/react-query";
 
 import { postTemplateChoiceListView } from "@/api/backoffice";
+import { TemplateChoiceFormTag } from "@/types/template";
 
-export const useApiPostTemplateChoiceListView = (options?: UseMutationOptions) => {
+export const useApiPostTemplateChoiceListView = (options?: UseMutationOptions<unknown, Error, TemplateChoiceFormTag>) => {
   return useMutation({
     mutationFn: postTemplateChoiceListView,
     ...options,

--- a/apps/web/src/types/template.ts
+++ b/apps/web/src/types/template.ts
@@ -3,6 +3,11 @@ import { Questions } from "./retrospectCreate";
 
 type TemplateTag = "KPT" | "5F" | "Mad Sad Glad" | "SSC" | "PMI" | "무제";
 
+/**
+ * @description 백오피스: 템플릿 리스트 보기 내에서 선택 이벤트의 통계 전송 시 사용하는 폼 태그입니다.
+ */
+export type TemplateChoiceFormTag = "KPT" | "FIVE_F" | "MAD_SAD_GLAD" | "SSC" | "PMI" | "UNTITLED" | "CUSTOM";
+
 export type CustomTemplateRes = {
   title: string;
   tag: string;

--- a/apps/web/src/utils/template/resolveFormTag.ts
+++ b/apps/web/src/utils/template/resolveFormTag.ts
@@ -1,0 +1,16 @@
+import { TemplateChoiceFormTag } from "@/types/template";
+
+/**
+ * 화면에 보여주는 템플릿 태그 문자열을 백엔드 통계 API의 enum 값으로 매핑합니다.
+ * 매핑되지 않은 케이스는 커스텀 템플릿(CUSTOM)으로 간주합니다.
+ */
+const TEMPLATE_TAG_TO_FORM_TAG: Record<string, TemplateChoiceFormTag> = {
+  KPT: "KPT",
+  "5F": "FIVE_F",
+  "Mad Sad Glad": "MAD_SAD_GLAD",
+  SSC: "SSC",
+  PMI: "PMI",
+  무제: "UNTITLED",
+};
+
+export const resolveFormTag = (tag: string): TemplateChoiceFormTag => TEMPLATE_TAG_TO_FORM_TAG[tag] ?? "CUSTOM";


### PR DESCRIPTION
> ### 템플릿 리스트보기 내에서 이벤트 클릭 시, formTag 함께 전송하도록 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

- 템플릿 리스트보기 내에서 이벤트 클릭 시, formTag 함께 전송하도록 수정합니다. 

### 🫨 Describe your Change (변경사항)

- `postTemplateChoiceListView` params 추가
- `TemplateChoiceFormTag` 타입 추가 

### 🧐 Issue number and link (참고)
- close #870 

### 📚 Reference (참조)

- n/a
