### PR TITLE
ID 파라미터 숫자형 통일 및 타입 개선

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTab.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/AnalysisTab.tsx
@@ -21,14 +21,14 @@ type AnalysisTabProps = {
 export default function AnalysisTab({ analysisData }: AnalysisTabProps) {
   const [searchParams] = useSearchParams();
 
-  const spaceId = searchParams.get("spaceId");
-  const retrospectId = searchParams.get("retrospectId");
+  const spaceId = Number(searchParams.get("spaceId"));
+  const retrospectId = Number(searchParams.get("retrospectId"));
 
   const { hasAIAnalyzed } = analysisData;
 
   const { data: analysisRetrospectsData, isPending: isPendingAnalysisData } = useApiGetAnalysis({
-    spaceId: spaceId || "",
-    retrospectId: retrospectId || "",
+    spaceId,
+    retrospectId,
   });
 
   const [selectedView, setSelectedView] = useState<ViewType>("개인");

--- a/apps/web/src/app/desktop/component/analysis/AnalysisDialog/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisDialog/index.tsx
@@ -14,15 +14,15 @@ export const PERSONAL_ANALYSIS_MENU_TABS = ["회고", "분석"] as const;
 export type AnalysisTab = (typeof TEAM_ANALYSIS_MENU_TABS)[number] | (typeof PERSONAL_ANALYSIS_MENU_TABS)[number];
 
 type AnalysisDialogProps = {
-  spaceId: string | null;
-  retrospectId: string | null;
+  spaceId: number | null;
+  retrospectId: number | null;
   isOverviewVisible: boolean;
   onToggleOverview: () => void;
 };
 
 export default function AnalysisDialog({ spaceId, retrospectId, isOverviewVisible, onToggleOverview }: AnalysisDialogProps) {
   const { data: analysisData, isPending: isPendingAnalysisData } = useGetAnalysisAnswer({ spaceId: spaceId, retrospectId: retrospectId });
-  const { data: spaceInfo } = useQuery(useApiOptionsGetSpaceInfo(spaceId as string));
+  const { data: spaceInfo } = useQuery(useApiOptionsGetSpaceInfo(spaceId ?? undefined));
 
   const isPersonal = Boolean(analysisData?.individuals.length === 1 && spaceInfo?.category === "INDIVIDUAL");
 

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/ActionItems.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/ActionItems.tsx
@@ -95,7 +95,7 @@ function Tab() {
 function List() {
   const { currentTab } = useActionItemsContext();
   const [searchParams] = useSearchParams();
-  const spaceId = searchParams.get("spaceId") as string;
+  const spaceId = Number(searchParams.get("spaceId"));
 
   const { data } = useQuery(useApiOptionsGetTeamActionItemList(spaceId));
 

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
@@ -48,7 +48,7 @@ export default function AnalysisOverviewHeader() {
     if (spaceInfo?.formId) {
       setRetrospectValue((prev) => ({
         ...prev,
-        templateId: String(spaceInfo.formId),
+        templateId: spaceInfo.formId,
       }));
 
       open({
@@ -196,7 +196,7 @@ export default function AnalysisOverviewHeader() {
         </article>
 
         {/* ---------- 회고 인원수 필터 ---------- */}
-        <MemberManagement spaceId={spaceId as string} />
+        {spaceId && <MemberManagement spaceId={spaceId} />}
       </section>
 
       {/* ---------- 실행목표 ---------- */}

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/RetrospectSection.tsx
@@ -22,7 +22,7 @@ interface RetrospectSectionProps {
   isPending: boolean;
   retrospects: Retrospect[];
   emptyMessage: string;
-  spaceId?: string | null;
+  spaceId?: number | null;
   needRetrospectAddButton?: boolean;
   enableScroll?: boolean;
 }
@@ -54,14 +54,14 @@ export default function RetrospectSection({
 
   const setRetrospectValue = useSetAtom(retrospectInitialState);
 
-  const { data: spaceInfo } = useQuery(useApiOptionsGetSpaceInfo(spaceId || undefined));
+  const { data: spaceInfo } = useQuery(useApiOptionsGetSpaceInfo(spaceId ?? undefined));
 
   // *회고 추가 함수
   const handleRetrospectCreate = () => {
     if (spaceInfo?.formId) {
       setRetrospectValue((prev) => ({
         ...prev,
-        templateId: String(spaceInfo.formId),
+        templateId: spaceInfo.formId,
       }));
 
       open({

--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/index.tsx
@@ -7,12 +7,12 @@ import RetrospectSection from "./RetrospectSection";
 import AnalysisOverviewHeader from "./AnalysisOverviewHeader";
 
 type AnalysisOverviewProps = {
-  spaceId: string | null;
+  spaceId: number | null;
 };
 
 export default function AnalysisOverview({ spaceId }: AnalysisOverviewProps) {
   // * 스페이스 회고 목록 조회
-  const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId || undefined));
+  const { data: retrospects, isPending: isRetrospectsPending } = useQuery(useApiOptionsGetRetrospects(spaceId ?? undefined));
 
   // * 진행 중인 회고 필터링
   const proceedingRetrospects = useMemo(() => retrospects?.filter((retrospect) => retrospect.retrospectStatus === "PROCEEDING") || [], [retrospects]);

--- a/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
@@ -21,7 +21,7 @@ export default function ActionItemsWrapper() {
 
   // * 실행목표 리스트 요청
   const { data: myActionItems, isPending: isMyActionItemsPending } = useGetActionItemList({
-    memberId: memberId as string,
+    memberId: Number(memberId),
     options: {
       enabled: !!memberId,
       select: (data) => data.actionItems,

--- a/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
+++ b/apps/web/src/app/desktop/component/home/RetrospectCard/index.tsx
@@ -17,7 +17,7 @@ import { useApiPostRetrospectClick } from "@/hooks/api/backoffice/useApiPostRetr
 
 interface RetrospectCardProps {
   retrospect: Retrospect;
-  spaceId?: string | null;
+  spaceId?: number | null;
 }
 
 export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardProps) {
@@ -57,7 +57,7 @@ export default function RetrospectCard({ retrospect, spaceId }: RetrospectCardPr
         openFunnelModal({
           title: "",
           step: "retrospectWrite",
-          contents: <Prepare spaceId={Number(targetSpaceId)} retrospectId={retrospectId} title={title} introduction={introduction} />,
+          contents: <Prepare spaceId={targetSpaceId} retrospectId={retrospectId} title={title} introduction={introduction} />,
         });
       } else if (writeStatus === "DONE") {
         navigate(PATHS.retrospectAnalysis(String(targetSpaceId), retrospectId, title));

--- a/apps/web/src/app/desktop/component/retrospect/template/list/CustomTemplateListDetailItem/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/CustomTemplateListDetailItem/index.tsx
@@ -26,7 +26,7 @@ function CustomTemplateListDetailItem({ templateId }: { templateId: number }) {
   const handleSelectTemplate = () => {
     setRetrospectValue((prev) => ({
       ...prev,
-      templateId: String(templateId),
+      templateId,
       saveTemplateId: true,
     }));
 

--- a/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListConform.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListConform.tsx
@@ -20,7 +20,7 @@ export function TemplateListConform() {
   const [retrospectValue, setRetrospectValue] = useAtom(retrospectInitialState);
   const setRetroCreateData = useSetAtom(retrospectCreateAtom);
 
-  const { data: templateData, isLoading } = useGetSimpleTemplateInfo(retrospectValue.tempTemplateId);
+  const { data: templateData, isLoading } = useGetSimpleTemplateInfo(retrospectValue.tempTemplateId ?? 0);
   const { openFunnelModal } = useFunnelModal();
   const { openActionModal } = useActionModal();
   const branchLayout = useAtomValue(branchLayoutAtom);

--- a/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListDetailItem/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListDetailItem/index.tsx
@@ -35,7 +35,7 @@ function TemplateListDetailItem({ templateId }: { templateId: number }) {
     } else {
       setRetrospectValue((prev) => ({
         ...prev,
-        tempTemplateId: String(templateId),
+        tempTemplateId: templateId,
         saveTemplateId: true,
       }));
 

--- a/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListItem/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListItem/index.tsx
@@ -112,7 +112,7 @@ export function TemplateListItem({ id, title, tag, imageUrl }: DesktopTemplateLi
               // 기존 스페이스가 존재할 때, (회고 템플릿 별도 생성)
               setRetrospectValue((prev) => ({
                 ...prev,
-                tempTemplateId: String(id),
+                tempTemplateId: id,
                 saveTemplateId: true,
               }));
               openFunnelModal({

--- a/apps/web/src/app/desktop/component/retrospect/template/recommend/Done.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/recommend/Done.tsx
@@ -21,8 +21,8 @@ import { TemplateList } from "../list";
 function RecommendDone() {
   const setRetrospectValue = useSetAtom(retrospectInitialState);
   const { tempTemplateId, spaceId } = useAtomValue(retrospectInitialState);
-  const { data } = useApiGetSpace(spaceId);
-  const { data: templateData, isLoading } = useGetSimpleTemplateInfo(tempTemplateId);
+  const { data } = useApiGetSpace(spaceId ?? 0);
+  const { data: templateData, isLoading } = useGetSimpleTemplateInfo(tempTemplateId ?? 0);
   const { openFunnelModal } = useFunnelModal();
   const { openActionModal } = useActionModal();
   const branchLayout = useAtomValue(branchLayoutAtom);

--- a/apps/web/src/app/desktop/component/retrospect/template/recommend/Search.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/recommend/Search.tsx
@@ -9,10 +9,10 @@ import { createTemplateArr } from "@/utils/retrospect/createTemplateArr";
 import { useAtomValue } from "jotai";
 import { retrospectInitialState } from "@/store/retrospect/retrospectInitial";
 
-export function RecommendSearch({ newTempTemplateId }: { newTempTemplateId: string }) {
+export function RecommendSearch({ newTempTemplateId }: { newTempTemplateId: number }) {
   const { spaceId } = useAtomValue(retrospectInitialState);
-  const TemplateArr = createTemplateArr(newTempTemplateId as unknown as TemplateKey);
-  const { data, isLoading } = useApiGetSpace(spaceId);
+  const TemplateArr = createTemplateArr(newTempTemplateId as TemplateKey);
+  const { data, isLoading } = useApiGetSpace(spaceId ?? 0, false, { enabled: spaceId != null });
 
   if (isLoading) return <LoadingModal />;
 
@@ -23,7 +23,7 @@ export function RecommendSearch({ newTempTemplateId }: { newTempTemplateId: stri
       <Header title={`${data?.name}${particle} 어울리는\n회고 템플릿을 찾는중...`} />
       <Spacing size={13} />
       <div>
-        <CardCarousel templateId={newTempTemplateId} spaceId={spaceId} templateArr={TemplateArr} />
+        <CardCarousel templateId={newTempTemplateId} spaceId={spaceId ?? undefined} templateArr={TemplateArr} />
       </div>
     </>
   );

--- a/apps/web/src/app/desktop/component/retrospect/template/recommend/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/recommend/index.tsx
@@ -50,7 +50,7 @@ export function TemplateRecommend() {
 
       setRetrospectValue((prev) => ({
         ...prev,
-        tempTemplateId: String(data.formId),
+        tempTemplateId: data.formId,
       }));
 
       track("TEMPLATE_RECOMMEND", {
@@ -64,7 +64,7 @@ export function TemplateRecommend() {
       openFunnelModal({
         title: "",
         step: "recommendTemplate",
-        contents: <RecommendSearch newTempTemplateId={String(data.formId)} />,
+        contents: <RecommendSearch newTempTemplateId={data.formId} />,
       });
     } catch (error) {
       console.log(error);

--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -70,7 +70,7 @@ export function RetrospectCreate() {
 
           setRetrospectValue((prev) => ({
             ...prev,
-            tempTemplateId: "",
+            tempTemplateId: null,
             saveTemplateId: false,
           }));
 

--- a/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
+++ b/apps/web/src/app/desktop/retrospect/AnalysisPage.tsx
@@ -18,10 +18,12 @@ export default function AnalysisPage() {
 
   const { isCollapsed, handleCollapse } = useNavigation();
 
-  const spaceId = searchParams.get("spaceId");
-  const retrospectId = searchParams.get("retrospectId");
+  const rawSpaceId = searchParams.get("spaceId");
+  const rawRetrospectId = searchParams.get("retrospectId");
+  const spaceId = rawSpaceId ? Number(rawSpaceId) : null;
+  const retrospectId = rawRetrospectId ? Number(rawRetrospectId) : null;
 
-  const { data: spaceInfo } = useQuery(useApiOptionsGetSpaceInfo(spaceId || undefined));
+  const { data: spaceInfo } = useQuery(useApiOptionsGetSpaceInfo(spaceId ?? undefined));
 
   const handleToggleOverview = () => {
     setIsOverviewVisible(!isOverviewVisible);
@@ -36,7 +38,7 @@ export default function AnalysisPage() {
   }, []);
 
   useEffect(() => {
-    if (spaceId && spaceInfo && (!currentSpace || String(currentSpace.id) !== spaceId)) {
+    if (spaceId && spaceInfo && (!currentSpace || currentSpace.id !== spaceId)) {
       setCurrentSpace(spaceInfo);
     }
   }, [spaceId, spaceInfo, currentSpace, setCurrentSpace]);

--- a/apps/web/src/app/desktop/retrospectSpace/RetroSpectSpacePage.tsx
+++ b/apps/web/src/app/desktop/retrospectSpace/RetroSpectSpacePage.tsx
@@ -5,7 +5,7 @@ import RetrospectSpaceHeader from "@/component/retrospect/space/RetrospectSpaceH
 import { useApiPostRetrospectImpression } from "@/hooks/api/backoffice/useApiPostRetrospectImpression";
 import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
 import { useApiGetSpace } from "@/hooks/api/space/useApiGetSpace";
-import { useRequiredParams } from "@/hooks/useRequiredParams";
+import { useRequiredNumberParams } from "@/hooks/useRequiredParams";
 import { retrospectInitialState } from "@/store/retrospect/retrospectInitial";
 import { currentSpaceState } from "@/store/space/spaceAtom";
 import { css } from "@emotion/react";
@@ -14,7 +14,7 @@ import { useAtom, useSetAtom } from "jotai";
 import { useEffect } from "react";
 
 export default function RetroSpectSpacePage() {
-  const { spaceId } = useRequiredParams<{ spaceId: string }>();
+  const { spaceId } = useRequiredNumberParams<{ spaceId: number }>();
   const setRetrospectValue = useSetAtom(retrospectInitialState);
   const [currentSpace, setCurrentSpace] = useAtom(currentSpaceState);
 
@@ -42,7 +42,7 @@ export default function RetroSpectSpacePage() {
   useEffect(() => {
     if (isSuccess && spaceData) {
       setCurrentSpace((prev) => ({
-        id: spaceData.id.toString(),
+        id: spaceData.id,
         category: spaceData.category,
         fieldList: prev?.fieldList ?? [],
         name: spaceData.name,

--- a/apps/web/src/app/desktop/retrospectWrite/RetrospectWritePage.tsx
+++ b/apps/web/src/app/desktop/retrospectWrite/RetrospectWritePage.tsx
@@ -8,7 +8,7 @@ function RetroSpectWritePage() {
   const [searchParams] = useSearchParams();
   const [isOverviewVisible, setIsOverviewVisible] = useState(true);
 
-  const spaceId = searchParams.get("spaceId");
+  const spaceId = Number(searchParams.get("spaceId"));
   const retrospectId = searchParams.get("retrospectId");
 
   const handleToggleOverview = () => {

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -303,8 +303,8 @@ function SelectRetrospectTemplateBranchFunnel() {
     setFlow("RECOMMEND", 0);
   };
 
-  const handleNextPhase = ({ id, to }: { id: string; to: "result" | "detail" }) => {
-    setSelectedRecommendTemplateId(Number(id));
+  const handleNextPhase = ({ id, to }: { id: number; to: "result" | "detail" }) => {
+    setSelectedRecommendTemplateId(id);
     if (to === "detail") {
       nextPhase();
     }
@@ -325,7 +325,7 @@ function SelectRetrospectTemplateBranchFunnel() {
           background-color: #fff;
           cursor: pointer;
         `}
-        onClick={() => handleNextPhase({ id: id?.toString(), to: "detail" })}
+        onClick={() => handleNextPhase({ id, to: "detail" })}
       >
         <div
           css={css`
@@ -379,7 +379,7 @@ function SelectRetrospectTemplateBranchFunnel() {
           onClick={(event) => {
             event.stopPropagation();
             templateChoiceClickMutation(resolveFormTag(tag));
-            handleNextPhase({ id: id?.toString(), to: "result" });
+            handleNextPhase({ id, to: "result" });
           }}
         >
           <Typography variant={"body12Bold"} color={"gray800"}>
@@ -706,7 +706,7 @@ function SelectRetrospectTemplateFunnel() {
 function ConfirmRetrospectTemplateFunnel() {
   const { selectedRecommendTemplateId, setFlow, goBackToTemplateSelect, setDetailFrom } = useContext(PhaseContext);
   if (!selectedRecommendTemplateId) return;
-  const { data: templateData } = useGetSimpleTemplateInfo(selectedRecommendTemplateId?.toString());
+  const { data: templateData } = useGetSimpleTemplateInfo(selectedRecommendTemplateId);
   return (
     <Fragment>
       <Header title={`해당 템플릿으로\n회고를 진행할까요?`} contents="템플릿을 기반으로 질문을 커스텀 할 수 있어요" />
@@ -1324,13 +1324,13 @@ function CompleteCreateSpace() {
   const { toast } = useToast();
   const { data: userData } = useApiGetUser();
   const { close: closeModalDesktop } = useDesktopBasicModal();
-  const { data: spaceData, isLoading } = useApiGetSpace(spaceId!.toString());
+  const { data: spaceData, isLoading } = useApiGetSpace(spaceId!);
   const { resetAll: resetRetrospectInfo } = useRetrospectCreateReset();
   const { resetAll: resetSpaceInfo } = useSpaceCreateReset();
   const isCreatedIndividualSpace = spaceData?.category === ProjectType.Individual;
   const isCreatedTeamSpace = spaceData?.category === ProjectType.Team;
   const [animate, setAnimate] = useState(isCreatedIndividualSpace);
-  const encryptedId = encryptId(spaceId!.toString());
+  const encryptedId = encryptId(spaceId!);
   const navigate = useNavigate();
   const branchLayout = useAtomValue(branchLayoutAtom);
 

--- a/apps/web/src/app/desktop/space/modify/ModifySpacePage.tsx
+++ b/apps/web/src/app/desktop/space/modify/ModifySpacePage.tsx
@@ -13,7 +13,7 @@ import { useSearchParams } from "react-router-dom";
 export default function ModifySpacePage() {
   const [searchParams] = useSearchParams();
   const [isChangedImage, setIsChangedImage] = useState(false);
-  const spaceId = searchParams.get(MODIFY_SPACE_ID_QUERY_KEY) as string;
+  const spaceId = Number(searchParams.get(MODIFY_SPACE_ID_QUERY_KEY));
   const {
     data,
     isLoading,

--- a/apps/web/src/app/mobile/actionItem/ActionItemMorePage.tsx
+++ b/apps/web/src/app/mobile/actionItem/ActionItemMorePage.tsx
@@ -19,7 +19,7 @@ import { DESIGN_TOKEN_COLOR, DESIGN_TOKEN_TEXT } from "@/style/designTokens.ts";
 
 export function ActionItemMorePage() {
   const location = useLocation();
-  const { spaceId, leaderId } = location.state as { spaceId: string; leaderId: number };
+  const { spaceId, leaderId } = location.state as { spaceId: number; leaderId: number };
   const memberId = Cookies.get(COOKIE_KEYS.memberId);
   const { openBottomSheet } = useBottomSheet();
   const { data, isLoading, refetch } = useGetSpaceActionItemList({ spaceId: spaceId });
@@ -30,7 +30,7 @@ export function ActionItemMorePage() {
     actionItemList: item.actionItemList,
   }));
   const SHEET_ID = "info";
-  const isLeader = memberId === String(leaderId);
+  const isLeader = Number(memberId) === leaderId;
   return (
     <Fragment>
       {isLoading && <LoadingModal />}

--- a/apps/web/src/app/mobile/home/GoalViewPage.tsx
+++ b/apps/web/src/app/mobile/home/GoalViewPage.tsx
@@ -19,7 +19,7 @@ import { formatOnlyDate } from "@/utils/date";
 export function GoalViewPage() {
   const { tabs, curTab, selectTab } = useTabs(["실행중", "지난"] as const);
   const memberId = Cookies.get(COOKIE_KEYS.memberId);
-  const { data, isLoading } = useGetActionItemList({ memberId: memberId as string });
+  const { data, isLoading } = useGetActionItemList({ memberId: Number(memberId) });
   const filteredItems = data?.actionItems?.filter(
     (item) => (curTab === tabs[0] && item.status === status[0]) || (curTab === tabs[1] && item.status === status[1]),
   );

--- a/apps/web/src/app/mobile/retrospect/analysis/RetrospectAnalysisPage.tsx
+++ b/apps/web/src/app/mobile/retrospect/analysis/RetrospectAnalysisPage.tsx
@@ -27,10 +27,10 @@ export const RetrospectAnalysisPage = () => {
   const { tabs, curTab, selectTab } = useTabs(tabNames);
   const selectedTab = tabMappings[curTab];
   const queryParams = new URLSearchParams(location.search);
-  const spaceId = queryParams.get("spaceId") as string;
-  const retrospectId = queryParams.get("retrospectId") as string;
+  const spaceId = Number(queryParams.get("spaceId"));
+  const retrospectId = Number(queryParams.get("retrospectId"));
   const { data, isLoading } = useGetAnalysisAnswer({ spaceId: spaceId, retrospectId: retrospectId });
-  const { data: spaceInfo } = useApiGetSpacePrivate(Number(spaceId));
+  const { data: spaceInfo } = useApiGetSpacePrivate(spaceId);
   let pendingPeopleCnt = 0;
 
   if (spaceInfo && data) {

--- a/apps/web/src/app/mobile/retrospect/template/recommend/RecommendSearch.tsx
+++ b/apps/web/src/app/mobile/retrospect/template/recommend/RecommendSearch.tsx
@@ -11,8 +11,8 @@ import { chooseParticle } from "@/utils/retrospect/chooseParticle";
 import { createTemplateArr } from "@/utils/retrospect/createTemplateArr";
 
 export function RecommendSearch() {
-  const { templateId, spaceId } = useLocation().state as { templateId: string; spaceId: string };
-  const TemplateArr = createTemplateArr(templateId as unknown as TemplateKey);
+  const { templateId, spaceId } = useLocation().state as { templateId: number; spaceId: number };
+  const TemplateArr = createTemplateArr(templateId as TemplateKey);
   const { data, isLoading } = useApiGetSpace(spaceId);
 
   if (isLoading) return <LoadingModal />;

--- a/apps/web/src/app/mobile/space/CreateDonePage.tsx
+++ b/apps/web/src/app/mobile/space/CreateDonePage.tsx
@@ -21,7 +21,7 @@ import { PATHS } from "@layer/shared";
 
 export function CreateDonePage() {
   const navigate = useNavigate();
-  const { spaceId } = useLocation().state as { spaceId: string };
+  const { spaceId } = useLocation().state as { spaceId: number };
   const { data: spaceData, isLoading } = useApiGetSpace(spaceId);
   const [animate, setAnimate] = useState(spaceData?.category === ProjectType.Individual);
   const { data: userData } = useApiGetUser();

--- a/apps/web/src/app/mobile/space/CreateNextPage.tsx
+++ b/apps/web/src/app/mobile/space/CreateNextPage.tsx
@@ -14,7 +14,7 @@ import Recommend from "@/assets/lottie/space/recommend.json";
 
 export function CreateNextPage() {
   const navigate = useNavigate();
-  const { spaceId } = useLocation().state as { spaceId: string };
+  const { spaceId } = useLocation().state as { spaceId: number };
   const { data } = useApiGetSpace(spaceId);
 
   if (!data) return null;
@@ -59,7 +59,7 @@ export function CreateNextPage() {
         <ButtonProvider.Primary onClick={() => navigate(PATHS.retrospectRecommend(), { state: { spaceId } })}>
           회고 템플릿 추천 받기
         </ButtonProvider.Primary>
-        <div css={laterTextStyles} onClick={() => navigate(PATHS.spaceDetail(spaceId))}>
+        <div css={laterTextStyles} onClick={() => navigate(PATHS.spaceDetail(`${spaceId}`))}>
           다음에 하기
         </div>
       </ButtonProvider>

--- a/apps/web/src/app/mobile/space/SpaceViewPage.tsx
+++ b/apps/web/src/app/mobile/space/SpaceViewPage.tsx
@@ -22,7 +22,7 @@ import { useApiLeaveSpace } from "@/hooks/api/space/useApiLeaveSpace";
 import { useApiOptionsGetSpaceInfo } from "@/hooks/api/space/useApiOptionsGetSpaceInfo";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { useModal } from "@/hooks/useModal";
-import { useRequiredParams } from "@/hooks/useRequiredParams";
+import { useRequiredNumberParams } from "@/hooks/useRequiredParams";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 import { useTestNavigate } from "@/lib/test-natigate";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
@@ -36,7 +36,7 @@ export function SpaceViewPage() {
   const navigate = useNavigate();
   const appNavigate = useTestNavigate();
   const memberId = Cookies.get(COOKIE_KEYS.memberId);
-  const { spaceId } = useRequiredParams<{ spaceId: string }>();
+  const { spaceId } = useRequiredNumberParams<{ spaceId: number }>();
   const { openBottomSheet, closeBottomSheet } = useBottomSheet();
   const { open } = useModal();
   const SHEET_ID = "createSpaceSheet";
@@ -64,7 +64,7 @@ export function SpaceViewPage() {
   }, [restrospectArr]);
 
   const isLoading = isLoadingRestrospects || isLoadingSpaceInfo || isLoadingTeamActionList;
-  const isLeader = memberId === String(spaceInfo?.leader.id);
+  const isLeader = Number(memberId) === spaceInfo?.leader.id;
 
   const handleDeleteRetrospect = (retrospectId: number) => {
     setProceedingRetrospects((prev) => prev.filter((item) => item.retrospectId !== retrospectId));
@@ -152,7 +152,7 @@ export function SpaceViewPage() {
         <ActionItemListView
           restrospectArr={restrospectArr ? restrospectArr : []}
           isPossibleMake={doneRetrospects.length === 0}
-          spaceId={spaceInfo?.id as string}
+          spaceId={spaceInfo?.id}
           teamActionList={teamActionList?.teamActionItemList || []}
           leaderId={spaceInfo?.leader.id}
         />

--- a/apps/web/src/component/common/LocalNavigationBar/UserProfile.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/UserProfile.tsx
@@ -144,7 +144,7 @@ export default function UserProfile() {
       contents: "정말 로그아웃 하시겠어요?",
       onConfirm: () => {
         if (memberId) {
-          signOut({ memberId: memberId });
+          signOut({ memberId: Number(memberId) });
         }
       },
       options: {

--- a/apps/web/src/component/common/Modal/Member/InviteMemberModal.tsx
+++ b/apps/web/src/component/common/Modal/Member/InviteMemberModal.tsx
@@ -16,7 +16,7 @@ import { encryptId } from "@/utils/space/cryptoKey";
 type InviteMemberModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  spaceId: string;
+  spaceId: number;
 };
 
 export function InviteMemberModal({ isOpen, onClose, spaceId }: InviteMemberModalProps) {

--- a/apps/web/src/component/common/Modal/UserSetting/AccountSettingsModal.tsx
+++ b/apps/web/src/component/common/Modal/UserSetting/AccountSettingsModal.tsx
@@ -101,7 +101,7 @@ export function AccountSettingsModal({ isOpen, onClose }: AccountSettingsModalPr
       const booleans = [deleteReasons.notUseful, deleteReasons.uncomfortable, deleteReasons.other];
 
       deleteUser({
-        memberId: memberId,
+        memberId: Number(memberId),
         booleans: booleans,
         description: feedbackInput.value,
       });

--- a/apps/web/src/component/home/SpaceOverview.tsx
+++ b/apps/web/src/component/home/SpaceOverview.tsx
@@ -24,8 +24,8 @@ const SpaceOverview = forwardRef<HTMLDivElement, SpaceOverviewProps>(
       <div
         ref={ref}
         onClick={() => {
-          postSpacesClick(Number(id));
-          navigate(PATHS.spaceDetail(id));
+          postSpacesClick(id);
+          navigate(PATHS.spaceDetail(`${id}`));
         }}
         key={id}
         css={css`

--- a/apps/web/src/component/info/UserManageBox.tsx
+++ b/apps/web/src/component/info/UserManageBox.tsx
@@ -41,7 +41,7 @@ export function UserManageBox() {
         onConfirm: () => {
           if (memberId) {
             deleteUser({
-              memberId: memberId,
+              memberId: Number(memberId),
               booleans: state.booleans!,
               description: state.description!,
             });
@@ -107,7 +107,7 @@ export function UserManageBox() {
                   type: "confirm",
                 },
                 onConfirm: () => {
-                  if (memberId) signOut({ memberId: memberId });
+                  if (memberId) signOut({ memberId: Number(memberId) });
                 },
               });
             }}

--- a/apps/web/src/component/retrospect/analysis/Analysis.tsx
+++ b/apps/web/src/component/retrospect/analysis/Analysis.tsx
@@ -15,8 +15,8 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { getDeviceType } from "@/utils/deviceUtils";
 
 type AnalysisContainerProps = {
-  spaceId: string;
-  retrospectId: string;
+  spaceId: number;
+  retrospectId: number;
   hasAIAnalyzed: boolean | undefined;
 };
 

--- a/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/CompletedRetrospects.tsx
@@ -11,7 +11,8 @@ import RetrospectCard from "@/app/desktop/component/home/RetrospectCard";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
 
 export default function CompletedRetrospects() {
-  const { spaceId } = useParams();
+  const { spaceId: rawSpaceId } = useParams();
+  const spaceId = rawSpaceId ? Number(rawSpaceId) : undefined;
 
   // * 스페이스 회고 목록 조회
   const { data: retrospects, isPending: isPendingRetrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));

--- a/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
@@ -20,7 +20,8 @@ import { TemplateChoice } from "@/app/desktop/component/retrospect/choice";
 import { useApiOptionsGetSpaceInfo } from "@/hooks/api/space/useApiOptionsGetSpaceInfo";
 
 export default function InProgressRetrospects() {
-  const { spaceId } = useParams();
+  const { spaceId: rawSpaceId } = useParams();
+  const spaceId = rawSpaceId ? Number(rawSpaceId) : undefined;
 
   // * 스페이스 회고 목록 조회
   const { data: retrospects, isPending: isPendingRetrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
@@ -41,7 +42,7 @@ export default function InProgressRetrospects() {
     if (spaceInfo?.formId) {
       setRetrospectValue((prev) => ({
         ...prev,
-        templateId: String(spaceInfo.formId),
+        templateId: spaceInfo.formId,
       }));
 
       open({

--- a/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
+++ b/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
@@ -4,7 +4,7 @@ import { Typography } from "@/component/common/typography";
 import SpaceManageToggleMenu from "@/component/space/edit/SpaceManageToggleMenu";
 import { useApiOptionsGetSpaceInfo } from "@/hooks/api/space/useApiOptionsGetSpaceInfo";
 import { useFunnelModal } from "@/hooks/useFunnelModal";
-import { useRequiredParams } from "@/hooks/useRequiredParams";
+import { useRequiredNumberParams } from "@/hooks/useRequiredParams";
 import { retrospectInitialState } from "@/store/retrospect/retrospectInitial";
 import { currentSpaceState } from "@/store/space/spaceAtom";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
@@ -20,7 +20,7 @@ export default function RetrospectSpaceHeader() {
   const { openFunnelModal } = useFunnelModal();
 
   const currentSpace = useAtomValue(currentSpaceState);
-  const { spaceId } = useRequiredParams<{ spaceId: string }>();
+  const { spaceId } = useRequiredNumberParams<{ spaceId: number }>();
   const [_, setSearchParams] = useSearchParams();
 
   const setRetrospectValue = useSetAtom(retrospectInitialState);
@@ -36,7 +36,7 @@ export default function RetrospectSpaceHeader() {
     if (spaceInfo?.formId) {
       setRetrospectValue((prev) => ({
         ...prev,
-        templateId: String(spaceInfo.formId),
+        templateId: spaceInfo.formId,
       }));
 
       openFunnelModal({

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
@@ -15,7 +15,7 @@ import { trackEvent } from "@/lib/google-analytics";
 import { GA_EVENTS } from "@/lib/google-analytics/events";
 
 type ActionItemAddSectionProps = {
-  spaceId: string;
+  spaceId: number;
   retrospectId: number;
   onClose: () => void;
 };
@@ -81,7 +81,7 @@ export default function ActionItemAddSection({ spaceId, retrospectId, onClose }:
         },
         {
           onSuccess: async (response) => {
-            const previousData: { spaceId: string; spaceName: string; teamActionItemList: ExtendedActionItemType[] } | undefined =
+            const previousData: { spaceId: number; spaceName: string; teamActionItemList: ExtendedActionItemType[] } | undefined =
               await queryClient.getQueryData(["getTeamActionItemList", spaceId]);
 
             if (previousData) {

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
@@ -12,7 +12,7 @@ import { trackEvent } from "@/lib/google-analytics";
 import { GA_EVENTS } from "@/lib/google-analytics/events";
 
 type ActionItemCardProps = {
-  spaceId: string;
+  spaceId: number;
   retrospectId: number;
   title: string;
   todoList: {

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
@@ -12,7 +12,7 @@ import { trackEvent } from "@/lib/google-analytics";
 import { GA_EVENTS } from "@/lib/google-analytics/events";
 
 type ActionItemManageToggleMenuProps = {
-  spaceId: string;
+  spaceId: number;
   retrospectId: number;
   todoList: {
     actionItemId: number;

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
@@ -23,7 +23,7 @@ type ActionItem = {
 };
 
 type ActionItemsEditSectionProps = {
-  spaceId: string;
+  spaceId: number;
   retrospectId: number;
   todoList: ActionItem[];
   onClose: () => void;

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
@@ -15,7 +15,7 @@ type ActionItemsListProps = {
 
 export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
   const params = useParams();
-  const spaceId = params.spaceId as string;
+  const spaceId = Number(params.spaceId);
 
   // * 팀 실행목표 리스트 조회
   const { data } = useQuery(useApiOptionsGetTeamActionItemList(spaceId));

--- a/apps/web/src/component/retrospect/space/members/MemberManagement.tsx
+++ b/apps/web/src/component/retrospect/space/members/MemberManagement.tsx
@@ -17,7 +17,7 @@ import { useApiOptionsGetSpaceInfo } from "@/hooks/api/space/useApiOptionsGetSpa
 import { useQueries } from "@tanstack/react-query";
 import { InviteMemberModal } from "@/component/common/Modal/Member/InviteMemberModal";
 
-export default function MemberManagement({ spaceId }: { spaceId: string }) {
+export default function MemberManagement({ spaceId }: { spaceId: number }) {
   const [{ data: spaceInfo }] = useQueries({
     queries: [useApiOptionsGetSpaceInfo(spaceId)],
   });
@@ -90,7 +90,7 @@ export default function MemberManagement({ spaceId }: { spaceId: string }) {
     changeLeader(
       {
         spaceId,
-        memberId: String(selectedLeaderId),
+        memberId: selectedLeaderId as number,
       },
       {
         onSuccess: () => {
@@ -113,7 +113,7 @@ export default function MemberManagement({ spaceId }: { spaceId: string }) {
     kickMember(
       {
         spaceId,
-        memberId: String(selectedDeleteMemberId),
+        memberId: selectedDeleteMemberId as number,
       },
       {
         onSuccess: () => {

--- a/apps/web/src/component/retrospect/template/card/CardCarousel.tsx
+++ b/apps/web/src/component/retrospect/template/card/CardCarousel.tsx
@@ -17,8 +17,8 @@ import { useFunnelModal } from "@/hooks/useFunnelModal";
 import RecommendDone from "@/app/desktop/component/retrospect/template/recommend/Done";
 
 type CardCarouselProp = {
-  spaceId?: string;
-  templateId?: string;
+  spaceId?: number;
+  templateId?: number;
   templateArr: {
     title: string;
     templateName: string;

--- a/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
@@ -57,7 +57,7 @@ export default function TemplateCardManageToggleMenu({
   const handleCloseRetrospect = async () => {
     try {
       setProgress(true);
-      await mutateCloseRetrospect({ spaceId: String(spaceId), retrospectId: retrospectId });
+      await mutateCloseRetrospect({ spaceId, retrospectId });
     } catch (e) {
     } finally {
       setProgress(false);
@@ -71,7 +71,7 @@ export default function TemplateCardManageToggleMenu({
   const handleRemoveRetrospect = async () => {
     try {
       setProgress(true);
-      await mutateDeleteRetrospect({ spaceId: String(spaceId), retrospectId: String(retrospectId) });
+      await mutateDeleteRetrospect({ spaceId, retrospectId });
     } catch (e) {
     } finally {
       setProgress(false);

--- a/apps/web/src/component/retrospect/template/recommend/RecommendDone.tsx
+++ b/apps/web/src/component/retrospect/template/recommend/RecommendDone.tsx
@@ -13,7 +13,7 @@ import { useGetSimpleTemplateInfo } from "@/hooks/api/template/useGetSimpleTempl
 import { DefaultLayout } from "@/layout/DefaultLayout";
 
 export function RecommendDone() {
-  const { templateId, spaceId } = useLocation().state as { templateId: string; spaceId: string };
+  const { templateId, spaceId } = useLocation().state as { templateId: number; spaceId: number };
 
   const navigate = useNavigate();
   const { data: templateData, isLoading } = useGetSimpleTemplateInfo(templateId);
@@ -31,7 +31,7 @@ export function RecommendDone() {
           css={css`
             cursor: pointer;
           `}
-          onClick={() => navigate(PATHS.spaceDetail(spaceId))}
+          onClick={() => navigate(PATHS.spaceDetail(`${spaceId}`))}
         />
       }
     >
@@ -62,7 +62,7 @@ export function RecommendDone() {
             gap: 0.8rem;
           `}
         >
-          <ButtonProvider.Gray onClick={() => navigate(PATHS.template(spaceId), { state: { readOnly: false } })}>템플릿 변경</ButtonProvider.Gray>
+          <ButtonProvider.Gray onClick={() => navigate(PATHS.template(`${spaceId}`), { state: { readOnly: false } })}>템플릿 변경</ButtonProvider.Gray>
           <ButtonProvider.Primary
             onClick={() =>
               navigate(PATHS.retrospectCreate(), {

--- a/apps/web/src/component/space/CreateRetrospectiveSheet.tsx
+++ b/apps/web/src/component/space/CreateRetrospectiveSheet.tsx
@@ -12,7 +12,7 @@ import { useApiPostTemplateClickListView } from "@/hooks/api/backoffice/useApiPo
 
 type Props = {
   teamName: string | undefined;
-  spaceId: string;
+  spaceId: number;
   closeBottomSheet: () => void;
 };
 
@@ -83,7 +83,7 @@ export function CreateRetrospectiveSheet({ teamName, spaceId, closeBottomSheet }
         <button
           onClick={() => {
             templateListClickMutation();
-            navigate(PATHS.template(spaceId), {
+            navigate(PATHS.template(`${spaceId}`), {
               state: { readOnly: false },
             });
             closeBottomSheet();

--- a/apps/web/src/component/space/edit/SpaceEdit.tsx
+++ b/apps/web/src/component/space/edit/SpaceEdit.tsx
@@ -18,9 +18,10 @@ import { PATHS } from "@layer/shared";
 
 export function SpaceEdit() {
   const { id } = useParams() as { id: string };
+  const spaceId = Number(id);
 
   const navigate = useNavigate();
-  const { data, isLoading } = useApiGetSpace(id);
+  const { data, isLoading } = useApiGetSpace(spaceId);
   const { mutate, isPending } = useApiEditSpace();
   const [imgFile, setImgFile] = useState<File | null>(null);
   const { value: name, handleInputChange: handleChangeName, setValue: setName } = useInput();
@@ -45,14 +46,14 @@ export function SpaceEdit() {
         });
 
         mutate({
-          spaceId: id,
+          spaceId,
           name,
           introduction,
           imgUrl: data.imageUrl,
         });
       } else {
         mutate({
-          spaceId: id,
+          spaceId,
           name,
           introduction,
           imgUrl: data?.bannerUrl || "",

--- a/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
+++ b/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
@@ -16,7 +16,7 @@ export default function SpaceManageToggleMenu({
   iconSize = 1.8,
   iconColor = "gray900",
 }: {
-  spaceId: string;
+  spaceId: number;
   isLeader: boolean;
   iconSize?: number | string;
   iconColor?: keyof typeof DESIGN_TOKEN_COLOR;
@@ -24,7 +24,7 @@ export default function SpaceManageToggleMenu({
   const { isShowMenu, showMenu, hideMenu } = useToggleMenu();
   const { open: openDesktopModal } = useDesktopBasicModal();
   const { open: openAlertModal } = useModal();
-  const { onSubmitDeleteSpace, initializeSearchQuery } = useModifySpace({ id: spaceId.toString() });
+  const { onSubmitDeleteSpace, initializeSearchQuery } = useModifySpace({ id: spaceId });
   const [_, setSearchParams] = useSearchParams();
   const { mutate: leaveSpace } = useApiLeaveSpace();
 
@@ -43,7 +43,7 @@ export default function SpaceManageToggleMenu({
   const handleEditSpace = () => {
     setSearchParams((prev) => ({
       ...Object.fromEntries(prev.entries()),
-      [MODIFY_SPACE_ID_QUERY_KEY]: spaceId,
+      [MODIFY_SPACE_ID_QUERY_KEY]: `${spaceId}`,
       [MODIFY_SPACE_METHOD_QUERY_KEY]: "edit",
     }));
     openDesktopModal({

--- a/apps/web/src/component/space/join/JoinSpace.tsx
+++ b/apps/web/src/component/space/join/JoinSpace.tsx
@@ -19,7 +19,7 @@ import { getDeviceType } from "@/utils/deviceUtils";
 
 export function JoinSpace() {
   const { id } = useParams() as { id: string };
-  const spaceId = decryptId(id);
+  const spaceId = Number(decryptId(id));
   const { data, isLoading } = useApiGetSpace(spaceId, true);
   const { mutate, isPending } = useApiJoinSpace();
   const { toast } = useToast();
@@ -61,20 +61,20 @@ export function JoinSpace() {
       <ButtonProvider isProgress={isPending}>
         <ButtonProvider.Primary
           onClick={() =>
-            mutate(Number(spaceId), {
+            mutate(spaceId, {
               onSuccess: () => {
                 toast.success(`스페이스에 초대되었어요!`);
-                navigate(PATHS.spaceDetail(spaceId));
+                navigate(PATHS.spaceDetail(`${spaceId}`));
               },
               onError: (error) => {
                 if (error.status === 400) {
                   toast.success("이미 참여한 스페이스로 이동했어요!");
-                  navigate(PATHS.spaceDetail(spaceId));
+                  navigate(PATHS.spaceDetail(`${spaceId}`));
                 }
                 if (error.status === 403) {
                   // 로그인 또는 회원가입 후, 해당 쿠키 값을 판별하여 스페이스 가입을 진행합니다.
                   // FIXME: Cookie 모음 저장 필요
-                  Cookies.set(COOKIE_VALUE_SAVE_SPACE_ID_PHASE, spaceId);
+                  Cookies.set(COOKIE_VALUE_SAVE_SPACE_ID_PHASE, `${spaceId}`);
                   open({
                     title: "스페이스 참여를 위해 로그인이 필요해요",
                     contents: "지금 팀원들과 함께 회고를 진행해보세요",

--- a/apps/web/src/component/space/members/MembersEditList.tsx
+++ b/apps/web/src/component/space/members/MembersEditList.tsx
@@ -14,24 +14,29 @@ import { useModal } from "@/hooks/useModal";
 import { DefaultLayout } from "@/layout/DefaultLayout";
 
 export function MembersEditList() {
-  const { spaceId } = useParams() as { spaceId: string };
+  const { spaceId: rawSpaceId } = useParams() as { spaceId: string };
+  const spaceId = Number(rawSpaceId);
   const { editType } = useLocation().state as { editType: EditType };
   const { data, isLoading } = useApiGetMemers(spaceId);
   const { mutate: kickMember } = useApiKickMember(spaceId);
   const { mutate: changeLeader } = useChangeLeader(spaceId);
   const { open } = useModal();
-  const [selectedOption, setSelectedOption] = useState("");
-  const [leaderIndex, setLeaderIndex] = useState("");
+  const [selectedOption, setSelectedOption] = useState<number | null>(null);
+  const [leaderId, setLeaderId] = useState<number | null>(null);
 
   useEffect(() => {
     if (data) {
       const leaderIndex = data.findIndex((member) => member.isLeader);
-      setLeaderIndex(data[leaderIndex].id);
-      setSelectedOption(data[leaderIndex].id);
+      const leader = data[leaderIndex];
+
+      if (leader) {
+        setLeaderId(leader.id);
+        setSelectedOption(leader.id);
+      }
     }
   }, [data]);
 
-  const onClickEdit = (memberId: string) => {
+  const onClickEdit = (memberId: number) => {
     open({
       title: "팀원을 삭제하시겠어요?",
       contents: "삭제하시면 다시 되돌릴 수 없어요",
@@ -42,11 +47,13 @@ export function MembersEditList() {
     });
   };
 
-  const handleRadioChange = (value: string) => {
+  const handleRadioChange = (value: number) => {
     setSelectedOption(value);
   };
 
   const onChangeLeader = () => {
+    if (selectedOption == null) return;
+
     open({
       title: "대표자를 변경하시겠어요?",
       contents: "대표자를 변경하면\n팀 스페이스 관리 권한이 변경돼요",
@@ -78,7 +85,7 @@ export function MembersEditList() {
       ))}
       {editType === "LEADER" && (
         <ButtonProvider>
-          <ButtonProvider.Primary onClick={onChangeLeader} disabled={!leaderIndex || leaderIndex === selectedOption}>
+          <ButtonProvider.Primary onClick={onChangeLeader} disabled={leaderId == null || leaderId === selectedOption}>
             변경
           </ButtonProvider.Primary>
         </ButtonProvider>

--- a/apps/web/src/component/space/members/MembersItem.tsx
+++ b/apps/web/src/component/space/members/MembersItem.tsx
@@ -8,7 +8,7 @@ import { defaultUserImgUrl } from "@/component/space/space.const";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
 type MembersItemProps = {
-  id?: string;
+  id?: number;
   avatar?: string | null;
   name: string;
   isLeader?: boolean;
@@ -17,7 +17,7 @@ type MembersItemProps = {
   onClick?: () => void;
   onClickEdit?: () => void;
   handleRadioChange?: () => void;
-  selectedOption?: string;
+  selectedOption?: number | null;
   isChecked?: boolean;
 };
 

--- a/apps/web/src/component/space/members/MembersList.tsx
+++ b/apps/web/src/component/space/members/MembersList.tsx
@@ -22,7 +22,8 @@ import { encryptId } from "@/utils/space/cryptoKey";
 export type EditType = "LEADER" | "KICK";
 
 export function MembersList() {
-  const { spaceId } = useParams() as { spaceId: string };
+  const { spaceId: rawSpaceId } = useParams() as { spaceId: string };
+  const spaceId = Number(rawSpaceId);
   const { data: spaceInfo, isLoading: spaceInfoLoading } = useApiGetSpace(spaceId);
   const { data, isLoading } = useApiGetMemers(spaceId);
   const { open, close } = useModal();
@@ -125,7 +126,7 @@ export function MembersList() {
 
     const leaderIndex = data.findIndex((member) => member.isLeader);
 
-    return data[leaderIndex].id?.toString() === userData.memberId?.toString() && data[leaderIndex].isLeader;
+    return data[leaderIndex].id === userData.memberId && data[leaderIndex].isLeader;
   }, [data, userData.memberId]);
 
   if (isLoading || spaceInfoLoading) return <LoadingModal />;

--- a/apps/web/src/component/space/members/MembersList.tsx
+++ b/apps/web/src/component/space/members/MembersList.tsx
@@ -125,7 +125,7 @@ export function MembersList() {
 
     const leaderIndex = data.findIndex((member) => member.isLeader);
 
-    return data[leaderIndex].id === userData.memberId?.toString() && data[leaderIndex].isLeader;
+    return data[leaderIndex].id?.toString() === userData.memberId?.toString() && data[leaderIndex].isLeader;
   }, [data, userData.memberId]);
 
   if (isLoading || spaceInfoLoading) return <LoadingModal />;

--- a/apps/web/src/component/space/view/ActionItemListView.tsx
+++ b/apps/web/src/component/space/view/ActionItemListView.tsx
@@ -25,7 +25,7 @@ import { PATHS } from "@layer/shared";
 type ActionItemListViewProps = {
   isPossibleMake: boolean;
   teamActionList: ActionItemType[];
-  spaceId: string | undefined;
+  spaceId: number | undefined;
   leaderId: number | undefined;
   restrospectArr: Retrospect[] | [];
 };
@@ -50,7 +50,7 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
   const memberId = Cookies.get(COOKIE_KEYS.memberId);
   const [retrospect, setRetrospect] = useState("");
   const [retrospectId, setRetrospectId] = useState<number | undefined>(-1);
-  const isLeader = memberId === String(leaderId);
+  const isLeader = Number(memberId) === leaderId;
 
   const { value: actionItemValue, handleInputChange } = useInput();
   const { mutate } = useCreateActionItem();

--- a/apps/web/src/component/space/view/RetrospectBox.tsx
+++ b/apps/web/src/component/space/view/RetrospectBox.tsx
@@ -32,7 +32,7 @@ export function RetrospectBox({
   isLeader,
   refetchRestrospectData,
 }: {
-  spaceId: string;
+  spaceId: number;
   retrospect: Retrospect;
   onDelete: (retrospectId: number) => void;
   refetchRestrospectData?: () => void;
@@ -57,7 +57,7 @@ export function RetrospectBox({
     const { analysisStatus, retrospectStatus, writeStatus } = retrospect;
 
     const navigateToAnalysis = (defaultTab?: "분석" | "") =>
-      navigate(PATHS.retrospectAnalysis(spaceId, retrospectId), { state: { title, ...(defaultTab && { defaultTab }) } });
+      navigate(PATHS.retrospectAnalysis(`${spaceId}`, retrospectId), { state: { title, ...(defaultTab && { defaultTab }) } });
 
     if (analysisStatus === "DONE") {
       navigateToAnalysis("분석");
@@ -110,7 +110,7 @@ export function RetrospectBox({
       },
       onConfirm: () => {
         retrospectDelete(
-          { spaceId: spaceId, retrospectId: String(retrospectId) },
+          { spaceId, retrospectId },
           {
             onSuccess: () => {
               setIsDeleted(true);
@@ -281,7 +281,7 @@ export function RetrospectBox({
       {isEditModalOpen && (
         <RetrospectEditModal
           spaceId={spaceId}
-          retrospectId={retrospectId.toString()}
+          retrospectId={retrospectId}
           defaultValue={{ title, introduction, deadline }}
           isAnalyzed={retrospectStatus === "DONE"}
           close={() => setIsEditModalOpen(false)}

--- a/apps/web/src/component/space/view/RetrospectEditModal.tsx
+++ b/apps/web/src/component/space/view/RetrospectEditModal.tsx
@@ -13,8 +13,8 @@ import { DefaultLayout } from "@/layout/DefaultLayout";
 import { Retrospect } from "@/types/retrospect";
 
 type RetrospectEditProps = {
-  spaceId: string;
-  retrospectId: string;
+  spaceId: number;
+  retrospectId: number;
   defaultValue: Pick<Retrospect, "title" | "introduction" | "deadline">;
   isAnalyzed?: boolean;
   close: () => void;
@@ -30,8 +30,8 @@ export function RetrospectEditModal({ spaceId, retrospectId, defaultValue, isAna
 
   const handleModifyRetrospect = async () => {
     patchRetrospect({
-      spaceId: +spaceId,
-      retrospectId: +retrospectId,
+      spaceId,
+      retrospectId,
       data: { title, introduction, deadline: deadline },
     });
   };

--- a/apps/web/src/component/space/view/SpaceAppBarRightComp.tsx
+++ b/apps/web/src/component/space/view/SpaceAppBarRightComp.tsx
@@ -9,7 +9,7 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { PATHS } from "@layer/shared";
 
 type RightCompProps = {
-  spaceId: string;
+  spaceId: number;
   onDeleteClick: () => void;
   isTooltipVisible: boolean;
   onClickPlus: () => void;
@@ -34,7 +34,7 @@ export function SpaceAppBarRightComp({ spaceId, onDeleteClick, isTooltipVisible,
   const navigate = useNavigate();
 
   const handleModifyFun = () => {
-    navigate(PATHS.spaceEdit(spaceId) as string);
+    navigate(PATHS.spaceEdit(`${spaceId}`) as string);
     setIsBoxVisible((prev) => !prev);
   };
 

--- a/apps/web/src/hooks/api/actionItem/useAPiOptionsRecentTeamActionList.ts
+++ b/apps/web/src/hooks/api/actionItem/useAPiOptionsRecentTeamActionList.ts
@@ -7,14 +7,14 @@ type RecentActionItemList = {
   teamActionItemList: ActionItemType[];
 };
 
-const getRecentTeamActionItemList = async (spaceId: string | undefined) => {
+const getRecentTeamActionItemList = async (spaceId: number | undefined) => {
   const response = await api.get<RecentActionItemList>(`/api/action-item/space/${spaceId}/recent`);
   return response.data;
 };
 
 export const useAPiOptionsRecentTeamActionList = (
-  spaceId?: string,
-): UseQueryOptions<RecentActionItemList, Error, RecentActionItemList, [string, string]> => ({
+  spaceId?: number,
+): UseQueryOptions<RecentActionItemList, Error, RecentActionItemList, [string, number]> => ({
   queryKey: ["getTeamActionItemList", spaceId!],
   queryFn: () => getRecentTeamActionItemList(spaceId),
   select(data) {

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetTeamActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetTeamActionItemList.ts
@@ -3,14 +3,14 @@ import { UseQueryOptions } from "@tanstack/react-query";
 import { api } from "@/api";
 import { TeamActionItemType } from "@/types/actionItem";
 
-const getTeamActionItemList = async (spaceId: string | undefined) => {
+const getTeamActionItemList = async (spaceId: number | undefined) => {
   const response = await api.get<TeamActionItemType>(`/api/action-item/space/${spaceId}`);
   return response.data;
 };
 
 export const useApiOptionsGetTeamActionItemList = (
-  spaceId?: string,
-): UseQueryOptions<TeamActionItemType, Error, TeamActionItemType, [string, string]> => ({
+  spaceId?: number,
+): UseQueryOptions<TeamActionItemType, Error, TeamActionItemType, [string, number]> => ({
   queryKey: ["getTeamActionItemList", spaceId!],
   queryFn: () => getTeamActionItemList(spaceId),
   select(data) {

--- a/apps/web/src/hooks/api/actionItem/useGetActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useGetActionItemList.ts
@@ -7,7 +7,7 @@ export const useGetActionItemList = <TData = PersonalActionItemListType>({
   memberId,
   options,
 }: {
-  memberId: string;
+  memberId: number;
   options?: Omit<UseQueryOptions<PersonalActionItemListType, Error, TData>, "queryKey" | "queryFn">;
 }) => {
   const getActionItemList = () => {

--- a/apps/web/src/hooks/api/actionItem/useGetSpaceActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useGetSpaceActionItemList.ts
@@ -17,7 +17,7 @@ export type PersonalActionItemListType = {
   }[];
 };
 
-export const useGetSpaceActionItemList = ({ spaceId }: { spaceId: string }) => {
+export const useGetSpaceActionItemList = ({ spaceId }: { spaceId: number }) => {
   const getActionItemList = () => {
     const res = api.get<PersonalActionItemListType>(`/api/action-item/space/${spaceId}`).then((res) => res.data);
     return res;

--- a/apps/web/src/hooks/api/analysis/useApiGetAnalysis.ts
+++ b/apps/web/src/hooks/api/analysis/useApiGetAnalysis.ts
@@ -31,7 +31,7 @@ export type AnalysisType = {
   individualAnalyze: IndividualAnalyzeType;
 };
 
-export const useApiGetAnalysis = ({ spaceId, retrospectId }: { spaceId: string; retrospectId: string }) => {
+export const useApiGetAnalysis = ({ spaceId, retrospectId }: { spaceId: number; retrospectId: number }) => {
   const { track } = useMixpanel();
 
   const getAnalysis = () => {
@@ -42,8 +42,8 @@ export const useApiGetAnalysis = ({ spaceId, retrospectId }: { spaceId: string; 
         throw error;
       });
     track("RESULT_ANALYSIS_VIEW", {
-      retrospectId: +retrospectId,
-      spaceId: +spaceId,
+      retrospectId,
+      spaceId,
     });
     return res;
   };

--- a/apps/web/src/hooks/api/login/usePostSignOut.ts
+++ b/apps/web/src/hooks/api/login/usePostSignOut.ts
@@ -11,9 +11,9 @@ export const usePostSignOut = () => {
   const navigate = useTestNavigate();
   const [, setAuth] = useAtom(authAtom);
 
-  const signOutFun = async ({ memberId }: { memberId: string }) => {
+  const signOutFun = async ({ memberId }: { memberId: number }) => {
     const response = await api.post("/api/auth/sign-out", {
-      memberId: memberId,
+      memberId,
     });
     return response;
   };

--- a/apps/web/src/hooks/api/retrospect/analysis/useGetAnalysisAnswer.ts
+++ b/apps/web/src/hooks/api/retrospect/analysis/useGetAnalysisAnswer.ts
@@ -5,8 +5,8 @@ import { ACHIVEMENT_PERCENT } from "@/component/write/template/write/write.const
 import { calculateScaledAnswer } from "@/utils/answer/calculateScaledAnswer.ts";
 
 type getAnalysisAnswer = {
-  spaceId: string | null;
-  retrospectId: string | null;
+  spaceId: number | null;
+  retrospectId: number | null;
 };
 
 export interface IndividualsAnswersType {

--- a/apps/web/src/hooks/api/retrospect/close/useApiCloseRetrospect.ts
+++ b/apps/web/src/hooks/api/retrospect/close/useApiCloseRetrospect.ts
@@ -4,7 +4,7 @@ import { api } from "@/api";
 import { useToast } from "@/hooks/useToast";
 import { queryClient } from "@/lib/tanstack-query/queryClient";
 
-type closeRetrospectProps = { spaceId: string; retrospectId: number };
+type closeRetrospectProps = { spaceId: number; retrospectId: number };
 
 export const useApiCloseRetrospect = () => {
   const { toast } = useToast();
@@ -18,7 +18,7 @@ export const useApiCloseRetrospect = () => {
     onSuccess: async (_, variable) => {
       toast.success("회고 마감이 완료되었어요");
       await queryClient.invalidateQueries({
-        queryKey: ["getRetrospects", variable.spaceId.toString()],
+        queryKey: ["getRetrospects", variable.spaceId],
       });
     },
     onError: () => {

--- a/apps/web/src/hooks/api/retrospect/edit/usePatchRetrospect.ts
+++ b/apps/web/src/hooks/api/retrospect/edit/usePatchRetrospect.ts
@@ -25,7 +25,7 @@ export const usePatchRetrospect = () => {
       toast.success("회고 정보가 수정되었어요!");
       await queryClient.invalidateQueries({
         // TODO: queryKey 타입 재정의 필요
-        queryKey: ["getRetrospects", variable.spaceId.toString()],
+        queryKey: ["getRetrospects", variable.spaceId],
       });
     },
     onError: () => {

--- a/apps/web/src/hooks/api/retrospect/useApiDeleteRetrospect.ts
+++ b/apps/web/src/hooks/api/retrospect/useApiDeleteRetrospect.ts
@@ -7,14 +7,14 @@ import { useToast } from "@/hooks/useToast";
 export const useApiDeleteRetrospect = () => {
   const { toast } = useToast();
 
-  const retrospectDelete = async (spaceId: string | undefined, retrospectId: string | undefined) => {
+  const retrospectDelete = async (spaceId: number | undefined, retrospectId: number | undefined) => {
     const response = await api.delete(`/space/${spaceId}/retrospect/${retrospectId}`);
     return response;
   };
 
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ spaceId, retrospectId }: { spaceId: string | undefined; retrospectId: string | undefined }) =>
+    mutationFn: ({ spaceId, retrospectId }: { spaceId: number | undefined; retrospectId: number | undefined }) =>
       retrospectDelete(spaceId, retrospectId),
     onMutate: async (variables) => {
       await queryClient.cancelQueries({ queryKey: ["getRetrospects", variables.spaceId] });
@@ -22,7 +22,7 @@ export const useApiDeleteRetrospect = () => {
       queryClient.setQueryData(["getRetrospects", variables.spaceId], (old: RetrospectResponse) => {
         return {
           ...old,
-          retrospects: old?.retrospects?.filter((item) => item.retrospectId !== Number(variables.retrospectId)),
+          retrospects: old?.retrospects?.filter((item) => item.retrospectId !== variables.retrospectId),
         };
       });
       return { prevList };

--- a/apps/web/src/hooks/api/retrospect/useApiOptionsGetRetrospects.ts
+++ b/apps/web/src/hooks/api/retrospect/useApiOptionsGetRetrospects.ts
@@ -8,7 +8,7 @@ export type RetrospectResponse = {
   retrospects: Retrospect[];
 };
 
-const spaceRetrospectFetch = async (spaceId: string | undefined) => {
+const spaceRetrospectFetch = async (spaceId: number | undefined) => {
   const response = await api.get<RetrospectResponse>(`/space/${spaceId}/retrospect`);
   return response.data;
 };
@@ -18,7 +18,7 @@ const getAllRetrospectsFetch = async () => {
   return response.data;
 };
 
-export const useApiOptionsGetRetrospects = (spaceId?: string): UseQueryOptions<RetrospectResponse, Error, RetrospectResponse["retrospects"]> => ({
+export const useApiOptionsGetRetrospects = (spaceId?: number): UseQueryOptions<RetrospectResponse, Error, RetrospectResponse["retrospects"]> => ({
   queryKey: ["getRetrospects", spaceId],
   queryFn: () => spaceRetrospectFetch(spaceId),
   select(data) {

--- a/apps/web/src/hooks/api/space/edit/useApiEditSpace.ts
+++ b/apps/web/src/hooks/api/space/edit/useApiEditSpace.ts
@@ -11,7 +11,7 @@ export const useApiEditSpace = () => {
   const { isMobile } = getDeviceType();
   const { toast } = useToast();
 
-  const editSpace = async (formData: { spaceId: string; imgUrl: string; name: string; introduction: string }) => {
+  const editSpace = async (formData: { spaceId: number; imgUrl: string; name: string; introduction: string }) => {
     const { imgUrl, name, introduction, spaceId } = formData;
     await api.put<{ spaceId: number }>(`/api/space`, {
       id: spaceId,
@@ -23,9 +23,9 @@ export const useApiEditSpace = () => {
   };
 
   return useMutation({
-    mutationFn: (formData: { spaceId: string; imgUrl: string; name: string; introduction: string }) => editSpace(formData),
+    mutationFn: (formData: { spaceId: number; imgUrl: string; name: string; introduction: string }) => editSpace(formData),
     onSuccess: (spaceId) => {
-      if (isMobile) navigate(PATHS.spaceDetail(spaceId));
+      if (isMobile) navigate(PATHS.spaceDetail(`${spaceId}`));
       else toast.success("스페이스 수정이 완료되었습니다.");
     },
     onError: (error) => {

--- a/apps/web/src/hooks/api/space/members/useApiChangeLeader.ts
+++ b/apps/web/src/hooks/api/space/members/useApiChangeLeader.ts
@@ -3,10 +3,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api";
 import { useToast } from "@/hooks/useToast";
 
-export const useChangeLeader = (spaceId: string) => {
+export const useChangeLeader = (spaceId: number) => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const changeLeader = async ({ spaceId, memberId }: { spaceId: string; memberId: string }) => {
+  const changeLeader = async ({ spaceId, memberId }: { spaceId: number; memberId: number }) => {
     const res = await api.patch(`/api/space/change-leader`, {
       spaceId,
       memberId,
@@ -15,7 +15,7 @@ export const useChangeLeader = (spaceId: string) => {
   };
 
   return useMutation({
-    mutationFn: (changeValue: { spaceId: string; memberId: string }) => changeLeader(changeValue),
+    mutationFn: (changeValue: { spaceId: number; memberId: number }) => changeLeader(changeValue),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: ["getMembers", spaceId],

--- a/apps/web/src/hooks/api/space/members/useApiGetMembers.ts
+++ b/apps/web/src/hooks/api/space/members/useApiGetMembers.ts
@@ -4,13 +4,13 @@ import { api } from "@/api";
 
 type MembersResponse = {
   avatar: string | null;
-  id: string;
+  id: number;
   isLeader: boolean;
   name: string;
 };
 
-export const useApiGetMemers = (spaceId: string) => {
-  const getMembers = async (spaceId: string) => {
+export const useApiGetMemers = (spaceId: number) => {
+  const getMembers = async (spaceId: number) => {
     const res = await api.get<MembersResponse[]>(`/api/space/members/${spaceId}`);
     return res.data;
   };

--- a/apps/web/src/hooks/api/space/members/useApiKickMembers.ts
+++ b/apps/web/src/hooks/api/space/members/useApiKickMembers.ts
@@ -3,17 +3,17 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api";
 import { useToast } from "@/hooks/useToast";
 
-export const useApiKickMember = (spaceId: string) => {
+export const useApiKickMember = (spaceId: number) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  const apiKickMember = async ({ spaceId, memberId }: { spaceId: string; memberId: string }) => {
+  const apiKickMember = async ({ spaceId, memberId }: { spaceId: number; memberId: number }) => {
     const response = await api.patch(`/api/space/kick`, { spaceId, memberId });
     return response;
   };
 
   return useMutation({
-    mutationFn: (deleteValue: { spaceId: string; memberId: string }) => apiKickMember(deleteValue),
+    mutationFn: (deleteValue: { spaceId: number; memberId: number }) => apiKickMember(deleteValue),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: ["getMembers", spaceId],

--- a/apps/web/src/hooks/api/space/useApiDeleteSpace.ts
+++ b/apps/web/src/hooks/api/space/useApiDeleteSpace.ts
@@ -9,13 +9,13 @@ export const useApiDeleteSpace = () => {
   const { toast } = useToast();
   const navigate = useNavigate();
 
-  const apiSpaceDelete = async (spaceId: string | undefined) => {
+  const apiSpaceDelete = async (spaceId: number | undefined) => {
     const response = await api.delete(`/api/space/${spaceId}`);
     return response;
   };
 
   return useMutation({
-    mutationFn: (spaceId: string) => apiSpaceDelete(spaceId),
+    mutationFn: (spaceId: number) => apiSpaceDelete(spaceId),
     onSuccess: () => {
       navigate(PATHS.home());
       toast.success("스페이스 삭제가 완료되었습니다.");

--- a/apps/web/src/hooks/api/space/useApiGetSpace.ts
+++ b/apps/web/src/hooks/api/space/useApiGetSpace.ts
@@ -19,8 +19,8 @@ type SpaceResponse = {
   };
 };
 
-export const useApiGetSpace = (spaceId: string, isPublic: boolean = false, options?: { enabled?: boolean }) => {
-  const getSpace = async (spaceId: string, isPublic: boolean) => {
+export const useApiGetSpace = (spaceId: number, isPublic: boolean = false, options?: { enabled?: boolean }) => {
+  const getSpace = async (spaceId: number, isPublic: boolean) => {
     const endpoint = isPublic ? `/api/space/public/${spaceId}` : `/api/space/${spaceId}`;
     const res = await api.get<SpaceResponse>(endpoint);
 

--- a/apps/web/src/hooks/api/space/useApiLeaveSpace.ts
+++ b/apps/web/src/hooks/api/space/useApiLeaveSpace.ts
@@ -10,13 +10,13 @@ export const useApiLeaveSpace = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const apiSpaceLeave = async (spaceId: string | undefined) => {
-    const response = await api.post(`/api/space/leave`, { spaceId: Number(spaceId) });
+  const apiSpaceLeave = async (spaceId: number | undefined) => {
+    const response = await api.post(`/api/space/leave`, { spaceId });
     return response;
   };
 
   return useMutation({
-    mutationFn: (spaceId: string) => apiSpaceLeave(spaceId),
+    mutationFn: (spaceId: number) => apiSpaceLeave(spaceId),
     onSuccess: () => {
       navigate(PATHS.home());
       queryClient.invalidateQueries({ queryKey: ["spaces"] });

--- a/apps/web/src/hooks/api/space/useApiOptionsGetSpaceInfo.ts
+++ b/apps/web/src/hooks/api/space/useApiOptionsGetSpaceInfo.ts
@@ -3,12 +3,12 @@ import { UseQueryOptions } from "@tanstack/react-query";
 import { api } from "@/api";
 import { Space } from "@/types/spaceType";
 
-const spaceInfoFetch = async (spaceId: string | undefined) => {
+const spaceInfoFetch = async (spaceId: number | undefined) => {
   const response = await api.get<Space>(`/api/space/${spaceId}`);
   return response.data;
 };
 
-export const useApiOptionsGetSpaceInfo = (spaceId?: string): UseQueryOptions<Space, Error, Space, [string, string]> => ({
+export const useApiOptionsGetSpaceInfo = (spaceId?: number): UseQueryOptions<Space, Error, Space, [string, number]> => ({
   queryKey: ["getSpaceInfo", spaceId!],
   queryFn: () => spaceInfoFetch(spaceId),
   enabled: !!spaceId,

--- a/apps/web/src/hooks/api/template/useGetSimpleTemplateInfo.ts
+++ b/apps/web/src/hooks/api/template/useGetSimpleTemplateInfo.ts
@@ -9,7 +9,7 @@ type InfoReponse = {
   imageUrl: string;
 };
 
-export const useGetSimpleTemplateInfo = (templateId: string) => {
+export const useGetSimpleTemplateInfo = (templateId: number) => {
   const getSimpleTemplateInfo = () => {
     const res = api.get<InfoReponse>(`/api/template/${templateId}/simple-info`).then((res) => res.data);
     return res;

--- a/apps/web/src/hooks/api/user/useDeleteUser.ts
+++ b/apps/web/src/hooks/api/user/useDeleteUser.ts
@@ -13,7 +13,7 @@ export const useDeleteUser = () => {
   const navigate = useTestNavigate();
   const setAuth = useSetAtom(authAtom);
 
-  const apiDeleteUser = async ({ memberId, booleans, description }: { memberId: string; booleans: boolean[]; description: string }) => {
+  const apiDeleteUser = async ({ memberId, booleans, description }: { memberId: number; booleans: boolean[]; description: string }) => {
     const response = await api.post(
       `/api/auth/withdraw`,
       {
@@ -30,7 +30,7 @@ export const useDeleteUser = () => {
   };
 
   return useMutation({
-    mutationFn: ({ memberId, booleans, description }: { memberId: string; booleans: boolean[]; description: string }) =>
+    mutationFn: ({ memberId, booleans, description }: { memberId: number; booleans: boolean[]; description: string }) =>
       apiDeleteUser({ memberId, booleans, description }),
     onSuccess: () => {
       clearAuthCookies();

--- a/apps/web/src/hooks/app/space/useModifySpace.ts
+++ b/apps/web/src/hooks/app/space/useModifySpace.ts
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 interface ModifySpaceProps {
-  id: string;
+  id: number;
 }
 
 export const MODIFY_SPACE_ID_QUERY_KEY = "modifyTargetId";

--- a/apps/web/src/hooks/useRequiredParams.ts
+++ b/apps/web/src/hooks/useRequiredParams.ts
@@ -4,3 +4,9 @@ export const useRequiredParams = <T extends Record<string, string>>() => {
   const params = useParams<T>();
   return params as T;
 };
+
+export const useRequiredNumberParams = <T extends Record<string, number>>() => {
+  const params = useParams<Record<keyof T, string>>();
+
+  return Object.fromEntries(Object.entries(params).map(([key, value]) => [key, Number(value)])) as T;
+};

--- a/apps/web/src/store/retrospect/retrospectInitial.ts
+++ b/apps/web/src/store/retrospect/retrospectInitial.ts
@@ -1,15 +1,15 @@
 import { atom } from "jotai";
 
 interface RetrospectInitialType {
-  spaceId: string;
-  templateId: string;
-  tempTemplateId: string;
+  spaceId: number | null;
+  templateId: number | null;
+  tempTemplateId: number | null;
   saveTemplateId: boolean;
 }
 
 export const retrospectInitialState = atom<RetrospectInitialType>({
-  spaceId: "",
-  templateId: "",
-  tempTemplateId: "",
+  spaceId: null,
+  templateId: null,
+  tempTemplateId: null,
   saveTemplateId: false,
 });

--- a/apps/web/src/types/actionItem/index.ts
+++ b/apps/web/src/types/actionItem/index.ts
@@ -17,7 +17,7 @@ export type ExtendedActionItemType = {
 };
 
 export type TeamActionItemType = {
-  spaceId: string;
+  spaceId: number;
   spaceName: string;
   teamActionItemList: ExtendedActionItemType[];
 };

--- a/apps/web/src/types/spaceType/index.ts
+++ b/apps/web/src/types/spaceType/index.ts
@@ -1,5 +1,5 @@
 export type Space = {
-  id: string;
+  id: number;
   category: "INDIVIDUAL" | "TEAM";
   fieldList: string[];
   name: string;

--- a/apps/web/src/utils/space/cryptoKey.ts
+++ b/apps/web/src/utils/space/cryptoKey.ts
@@ -6,8 +6,8 @@ const VECTOR_KEY = import.meta.env.VITE_VECTOR_KEY as string;
 const key = CryptoJS.enc.Utf8.parse(CRYPTO_KEY);
 const iv = CryptoJS.enc.Utf8.parse(VECTOR_KEY);
 
-const encryptId = (id: string) => {
-  const encrypted = CryptoJS.AES.encrypt(id.toString(), key, {
+const encryptId = (id: number | string) => {
+  const encrypted = CryptoJS.AES.encrypt(`${id}`, key, {
     iv: iv,
     mode: CryptoJS.mode.CBC,
     padding: CryptoJS.pad.Pkcs7,


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 주요 ID 파라미터(예: spaceId, retrospectId, templateId)를 숫자형으로 일관되게 적용했습니다.
- URL searchParams 및 전역 상태에서 ID를 가져올 때 명시적인 `Number()` 변환을 추가했습니다.
- API 호출 및 컴포넌트 간 ID 타입 불일치 문제를 해결하여 안정성을 높였습니다.

### 🫨 Describe your Change (변경사항)

- `useSearchParams`로 가져오는 `spaceId`, `retrospectId`를 `Number()`로 변환하도록 수정했습니다.
- 분석 및 회고 관련 컴포넌트의 `spaceId`, `retrospectId`, `templateId` prop 및 상태 타입을 `string | null`에서 `number | null` 또는 `number`로 변경했습니다.
- `useApiOptionsGetSpaceInfo`, `useApiGetSpace` 등 API 훅 호출 시 ID 인자를 숫자형으로 전달하도록 업데이트했습니다.
- `useRequiredParams`를 `useRequiredNumberParams`로 교체하여 숫자형 파라미터 처리를 강화했습니다.
- `tempTemplateId`의 초기값을 `null`로 변경하고, `encryptId` 함수도 숫자형 ID를 직접 처리하도록 개선했습니다.

### 🧐 Issue number and link (참고)

closes: #879

### 📚 Reference (참조)

-