### PR TITLE
툴팁 컴포넌트 개선 및 자동 PR 메시지 워크플로우 조건 수정

### DIFF
--- a/.github/workflows/auto-pr-message-gemini.yml
+++ b/.github/workflows/auto-pr-message-gemini.yml
@@ -20,7 +20,8 @@ jobs:
   generate:
     name: Generate PR title/body
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.type != 'Bot'
+    if: >
+      !(github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop')
 
     steps:
       - name: Checkout repository

--- a/apps/web/src/component/common/tip/Tooltip.tsx
+++ b/apps/web/src/component/common/tip/Tooltip.tsx
@@ -7,7 +7,7 @@ import { usePopper } from "react-popper";
 import { Portal } from "@/component/common/Portal";
 import { Typography } from "@/component/common/typography";
 import { ANIMATION } from "@/style/common/animation";
-import { DESIGN_SYSTEM_COLOR } from "@/style/variable";
+import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
 type TooltipContextState = {
   referenceEl: HTMLDivElement | null;
@@ -60,6 +60,7 @@ type Content = {
   modifiers?: Partial<OffsetModifier>[];
   offsetX?: number;
   offsetY?: number;
+  arrowOffsetX?: number;
   hideOnClick?: boolean;
   autoHide?: boolean;
 };
@@ -79,6 +80,7 @@ function Content({
   placement,
   offsetX = 0,
   offsetY = 30,
+  arrowOffsetX = 2,
   modifiers = [],
   hideOnClick = true,
   autoHide = true,
@@ -117,28 +119,27 @@ function Content({
 
   const getArrowPosition = (placement: ContentProps["placement"]) => {
     const offsetY = -0.4;
-    const offsetX = 2;
+
     switch (placement) {
       case "top-start":
         return css`
           bottom: ${offsetY}rem;
-          left: ${offsetX}rem;
+          left: ${arrowOffsetX}rem;
         `;
       case "top-end":
         return css`
           bottom: ${offsetY}rem;
-          right: ${offsetX}rem;
+          right: ${arrowOffsetX}rem;
         `;
-
       case "bottom-start":
         return css`
           top: ${offsetY}rem;
-          left: ${offsetX}rem;
+          left: ${arrowOffsetX}rem;
         `;
       case "bottom-end":
         return css`
           top: ${offsetY}rem;
-          right: ${offsetX}rem;
+          right: ${arrowOffsetX}rem;
         `;
     }
   };
@@ -153,9 +154,9 @@ function Content({
             css={css`
               position: relative;
               z-index: 100001;
-              background-color: ${DESIGN_SYSTEM_COLOR.blue600};
+              background: ${DESIGN_TOKEN_COLOR.gray900};
               padding: 1rem 1.4rem;
-              border-radius: 1.2rem;
+              border-radius: 0.8rem;
               width: max-content;
               ${animate &&
               css`
@@ -168,7 +169,7 @@ function Content({
                 visibility 0.2s ease;
             `}
           >
-            <Typography variant="CAPTION" color="white">
+            <Typography variant="body12SemiBold" color="white">
               {message}
             </Typography>
             <div
@@ -179,7 +180,7 @@ function Content({
                   width: 1.2rem;
                   height: 1.2rem;
                   border-radius: 0.2rem;
-                  background: ${DESIGN_SYSTEM_COLOR.blue600};
+                  background: ${DESIGN_TOKEN_COLOR.gray900};
                   visibility: visible;
                   content: "";
                   transform: rotate(45deg);

--- a/apps/web/src/component/login/SocialLoginArea.tsx
+++ b/apps/web/src/component/login/SocialLoginArea.tsx
@@ -89,7 +89,7 @@ export function SocialLoginArea({
     return (
       <Tooltip>
         <Tooltip.Trigger>{button}</Tooltip.Trigger>
-        <Tooltip.Content message="최근 로그인한 방법이에요!" placement="top-start" offsetY={15} hideOnClick={true} autoHide={false} />
+        <Tooltip.Content message="최근 로그인" placement="top-end" offsetY={0} arrowOffsetX={5} hideOnClick={true} autoHide={false} />
       </Tooltip>
     );
   };


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 툴팁 컴포넌트의 디자인 토큰 적용 및 스타일을 개선했습니다.
- 툴팁 화살표의 X축 오프셋을 제어하는 `arrowOffsetX` prop을 추가했습니다.
- `develop`에서 `main`으로 병합 시 자동 PR 메시지 생성을 방지하도록 워크플로우 조건을 업데이트했습니다.

### 🫨 Describe your Change (변경사항)

- .github/workflows/auto-pr-message-gemini.yml: `develop` -> `main` 병합 시 자동 PR 메시지 생성을 건너뛰도록 조건문 변경.
- apps/web/src/component/common/tip/Tooltip.tsx: 디자인 시스템 색상 토큰을 `DESIGN_TOKEN_COLOR`로 일관되게 적용하고, 툴팁 배경색을 `gray900`으로 변경했습니다.
- apps/web/src/component/common/tip/Tooltip.tsx: 툴팁의 `border-radius`를 `0.8rem`으로 조정하고, 텍스트 스타일을 `body12SemiBold`로 업데이트했습니다.
- apps/web/src/component/common/tip/Tooltip.tsx: 툴팁 화살표의 X축 위치를 미세 조정할 수 있는 `arrowOffsetX` prop을 추가하고 관련 로직에 적용했습니다.
- apps/web/src/component/login/SocialLoginArea.tsx: 소셜 로그인 영역의 툴팁 메시지, 배치(`top-end`), `offsetY`, `arrowOffsetX` 값을 조정하여 UI를 개선했습니다.

### 🧐 Issue number and link (참고)

-

### 📚 Reference (참조)

-