### PR TITLE
최근 소셜 로그인 방식 툴팁 기능 구현

### DIFF
--- a/apps/web/src/component/common/tip/Tooltip.tsx
+++ b/apps/web/src/component/common/tip/Tooltip.tsx
@@ -8,7 +8,6 @@ import { Portal } from "@/component/common/Portal";
 import { Typography } from "@/component/common/typography";
 import { ANIMATION } from "@/style/common/animation";
 import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
-import { getDeviceType } from "@/utils/deviceUtils";
 
 type TooltipContextState = {
   referenceEl: HTMLDivElement | null;
@@ -85,7 +84,6 @@ function Content({
   autoHide = true,
 }: ContentProps) {
   const context = useContext(TooltipContext);
-  const { isDesktop } = getDeviceType();
 
   const [isVisible, setIsVisible] = useState(true);
   useEffect(() => {
@@ -150,14 +148,11 @@ function Content({
       {asChild ? (
         children
       ) : (
-        <div ref={(el) => context.setPopperEl(el)} style={{ ...styles.popper, zIndex: isDesktop ? 100001 : undefined }} {...attributes.popper}>
+        <div ref={(el) => context.setPopperEl(el)} style={{ ...styles.popper, zIndex: 100001 }} {...attributes.popper}>
           <div
             css={css`
               position: relative;
-              ${isDesktop &&
-              css`
-                z-index: 100001;
-              `}
+              z-index: 100001;
               background-color: ${DESIGN_SYSTEM_COLOR.blue600};
               padding: 1rem 1.4rem;
               border-radius: 1.2rem;

--- a/apps/web/src/component/login/SocialLoginArea.tsx
+++ b/apps/web/src/component/login/SocialLoginArea.tsx
@@ -1,17 +1,21 @@
 import { css, Interpolation, Theme } from "@emotion/react";
 import Cookies from "js-cookie";
-import { HTMLAttributes, useEffect } from "react";
+import { HTMLAttributes, useEffect, useState } from "react";
 
 import { ButtonProvider } from "@/component/common/button";
+import { Tooltip } from "@/component/common/tip";
 import { SocialLoginButton } from "@/component/login/SocialLoginButton.tsx";
 import { usePostAppleLogin } from "@/hooks/api/login/usePostAppleToken.ts";
+import { SocialLoginKind } from "@/types/loginType";
 import { isMobile } from "@/utils/etc";
+import { getRecentSocialLoginType } from "@/utils/login/recentSocialLogin";
 
 export function SocialLoginArea({
   onlyContainerStyle,
   ...props
 }: Omit<HTMLAttributes<HTMLDivElement>, "type"> & { onlyContainerStyle?: Interpolation<Theme> }) {
   const { mutate: postAppleLogin, isPending } = usePostAppleLogin();
+  const [recentSocialLoginType, setRecentSocialLoginType] = useState<SocialLoginKind | null>(null);
 
   window.AppleID.auth.init({
     clientId: `${import.meta.env.VITE_APPLE_CLIENT_ID}`,
@@ -26,6 +30,8 @@ export function SocialLoginArea({
     if (typeof window.Kakao !== "undefined" && !window.Kakao.isInitialized()) {
       window.Kakao.init(import.meta.env.VITE_KAKAO_KEY);
     }
+
+    setRecentSocialLoginType(getRecentSocialLoginType());
   }, []);
 
   const kakaoLoginRedirection = () => {
@@ -73,6 +79,21 @@ export function SocialLoginArea({
     window.location.href = link;
   };
 
+  const renderSocialLoginButton = (type: SocialLoginKind, handler: () => void) => {
+    const button = <SocialLoginButton type={type} handler={handler} />;
+
+    if (recentSocialLoginType !== type) {
+      return button;
+    }
+
+    return (
+      <Tooltip>
+        <Tooltip.Trigger>{button}</Tooltip.Trigger>
+        <Tooltip.Content message="최근 로그인한 방법이에요!" placement="top-start" offsetY={15} hideOnClick={true} autoHide={false} />
+      </Tooltip>
+    );
+  };
+
   return (
     <div
       {...props}
@@ -81,9 +102,9 @@ export function SocialLoginArea({
       `}
     >
       <ButtonProvider onlyContainerStyle={onlyContainerStyle} isProgress={isPending}>
-        <SocialLoginButton type="kakao" handler={kakaoLogin} />
-        <SocialLoginButton type="apple" handler={appleLogin} />
-        <SocialLoginButton type="google" handler={googleLogin} />
+        {renderSocialLoginButton("kakao", kakaoLogin)}
+        {renderSocialLoginButton("apple", appleLogin)}
+        {renderSocialLoginButton("google", googleLogin)}
       </ButtonProvider>
     </div>
   );

--- a/apps/web/src/config/storage-keys.ts
+++ b/apps/web/src/config/storage-keys.ts
@@ -25,4 +25,5 @@ export const AUTH_COOKIE_OPTIONS = {
 
 export const LOCAL_STORAGE_KEYS = {
   utmParamsKey: "UTM_PARAMS",
+  recentSocialLoginType: "RECENT_SOCIAL_LOGIN_TYPE",
 } as const;

--- a/apps/web/src/hooks/api/login/usePostAppleToken.ts
+++ b/apps/web/src/hooks/api/login/usePostAppleToken.ts
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/useToast";
 import { useTestNavigate } from "@/lib/test-natigate";
 import { authAtom } from "@/store/auth/authAtom";
 import { AuthResponse } from "@/types/loginType";
+import { setRecentSocialLoginType } from "@/utils/login/recentSocialLogin";
 
 //FIXME -공통 에러 처리하기 (usePostSignIn)
 type ErrorType = {
@@ -50,6 +51,7 @@ export const usePostAppleLogin = () => {
     mutationFn: postAppleLogin,
     onSuccess: (data: AuthResponse) => {
       if (data) {
+        setRecentSocialLoginType("apple");
         Cookies.set(COOKIE_KEYS.memberId, data.memberId.toString(), AUTH_COOKIE_OPTIONS);
         Cookies.set(COOKIE_KEYS.accessToken, data.accessToken, ACCESS_TOKEN_COOKIE_OPTIONS);
         Cookies.set(COOKIE_KEYS.refreshToken, data.refreshToken, AUTH_COOKIE_OPTIONS);

--- a/apps/web/src/hooks/api/login/usePostSignIn.ts
+++ b/apps/web/src/hooks/api/login/usePostSignIn.ts
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/useToast";
 import { useTestNavigate } from "@/lib/test-natigate";
 import { authAtom } from "@/store/auth/authAtom";
 import { LoginKindType, AuthResponse } from "@/types/loginType";
+import { setRecentSocialLoginType } from "@/utils/login/recentSocialLogin";
 
 type ErrorType = {
   status: number;
@@ -41,8 +42,9 @@ export const usePostSignIn = () => {
 
   return useMutation<AuthResponse, ErrorType, LoginKindType>({
     mutationFn: signInWithToken,
-    onSuccess: (data: AuthResponse) => {
+    onSuccess: (data: AuthResponse, variables: LoginKindType) => {
       if (data) {
+        setRecentSocialLoginType(variables.socialType);
         Cookies.set(COOKIE_KEYS.memberId, data.memberId.toString(), AUTH_COOKIE_OPTIONS);
         Cookies.set(COOKIE_KEYS.accessToken, data.accessToken, ACCESS_TOKEN_COOKIE_OPTIONS);
         Cookies.set(COOKIE_KEYS.refreshToken, data.refreshToken, AUTH_COOKIE_OPTIONS);

--- a/apps/web/src/hooks/api/login/usePostSignUp.ts
+++ b/apps/web/src/hooks/api/login/usePostSignUp.ts
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/useToast";
 import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { authAtom } from "@/store/auth/authAtom";
 import { AuthResponse, SocialLoginKind } from "@/types/loginType";
+import { setRecentSocialLoginType } from "@/utils/login/recentSocialLogin";
 
 type PostSignUp = {
   accessToken: string;
@@ -44,8 +45,11 @@ export const usePostSignUp = () => {
 
   return useMutation<AuthResponse, unknown, PostSignUp>({
     mutationFn: signUpWithToken,
-    onSuccess: (data: AuthResponse) => {
+    onSuccess: (data: AuthResponse, variables: PostSignUp) => {
       if (data) {
+        if (variables.socialType) {
+          setRecentSocialLoginType(variables.socialType);
+        }
         Cookies.set(COOKIE_KEYS.memberId, data.memberId.toString(), AUTH_COOKIE_OPTIONS);
         Cookies.set(COOKIE_KEYS.accessToken, data.accessToken, ACCESS_TOKEN_COOKIE_OPTIONS);
         Cookies.set(COOKIE_KEYS.refreshToken, data.refreshToken, AUTH_COOKIE_OPTIONS);

--- a/apps/web/src/utils/login/recentSocialLogin.ts
+++ b/apps/web/src/utils/login/recentSocialLogin.ts
@@ -1,0 +1,18 @@
+import { LOCAL_STORAGE_KEYS } from "@/config/storage-keys";
+import { SocialLoginKind } from "@/types/loginType";
+
+const SOCIAL_LOGIN_TYPES = ["kakao", "apple", "google"] satisfies SocialLoginKind[];
+
+export const getRecentSocialLoginType = (): SocialLoginKind | null => {
+  const storedType = localStorage.getItem(LOCAL_STORAGE_KEYS.recentSocialLoginType);
+
+  if (SOCIAL_LOGIN_TYPES.includes(storedType as SocialLoginKind)) {
+    return storedType as SocialLoginKind;
+  }
+
+  return null;
+};
+
+export const setRecentSocialLoginType = (socialType: SocialLoginKind) => {
+  localStorage.setItem(LOCAL_STORAGE_KEYS.recentSocialLoginType, socialType);
+};


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 로그인 화면에서 사용자가 최근 로그인한 소셜 로그인 방식에 툴팁을 표시합니다.
- 로그인 성공 시 해당 소셜 로그인 방식을 로컬 스토리지에 저장합니다.
- Tooltip 컴포넌트의 zIndex 로직을 간소화했습니다.

### 🫨 Describe your Change (변경사항)

- SocialLoginArea에 최근 로그인 방식 툴팁 표시 로직을 추가했습니다.
- LOCAL_STORAGE_KEYS에 recentSocialLoginType을 정의했습니다.
- Apple 로그인, 일반 로그인, 회원가입 성공 시 최근 소셜 로그인 방식을 저장하도록 업데이트했습니다.
- recentSocialLogin.ts 유틸리티를 통해 로컬 스토리지 저장/조회 기능을 제공합니다.
- Tooltip 컴포넌트의 zIndex 설정을 고정하여 디바이스 타입 의존성을 제거했습니다.

### 🧐 Issue number and link (참고)

closes: #863

### 📚 Reference (참조)

-