### PR TITLE
feat: 개인 실행목표 기능 추가 및 홈 화면 UI 개선

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/ActionItems.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/ActionItems.tsx
@@ -149,6 +149,7 @@ function List() {
                   spaceId={spaceId}
                   retrospectId={goal.retrospectId}
                   title={goal.retrospectTitle}
+                  deadline={goal.deadline}
                   todoList={goal.actionItemList}
                   status={goal.status}
                 />

--- a/apps/web/src/app/desktop/component/home/ActionItemBox/index.tsx
+++ b/apps/web/src/app/desktop/component/home/ActionItemBox/index.tsx
@@ -1,28 +1,22 @@
-import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { PersonalActionItemType } from "@/types/actionItem";
 import { formatOnlyDate } from "@/utils/date";
 import { css } from "@emotion/react";
-import { PATHS } from "@layer/shared";
-import { useNavigate } from "react-router-dom";
 
 type ActionItemBoxProps = {
   actionItem: PersonalActionItemType;
 };
 
 export default function ActionItemBox({ actionItem }: ActionItemBoxProps) {
-  const navigate = useNavigate();
-
-  const { retrospectTitle, spaceName, deadline, actionItemList, spaceId, retrospectId } = actionItem;
-
-  const handleRetrospectClick = () => {
-    navigate(PATHS.retrospectAnalysis(String(spaceId), retrospectId, retrospectTitle));
-  };
+  const { retrospectTitle, spaceName, deadline, actionItemList } = actionItem;
 
   return (
     <section
       css={css`
+        display: flex;
+        flex-direction: column;
+        gap: 1.2rem;
         width: 27.7rem;
       `}
     >
@@ -48,77 +42,92 @@ export default function ActionItemBox({ actionItem }: ActionItemBoxProps) {
           <Typography variant="title16Bold" color="gray900">
             {retrospectTitle}
           </Typography>
-          <Typography
-            variant="body14Medium"
-            color="gray500"
+          <div
             css={css`
-              overflow: hidden;
-              text-overflow: ellipsis;
-              white-space: nowrap;
+              display: flex;
+              align-items: center;
+              gap: 0.6rem;
             `}
           >
-            {spaceName} | 회고 마감일 {deadline ? formatOnlyDate(deadline) : "없음"}
-          </Typography>
-        </div>
-        <div
-          css={css`
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 2.4rem;
-            height: 2.4rem;
-            border-radius: 50%;
-            cursor: pointer;
-            flex-shrink: 0;
-
-            transition: background-color 0.2s ease-in-out;
-
-            &:hover {
-              background-color: ${DESIGN_TOKEN_COLOR.gray300};
-            }
-          `}
-          onClick={handleRetrospectClick}
-        >
-          <Icon icon="ic_after" size={1.2} color={DESIGN_TOKEN_COLOR.gray800} />
+            <Typography
+              variant="body14Medium"
+              color="gray500"
+              css={css`
+                white-space: nowrap;
+              `}
+            >
+              {spaceName}
+            </Typography>
+            <div
+              css={css`
+                width: 0.1rem;
+                height: 1.2rem;
+                background-color: ${DESIGN_TOKEN_COLOR.gray400};
+                flex-shrink: 0;
+              `}
+            />
+            <Typography
+              variant="body14Medium"
+              color="gray500"
+              css={css`
+                white-space: nowrap;
+              `}
+            >
+              회고 마감일 {deadline ? formatOnlyDate(deadline) : "없음"}
+            </Typography>
+          </div>
         </div>
       </section>
 
       {/* ---------- 실행목표 리스트 ---------- */}
       {actionItemList && actionItemList.length > 0 ? (
-        <ul
+        <div
           css={css`
             display: flex;
             flex-direction: column;
-            margin-top: 2.4rem;
-            list-style: disc;
-            padding-left: 2.6rem;
-            margin-top: 2.4rem;
-            gap: 2rem;
-
-            li::marker {
-              color: ${DESIGN_TOKEN_COLOR.gray400};
-              font-size: 2rem;
-            }
+            padding: 0 0.4rem;
           `}
         >
-          {actionItemList.slice(0, 3).map((actionItem) => (
-            <li
-              key={actionItem.actionItemId}
+          {actionItemList.slice(0, 3).map((item) => (
+            <div
+              key={item.actionItemId}
               css={css`
-                padding-left: 0.8rem;
+                display: flex;
+                align-items: center;
+                gap: 0.8rem;
+                height: 4.6rem;
+                padding: 0.8rem 0;
               `}
             >
+              <span
+                css={css`
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  width: 1.4rem;
+                  flex-shrink: 0;
+                `}
+              >
+                <span
+                  css={css`
+                    width: 0.4rem;
+                    height: 0.4rem;
+                    border-radius: 50%;
+                    background-color: ${DESIGN_TOKEN_COLOR.gray400};
+                  `}
+                />
+              </span>
               <Typography variant="body16Medium" color="gray900">
-                {actionItem.content}
+                {item.content}
               </Typography>
-            </li>
+            </div>
           ))}
-        </ul>
+        </div>
       ) : (
         <div
           css={css`
             margin-top: 4.8rem;
-            padding: 2rem;
+            padding: 1.2rem 2rem;
             text-align: center;
           `}
         >

--- a/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
@@ -40,6 +40,34 @@ export default function ActionItemsWrapper() {
 
   const currentGoals = isTeamTab ? teamGoals : personalGoals;
   const isPending = isTeamTab ? isTeamPending : isPersonalPending;
+  const isEmptyGoals = !currentGoals || currentGoals.length === 0;
+
+  const renderActionItems = () => {
+    if (isPending) {
+      return (
+        <div
+          css={css`
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+          `}
+        >
+          <LoadingSpinner />
+        </div>
+      );
+    }
+
+    if (isEmptyGoals) {
+      return <ActionItemsWrapper.Onboarding />;
+    }
+
+    return currentGoals.map((actionItem, index) => (
+      <SwiperSlide key={`${actionItem.retrospectId}-${index}`}>
+        <ActionItemBox actionItem={actionItem} />
+      </SwiperSlide>
+    ));
+  };
 
   return (
     <article
@@ -200,7 +228,7 @@ export default function ActionItemsWrapper() {
               min-height: 22.8rem;
 
               .swiper-wrapper {
-                display: ${(currentGoals?.length ?? 0) === 0 ? "none" : "flex"};
+                display: ${isEmptyGoals ? "none" : "flex"};
                 align-items: stretch;
               }
 
@@ -211,26 +239,7 @@ export default function ActionItemsWrapper() {
               }
             `}
           >
-            {isPending ? (
-              <div
-                css={css`
-                  position: absolute;
-                  top: 50%;
-                  left: 50%;
-                  transform: translate(-50%, -50%);
-                `}
-              >
-                <LoadingSpinner />
-              </div>
-            ) : !currentGoals || currentGoals.length === 0 ? (
-              <ActionItemsWrapper.Onboarding />
-            ) : (
-              currentGoals.map((actionItem, index) => (
-                <SwiperSlide key={`${actionItem.retrospectId}-${index}`}>
-                  <ActionItemBox actionItem={actionItem} />
-                </SwiperSlide>
-              ))
-            )}
+            {renderActionItems()}
           </Swiper>
           <button ref={prevButtonRef} className="swiper-button-prev" />
           <button ref={nextButtonRef} className="swiper-button-next" />

--- a/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
@@ -1,32 +1,45 @@
+import { COOKIE_KEYS } from "@/config/storage-keys";
+import Cookies from "js-cookie";
+
+import { Icon } from "@/component/common/Icon";
+import { Spacing } from "@/component/common/Spacing";
+import Tooltip from "@/component/common/Tooltip";
 import { Typography } from "@/component/common/typography";
+import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
+import { useGetActionItemList } from "@/hooks/api/actionItem/useGetActionItemList";
+import { useGetPersonalActionItemList } from "@/hooks/api/actionItem/useGetPersonalActionItemList";
+import { useTabs } from "@/hooks/useTabs";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { css } from "@emotion/react";
-import ActionItemBox from "../ActionItemBox";
-import Cookies from "js-cookie";
-import { COOKIE_KEYS } from "@/config/storage-keys";
+import { useRef } from "react";
 
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation } from "swiper/modules";
 
 import "swiper/css";
 import "swiper/css/navigation";
-import { useGetActionItemList } from "@/hooks/api/actionItem/useGetActionItemList";
-import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
-import { Icon } from "@/component/common/Icon";
-import { Spacing } from "@/component/common/Spacing";
+import ActionItemBox from "../ActionItemBox";
+
+const GOAL_TAB_LABELS = ["팀", "개인"] as const;
 
 export default function ActionItemsWrapper() {
-  // * 본인 memberId 가져오기
+  const { tabs, curTab, selectTab } = useTabs(GOAL_TAB_LABELS);
   const memberId = Cookies.get(COOKIE_KEYS.memberId);
+  const isTeamTab = curTab === "팀";
+  const prevButtonRef = useRef<HTMLButtonElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
 
-  // * 실행목표 리스트 요청
-  const { data: myActionItems, isPending: isMyActionItemsPending } = useGetActionItemList({
+  // * 팀 탭: 내 모든 스페이스의 팀 실행목표 / 개인 탭: 내 모든 스페이스의 개인 실행목표
+  const { data: teamGoals, isPending: isTeamPending } = useGetActionItemList({
     memberId: Number(memberId),
-    options: {
-      enabled: !!memberId,
-      select: (data) => data.actionItems,
-    },
+    options: { enabled: !!memberId && isTeamTab, select: (data) => data.actionItems },
   });
+  const { data: personalGoals, isPending: isPersonalPending } = useGetPersonalActionItemList({
+    options: { enabled: !!memberId && !isTeamTab, select: (data) => data.actionItems },
+  });
+
+  const currentGoals = isTeamTab ? teamGoals : personalGoals;
+  const isPending = isTeamTab ? isTeamPending : isPersonalPending;
 
   return (
     <article
@@ -55,128 +68,174 @@ export default function ActionItemsWrapper() {
               content: "";
               width: 0.1rem;
               height: 0.9rem;
-              background-color: ${DESIGN_TOKEN_COLOR.gray500};
+              background-color: ${DESIGN_TOKEN_COLOR.gray400};
               margin-left: 0.7rem;
             }
           `}
         >
           실행목표
         </Typography>
-        <Typography variant="body15SemiBold" color="gray800">
-          {myActionItems?.length ?? 0}개의 실행목표가 진행 중이에요
+        <Typography variant="body15Medium" color="gray800">
+          {currentGoals?.length ?? 0}개의 실행목표가 진행중이에요
         </Typography>
       </section>
 
-      {/* ---------- 실행목표 컨텐츠 ---------- */}
-      <Swiper
-        modules={[Navigation]}
-        spaceBetween={16}
-        slidesPerView={3}
-        navigation
+      {/* ---------- 실행목표 컨텐츠 박스 ---------- */}
+      <div
         css={css`
-          height: 27.6rem;
+          position: relative;
           margin-top: 1.2rem;
+          display: flex;
+          flex-direction: column;
+          gap: 2.4rem;
           padding: 2.4rem 3.2rem;
           border-radius: 1.6rem;
           background-color: ${DESIGN_TOKEN_COLOR.gray00};
-          position: relative;
           overflow: hidden;
-
-          /* 좌측 오버플로우 가리기 */
-          &::before {
-            content: "";
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 3.2rem;
-            height: 100%;
-            background-color: ${DESIGN_TOKEN_COLOR.gray00};
-            z-index: 5;
-            pointer-events: none;
-          }
-
-          /* 우측 오버플로우 가리기 */
-          &::after {
-            content: "";
-            position: absolute;
-            top: 0;
-            right: 0;
-            width: 3.2rem;
-            height: 100%;
-            background-color: ${DESIGN_TOKEN_COLOR.gray00};
-            z-index: 5;
-            pointer-events: none;
-          }
-
-          .swiper-wrapper {
-            display: ${myActionItems?.length === 0 ? "none" : "flex"};
-            align-items: stretch;
-          }
-
-          .swiper-slide {
-            height: auto;
-            display: flex;
-            align-items: flex-start;
-          }
-
-          .swiper-button-prev,
-          .swiper-button-next {
-            width: 4.8rem;
-            height: 4.8rem;
-            background: white;
-            border-radius: 50%;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-            border: 1px solid ${DESIGN_TOKEN_COLOR.gray200};
-            top: 60%;
-            transform: translateY(-50%);
-            z-index: 10;
-
-            &::after {
-              font-size: 1.6rem;
-              font-weight: bold;
-              color: ${DESIGN_TOKEN_COLOR.gray600};
-            }
-
-            &:hover {
-              background: ${DESIGN_TOKEN_COLOR.gray100};
-              box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-            }
-
-            &.swiper-button-disabled {
-              opacity: 0;
-            }
-          }
-
-          .swiper-button-prev {
-            left: 0.8rem;
-          }
-
-          .swiper-button-next {
-            right: 0.8rem;
-          }
         `}
       >
-        {isMyActionItemsPending ? (
-          <div
-            css={css`
-              position: absolute;
+        {/* ---------- 팀/개인 탭 + NEW 툴팁 ---------- */}
+        <Tooltip placement="right" defaultOpen>
+          <Tooltip.Trigger>
+            <div
+              css={css`
+                display: flex;
+                gap: 0.4rem;
+                width: fit-content;
+              `}
+            >
+              {tabs.map((tab) => {
+                const isActive = tab === curTab;
+                return (
+                  <button
+                    key={tab}
+                    onClick={() => selectTab(tab)}
+                    css={css`
+                      position: relative;
+                      display: flex;
+                      align-items: center;
+                      padding: 0 0.4rem;
+                      cursor: pointer;
+                    `}
+                  >
+                    <Typography variant="subtitle18SemiBold" color={isActive ? "gray900" : "gray500"}>
+                      {tab}
+                    </Typography>
+                    {/* 밑줄바는 absolute로 띄워 탭 블록 높이가 글자 높이와 같아지도록 한다 (툴팁 수직 정렬용) */}
+                    <div
+                      css={css`
+                        position: absolute;
+                        left: 0.4rem;
+                        right: 0.4rem;
+                        top: calc(100% + 0.8rem);
+                        height: 0.2rem;
+                        background-color: ${isActive ? DESIGN_TOKEN_COLOR.gray900 : "transparent"};
+                      `}
+                    />
+                  </button>
+                );
+              })}
+            </div>
+          </Tooltip.Trigger>
+          <Tooltip.Content tag="NEW" arrow>
+            팀 회고 속 나의 목표를 관리해보세요.
+          </Tooltip.Content>
+        </Tooltip>
+
+        {/* ---------- 카드 리스트 ---------- */}
+        {/* 네비게이션 버튼은 Swiper(overflow: hidden) 밖에 두어야 음수 offset으로 가장자리까지 이동할 수 있다 */}
+        <div
+          css={css`
+            position: relative;
+
+            .swiper-button-prev,
+            .swiper-button-next {
+              width: 4.3rem;
+              height: 4.3rem;
+              background: ${DESIGN_TOKEN_COLOR.gray00};
+              border-radius: 50%;
+              box-shadow: 0px 0.3rem 0.5rem rgba(0, 0, 0, 0.08);
+              border: 1px solid ${DESIGN_TOKEN_COLOR.gray300};
               top: 50%;
-              left: 50%;
-              transform: translate(-50%, -50%);
+              transform: translateY(-50%);
+              z-index: 10;
+
+              &::after {
+                font-size: 1.4rem;
+                font-weight: bold;
+                color: ${DESIGN_TOKEN_COLOR.gray600};
+              }
+
+              &:hover {
+                background: ${DESIGN_TOKEN_COLOR.gray100};
+              }
+
+              &.swiper-button-disabled {
+                opacity: 0;
+              }
+            }
+
+            .swiper-button-prev {
+              left: -1.6rem;
+            }
+
+            .swiper-button-next {
+              right: -1.6rem;
+            }
+          `}
+        >
+          <Swiper
+            modules={[Navigation]}
+            spaceBetween={16}
+            slidesPerView={3}
+            navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
+            onBeforeInit={(swiper) => {
+              if (typeof swiper.params.navigation === "object" && swiper.params.navigation) {
+                swiper.params.navigation.prevEl = prevButtonRef.current;
+                swiper.params.navigation.nextEl = nextButtonRef.current;
+              }
+            }}
+            css={css`
+              width: 100%;
+              min-height: 22.8rem;
+
+              .swiper-wrapper {
+                display: ${(currentGoals?.length ?? 0) === 0 ? "none" : "flex"};
+                align-items: stretch;
+              }
+
+              .swiper-slide {
+                height: auto;
+                display: flex;
+                align-items: flex-start;
+              }
             `}
           >
-            <LoadingSpinner />
-          </div>
-        ) : !myActionItems || myActionItems.length === 0 ? (
-          <ActionItemsWrapper.Onboarding />
-        ) : (
-          myActionItems?.map((actionItem, index) => (
-            <SwiperSlide key={`${actionItem.retrospectId}-${index}`}>
-              <ActionItemBox actionItem={actionItem} />
-            </SwiperSlide>
-          ))
-        )}
-      </Swiper>
+            {isPending ? (
+              <div
+                css={css`
+                  position: absolute;
+                  top: 50%;
+                  left: 50%;
+                  transform: translate(-50%, -50%);
+                `}
+              >
+                <LoadingSpinner />
+              </div>
+            ) : !currentGoals || currentGoals.length === 0 ? (
+              <ActionItemsWrapper.Onboarding />
+            ) : (
+              currentGoals.map((actionItem, index) => (
+                <SwiperSlide key={`${actionItem.retrospectId}-${index}`}>
+                  <ActionItemBox actionItem={actionItem} />
+                </SwiperSlide>
+              ))
+            )}
+          </Swiper>
+          <button ref={prevButtonRef} className="swiper-button-prev" />
+          <button ref={nextButtonRef} className="swiper-button-next" />
+        </div>
+      </div>
     </article>
   );
 }

--- a/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
+++ b/apps/web/src/app/desktop/component/home/ActionItemsWrapper/index.tsx
@@ -1,4 +1,4 @@
-import { COOKIE_KEYS } from "@/config/storage-keys";
+import { COOKIE_KEYS, LOCAL_STORAGE_KEYS } from "@/config/storage-keys";
 import Cookies from "js-cookie";
 
 import { Icon } from "@/component/common/Icon";
@@ -95,7 +95,7 @@ export default function ActionItemsWrapper() {
         `}
       >
         {/* ---------- 팀/개인 탭 + NEW 툴팁 ---------- */}
-        <Tooltip placement="right" defaultOpen>
+        <Tooltip placement="right" defaultOpen storageKey={LOCAL_STORAGE_KEYS.actionItemGoalTooltipSeen}>
           <Tooltip.Trigger>
             <div
               css={css`

--- a/apps/web/src/app/mobile/actionItem/ActionItemEditPage.tsx
+++ b/apps/web/src/app/mobile/actionItem/ActionItemEditPage.tsx
@@ -11,8 +11,11 @@ import { LoadingModal } from "@/component/common/Modal/LoadingModal.tsx";
 import { Typography } from "@/component/common/typography";
 import { AddListItemButton } from "@/component/retrospectCreate/customTemplate/EditQuestions.tsx";
 import { useCreateActionItem } from "@/hooks/api/actionItem/useCreateActionItem.ts";
+import { useApiPostPersonalActionItem } from "@/hooks/api/actionItem/useApiPostPersonalActionItem.ts";
 import { useDeleteActionItemList } from "@/hooks/api/actionItem/useDeleteActionItemList.ts";
+import { useDeletePersonalActionItemList } from "@/hooks/api/actionItem/useDeletePersonalActionItemList.ts";
 import { usePatchActionItemList } from "@/hooks/api/actionItem/usePatchActionItemList.ts";
+import { usePatchPersonalActionItemList } from "@/hooks/api/actionItem/usePatchPersonalActionItemList.ts";
 import { useModal } from "@/hooks/useModal.ts";
 import { useToast } from "@/hooks/useToast.ts";
 import { DualToneLayout } from "@/layout/DualToneLayout.tsx";
@@ -32,10 +35,17 @@ type retrospectInfoType = {
 export function ActionItemEditPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { data: retrospectInfo } = location.state as { data: retrospectInfoType };
+  const {
+    data: retrospectInfo,
+    isPersonal = false,
+    spaceId,
+  } = location.state as { data: retrospectInfoType; isPersonal?: boolean; spaceId?: number };
   const { mutate: deleteActionItem, isPending: deleteActionItemPending } = useDeleteActionItemList();
+  const { mutate: deletePersonalActionItem, isPending: deletePersonalPending } = useDeletePersonalActionItemList();
   const { mutate: patchActionItem, isPending: patchActionItemPending } = usePatchActionItemList();
+  const { mutate: patchPersonalActionItem, isPending: patchPersonalPending } = usePatchPersonalActionItemList();
   const { mutate: createActionItem, isPending: createActionItemPending } = useCreateActionItem();
+  const { mutate: createPersonalActionItem, isPending: createPersonalPending } = useApiPostPersonalActionItem();
   const { open } = useModal();
   const { toast } = useToast();
 
@@ -55,16 +65,17 @@ export function ActionItemEditPage() {
         type: "confirm",
       },
       onConfirm: () => {
-        deleteActionItem(
-          { actionItemId: id },
-          {
-            onSuccess: () => {
-              setData(data.filter((item) => item.id !== id));
-              toast.success("성공적으로 삭제가 완료되었습니다.");
-            },
-            onError: () => toast.error("삭제 도중 에러가 발생했습니다."),
-          },
-        );
+        const onSuccess = () => {
+          setData(data.filter((item) => item.id !== id));
+          toast.success("성공적으로 삭제가 완료되었습니다.");
+        };
+        const onError = () => toast.error("삭제 도중 에러가 발생했습니다.");
+
+        if (isPersonal) {
+          deletePersonalActionItem({ actionItemId: id }, { onSuccess, onError });
+        } else {
+          deleteActionItem({ actionItemId: id }, { onSuccess, onError });
+        }
       },
     });
   };
@@ -92,37 +103,39 @@ export function ActionItemEditPage() {
 
   const handleAdd = () => {
     if (isLimit) return;
-    createActionItem(
-      { retrospectId: retrospectInfo.retrospectId, content: "" },
-      {
-        onSuccess: (res: AxiosResponse<{ actionItemId: number }>) => {
-          try {
-            setData([...data, { id: res.data.actionItemId, content: "" }]);
-          } catch {
-            toast.error("실행 목표 생성 과정에서 에러가 발생했어요!");
-          }
-        },
-      },
-    );
+    const onSuccess = (res: AxiosResponse<{ actionItemId: number }>) => {
+      try {
+        setData([...data, { id: res.data.actionItemId, content: "" }]);
+      } catch {
+        toast.error("실행 목표 생성 과정에서 에러가 발생했어요!");
+      }
+    };
+
+    if (isPersonal && spaceId != null) {
+      createPersonalActionItem({ spaceId, retrospectId: retrospectInfo.retrospectId, content: "" }, { onSuccess });
+    } else {
+      createActionItem({ retrospectId: retrospectInfo.retrospectId, content: "" }, { onSuccess });
+    }
   };
 
   const handleComplete = () => {
-    patchActionItem(
-      { retrospectId: retrospectInfo.retrospectId, actionItems: data },
-      {
-        onSuccess: () => {
-          toast.success("실행목표 편집이 완료되었어요!");
-          navigate(-1);
-        },
-        onError: () => toast.error("데이터를 수정하는데 오류가 발생했습니다."),
-      },
-    );
+    const onSuccess = () => {
+      toast.success("실행목표 편집이 완료되었어요!");
+      navigate(-1);
+    };
+    const onError = () => toast.error("데이터를 수정하는데 오류가 발생했습니다.");
+
+    if (isPersonal && spaceId != null) {
+      patchPersonalActionItem({ spaceId, retrospectId: retrospectInfo.retrospectId, actionItems: data }, { onSuccess, onError });
+    } else {
+      patchActionItem({ retrospectId: retrospectInfo.retrospectId, actionItems: data }, { onSuccess, onError });
+    }
   };
 
   return (
     <Fragment>
-      {createActionItemPending && <LoadingModal purpose={"실행 목표를 만드는 중입니다.."} />}
-      {deleteActionItemPending && <LoadingModal purpose={"데이터를 삭제하는 중..."} />}
+      {(createActionItemPending || createPersonalPending) && <LoadingModal purpose={"실행 목표를 만드는 중입니다.."} />}
+      {(deleteActionItemPending || deletePersonalPending) && <LoadingModal purpose={"데이터를 삭제하는 중..."} />}
       <DualToneLayout
         title={"실행목표 편집"}
         bottomTheme={"default"}
@@ -228,7 +241,7 @@ export function ActionItemEditPage() {
           </div>
         </div>
         <ButtonProvider>
-          <Button isProgress={patchActionItemPending} onClick={handleComplete}>
+          <Button isProgress={patchActionItemPending || patchPersonalPending} onClick={handleComplete}>
             완료
           </Button>
         </ButtonProvider>

--- a/apps/web/src/app/mobile/actionItem/ActionItemMorePage.tsx
+++ b/apps/web/src/app/mobile/actionItem/ActionItemMorePage.tsx
@@ -1,7 +1,8 @@
 import { css } from "@emotion/react";
+import { useQuery } from "@tanstack/react-query";
 import Cookies from "js-cookie";
 import { COOKIE_KEYS } from "@/config/storage-keys";
-import { Fragment } from "react";
+import { Fragment, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 import { status } from "@/component/ActionItem/actionItem.const.ts";
@@ -13,6 +14,7 @@ import { LoadingModal } from "@/component/common/Modal/LoadingModal.tsx";
 import { Spacing } from "@/component/common/Spacing";
 import { Typography } from "@/component/common/typography";
 import { useGetSpaceActionItemList } from "@/hooks/api/actionItem/useGetSpaceActionItemList.ts";
+import { useApiOptionsGetPersonalActionItemListBySpace } from "@/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts";
 import { useBottomSheet } from "@/hooks/useBottomSheet.ts";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 import { DESIGN_TOKEN_COLOR, DESIGN_TOKEN_TEXT } from "@/style/designTokens.ts";
@@ -31,9 +33,28 @@ export function ActionItemMorePage() {
   }));
   const SHEET_ID = "info";
   const isLeader = Number(memberId) === leaderId;
+
+  const [currentTab, setCurrentTab] = useState<"팀" | "개인">("팀");
+  const isTeam = currentTab === "팀";
+
+  // * 개인 실행목표는 개인 탭일 때만 조회한다.
+  const { data: personalData, isLoading: isPersonalLoading, refetch: refetchPersonal } = useQuery({
+    ...useApiOptionsGetPersonalActionItemListBySpace(spaceId),
+    enabled: !!spaceId && !isTeam,
+  });
+  const personalScaledData = personalData?.personalActionItemList.map((item) => ({
+    retrospectId: item.retrospectId,
+    retrospectTitle: item.retrospectTitle,
+    status: item.status,
+    actionItemList: item.actionItemList,
+  }));
+
+  // * 한 탭 안에서 진행 중(PROCEEDING) → 지난(DONE) 순으로 모두 표기한다.
+  const rawItems = isTeam ? data?.teamActionItemList : personalData?.personalActionItemList;
+  const sortedItems = [...(rawItems ?? [])].sort((a, b) => (a.status === status[0] ? 0 : 1) - (b.status === status[0] ? 0 : 1));
   return (
     <Fragment>
-      {isLoading && <LoadingModal />}
+      {(isTeam ? isLoading : isPersonalLoading) && <LoadingModal />}
       <BottomSheet
         id={"info"}
         title={"실행목표란?"}
@@ -74,6 +95,53 @@ export function ActionItemMorePage() {
           />
         }
       >
+        {/* ---------- 팀/개인 탭 ---------- */}
+        <div
+          css={css`
+            display: flex;
+            align-items: flex-end;
+            gap: 1.2rem;
+            padding-top: 0.5rem;
+          `}
+        >
+          {(["팀", "개인"] as const).map((tab) => {
+            const isActive = tab === currentTab;
+            return (
+              <button
+                key={tab}
+                onClick={() => setCurrentTab(tab)}
+                css={css`
+                  display: flex;
+                  flex-direction: column;
+                  align-items: center;
+                  gap: 0.6rem;
+                  padding: 0 0.4rem;
+                  background: none;
+                  border: none;
+                  cursor: pointer;
+                `}
+              >
+                <Typography
+                  variant="subtitle18SemiBold"
+                  color={isActive ? "gray900" : "gray500"}
+                  css={css`
+                    font-weight: 600;
+                  `}
+                >
+                  {tab}
+                </Typography>
+                <div
+                  css={css`
+                    width: 100%;
+                    height: 2px;
+                    background-color: ${isActive ? DESIGN_TOKEN_COLOR.gray900 : "transparent"};
+                  `}
+                />
+              </button>
+            );
+          })}
+        </div>
+
         <div
           css={css`
             display: flex;
@@ -82,7 +150,7 @@ export function ActionItemMorePage() {
             padding: 1.5rem 0;
           `}
         >
-          {data?.teamActionItemList?.map((item) => {
+          {sortedItems.map((item) => {
             return (
               <ActionItemBox
                 key={item.retrospectId}
@@ -90,9 +158,11 @@ export function ActionItemMorePage() {
                 inProgressYn={item.status === status[0]}
                 title={item.retrospectTitle}
                 contents={item.actionItemList}
-                retrospectInfo={scaledData}
-                emitDataRefetch={refetch}
-                readonly={!isLeader}
+                retrospectInfo={isTeam ? scaledData : personalScaledData}
+                emitDataRefetch={isTeam ? refetch : refetchPersonal}
+                readonly={isTeam ? !isLeader : false}
+                isPersonal={!isTeam}
+                spaceId={spaceId}
               />
             );
           })}

--- a/apps/web/src/component/ActionItem/ActionItemBox.tsx
+++ b/apps/web/src/component/ActionItem/ActionItemBox.tsx
@@ -12,6 +12,7 @@ import { Spacing } from "@/component/common/Spacing";
 import { Typography } from "@/component/common/typography";
 import { PATHS } from "@layer/shared";
 import { useCreateActionItem } from "@/hooks/api/actionItem/useCreateActionItem.ts";
+import { useApiPostPersonalActionItem } from "@/hooks/api/actionItem/useApiPostPersonalActionItem.ts";
 import { useBottomSheet } from "@/hooks/useBottomSheet.ts";
 import { useInput } from "@/hooks/useInput.ts";
 import { useToast } from "@/hooks/useToast.ts";
@@ -37,6 +38,10 @@ type ActionItemBoxProps = {
     retrospectTitle: string;
     status: "PROCEEDING" | "DONE";
   }[];
+  /** 개인 실행목표 카드 여부. true면 추가/편집을 개인 엔드포인트로 처리한다. */
+  isPersonal?: boolean;
+  /** 개인 실행목표 생성에 필요한 스페이스 ID */
+  spaceId?: number;
 };
 export default function ActionItemBox({
   id,
@@ -47,6 +52,8 @@ export default function ActionItemBox({
   description,
   retrospectInfo = [],
   emitDataRefetch,
+  isPersonal = false,
+  spaceId,
 }: ActionItemBoxProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [isFading, setIsFading] = useState(false);
@@ -60,22 +67,26 @@ export default function ActionItemBox({
   const [retrospect, setRetrospect] = useState("");
   const [retrospectId, setRetrospectId] = useState(id);
   const { mutate, isPending } = useCreateActionItem();
+  const { mutate: createPersonal, isPending: isPersonalPending } = useApiPostPersonalActionItem();
   const { toast } = useToast();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsFading(true); // 사라지는 애니메이션 시작
-        setTimeout(() => setIsVisible(false), 300); // 300ms 후에 메뉴를 숨김
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+  const handleAddSubmit = () => {
+    const onSuccess = () => {
+      emitDataRefetch && emitDataRefetch();
+      setRetrospect("");
+      resetInput();
+      toast.success("성공적으로 실행목표가 추가되었어요!");
+      closeBottomSheet();
     };
-  }, []);
+    const onError = () => toast.error("예기치못한 에러가 발생했어요");
+
+    if (isPersonal && spaceId != null) {
+      createPersonal({ spaceId, retrospectId: retrospectId as number, content: actionItemValue }, { onSuccess, onError });
+    } else {
+      mutate({ retrospectId: retrospectId as number, content: actionItemValue }, { onSuccess, onError });
+    }
+  };
 
   const handleClick = () => {
     if (isVisible) {
@@ -91,6 +102,20 @@ export default function ActionItemBox({
     setRetrospect(retrospectTitle);
     setRetrospectId(retrospectId);
   };
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsFading(true); // 사라지는 애니메이션 시작
+        setTimeout(() => setIsVisible(false), 300); // 300ms 후에 메뉴를 숨김
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
 
   return (
     <Fragment>
@@ -117,27 +142,7 @@ export default function ActionItemBox({
                   padding-bottom: 0;
                 `}
               >
-                <Button
-                  isProgress={isPending}
-                  onClick={() => {
-                    mutate(
-                      { retrospectId: retrospectId as number, content: actionItemValue },
-                      {
-                        onSuccess: () => {
-                          emitDataRefetch && emitDataRefetch();
-                          setRetrospect("");
-                          resetInput();
-                          toast.success("성공적으로 실행목표가 추가되었어요!");
-                          closeBottomSheet();
-                        },
-                        onError: () => {
-                          toast.error("예기치못한 에러가 발생했어요");
-                        },
-                      },
-                    );
-                  }}
-                  disabled={!actionItemValue}
-                >
+                <Button isProgress={isPending || isPersonalPending} onClick={handleAddSubmit} disabled={!actionItemValue}>
                   추가하기
                 </Button>
               </ButtonProvider>
@@ -299,6 +304,8 @@ export default function ActionItemBox({
                     navigate(PATHS.goalsEdit(), {
                       state: {
                         data: selectedRetrospect,
+                        isPersonal,
+                        spaceId,
                       },
                     });
                   }}

--- a/apps/web/src/component/ActionItem/ActionItemBox.tsx
+++ b/apps/web/src/component/ActionItem/ActionItemBox.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ActionItemList } from "@/component/ActionItem/ActionItemList.tsx";
@@ -14,6 +14,7 @@ import { PATHS } from "@layer/shared";
 import { useCreateActionItem } from "@/hooks/api/actionItem/useCreateActionItem.ts";
 import { useApiPostPersonalActionItem } from "@/hooks/api/actionItem/useApiPostPersonalActionItem.ts";
 import { useBottomSheet } from "@/hooks/useBottomSheet.ts";
+import useClickOutside from "@/hooks/useClickOutside.ts";
 import { useInput } from "@/hooks/useInput.ts";
 import { useToast } from "@/hooks/useToast.ts";
 import { ANIMATION } from "@/style/common/animation.ts";
@@ -103,19 +104,10 @@ export default function ActionItemBox({
     setRetrospectId(retrospectId);
   };
 
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsFading(true); // 사라지는 애니메이션 시작
-        setTimeout(() => setIsVisible(false), 300); // 300ms 후에 메뉴를 숨김
-      }
-    }
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
+  useClickOutside(menuRef, () => {
+    setIsFading(true); // 사라지는 애니메이션 시작
+    setTimeout(() => setIsVisible(false), 300); // 300ms 후에 메뉴를 숨김
+  });
 
   return (
     <Fragment>

--- a/apps/web/src/component/ActionItem/ActionItemBox.tsx
+++ b/apps/web/src/component/ActionItem/ActionItemBox.tsx
@@ -66,7 +66,7 @@ export default function ActionItemBox({
   const { value: actionItemValue, handleInputChange, resetInput } = useInput();
   const [retrospect, setRetrospect] = useState("");
   const [retrospectId, setRetrospectId] = useState(id);
-  const { mutate, isPending } = useCreateActionItem();
+  const { mutate: createActionItem, isPending: isActionItemPending } = useCreateActionItem();
   const { mutate: createPersonal, isPending: isPersonalPending } = useApiPostPersonalActionItem();
   const { toast } = useToast();
   const navigate = useNavigate();
@@ -84,7 +84,7 @@ export default function ActionItemBox({
     if (isPersonal && spaceId != null) {
       createPersonal({ spaceId, retrospectId: retrospectId as number, content: actionItemValue }, { onSuccess, onError });
     } else {
-      mutate({ retrospectId: retrospectId as number, content: actionItemValue }, { onSuccess, onError });
+      createActionItem({ retrospectId: retrospectId as number, content: actionItemValue }, { onSuccess, onError });
     }
   };
 
@@ -142,7 +142,7 @@ export default function ActionItemBox({
                   padding-bottom: 0;
                 `}
               >
-                <Button isProgress={isPending || isPersonalPending} onClick={handleAddSubmit} disabled={!actionItemValue}>
+                <Button isProgress={isActionItemPending || isPersonalPending} onClick={handleAddSubmit} disabled={!actionItemValue}>
                   추가하기
                 </Button>
               </ButtonProvider>

--- a/apps/web/src/component/common/Tooltip/index.tsx
+++ b/apps/web/src/component/common/Tooltip/index.tsx
@@ -23,14 +23,18 @@ interface TooltipContextType {
   triggerRef: RefObject<HTMLElement>;
   contentRef: RefObject<HTMLDivElement>;
   placement?: TooltipPlacement;
+  align?: TooltipAlign;
   delay?: number;
 }
 
 type TooltipPlacement = "top" | "bottom" | "left" | "right";
+/** top/bottom placement에서 교차축(가로) 정렬. start면 트리거 왼쪽 모서리에 맞춰 오른쪽으로 펼쳐진다. */
+type TooltipAlign = "center" | "start" | "end";
 
 interface TooltipProps {
   children: ReactNode;
   placement?: TooltipPlacement;
+  align?: TooltipAlign;
   delay?: number;
   disabled?: boolean;
   /** 마운트 시 기본으로 열어둔다 (안내/announcement 용도) */
@@ -62,7 +66,7 @@ const useTooltip = () => {
   return context;
 };
 
-const Tooltip = ({ children, placement = "top", delay = 200, disabled = false, defaultOpen = false }: TooltipProps) => {
+const Tooltip = ({ children, placement = "top", align = "center", delay = 200, disabled = false, defaultOpen = false }: TooltipProps) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const triggerRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -92,6 +96,7 @@ const Tooltip = ({ children, placement = "top", delay = 200, disabled = false, d
     triggerRef,
     contentRef,
     placement,
+    align,
     delay,
   };
 
@@ -148,7 +153,8 @@ const TooltipTrigger = ({ children, asChild = true }: TooltipTriggerProps) => {
   );
 };
 
-const getArrowStyle = (placement: TooltipPlacement): CSSProperties => {
+// crossOffsetPx: top/bottom일 때 화살표를 콘텐츠 왼쪽 모서리 기준 몇 px 지점에 둘지. null이면 가운데(50%).
+const getArrowStyle = (placement: TooltipPlacement, crossOffsetPx: number | null = null): CSSProperties => {
   const base: CSSProperties = {
     position: "absolute",
     width: "0.8rem",
@@ -157,11 +163,13 @@ const getArrowStyle = (placement: TooltipPlacement): CSSProperties => {
     borderRadius: "0.1rem",
   };
 
+  const horizontal = crossOffsetPx != null ? `${crossOffsetPx}px` : "50%";
+
   switch (placement) {
     case "top":
-      return { ...base, bottom: "-0.3rem", left: "50%", transform: "translateX(-50%) rotate(45deg)" };
+      return { ...base, bottom: "-0.3rem", left: horizontal, transform: "translateX(-50%) rotate(45deg)" };
     case "bottom":
-      return { ...base, top: "-0.3rem", left: "50%", transform: "translateX(-50%) rotate(45deg)" };
+      return { ...base, top: "-0.3rem", left: horizontal, transform: "translateX(-50%) rotate(45deg)" };
     case "left":
       return { ...base, right: "-0.3rem", top: "50%", transform: "translateY(-50%) rotate(45deg)" };
     case "right":
@@ -171,7 +179,7 @@ const getArrowStyle = (placement: TooltipPlacement): CSSProperties => {
 };
 
 const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow = false }: TooltipContentProps) => {
-  const { isOpen, contentRef, triggerRef, placement = "top" } = useTooltip();
+  const { isOpen, contentRef, triggerRef, placement = "top", align = "center" } = useTooltip();
   const [style, setStyle] = useState<CSSProperties>({
     position: "absolute",
     top: 0,
@@ -180,8 +188,10 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
     visibility: "hidden",
     pointerEvents: "none",
   });
+  // top/bottom + align !== center 일 때 화살표를 트리거 위/아래 중앙으로 보정하기 위한 가로 오프셋(px)
+  const [arrowCross, setArrowCross] = useState<number | null>(null);
 
-  const computeStyle = useCallback((): CSSProperties => {
+  const computeStyle = useCallback((): { content: CSSProperties; arrowCross: number | null } => {
     const trigger = triggerRef.current;
     const style: CSSProperties = {
       position: "absolute",
@@ -209,20 +219,41 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
     if (!trigger) {
       style.opacity = 0;
       style.visibility = "hidden";
-      return style;
+      return { content: style, arrowCross: null };
     }
 
     const triggerRect = trigger.getBoundingClientRect();
+    // top/bottom 가로 정렬: start면 트리거 왼쪽 모서리에 맞추고, end면 오른쪽 모서리에 맞춘다.
+    let arrowCross: number | null = null;
+    const horizontalAlign = () => {
+      switch (align) {
+        case "start":
+          style.left = triggerRect.left + window.scrollX;
+          arrowCross = triggerRect.width / 2;
+          return "";
+        case "end":
+          style.left = triggerRect.right + window.scrollX;
+          arrowCross = null;
+          return "translateX(-100%)";
+        case "center":
+        default:
+          style.left = triggerRect.left + triggerRect.width / 2 + window.scrollX;
+          arrowCross = null;
+          return "translateX(-50%)";
+      }
+    };
     const baseTransform = (() => {
       switch (placement) {
-        case "top":
-          style.left = triggerRect.left + triggerRect.width / 2 + window.scrollX;
+        case "top": {
+          const x = horizontalAlign();
           style.top = triggerRect.top - sideOffset + window.scrollY;
-          return "translateX(-50%) translateY(-100%)";
-        case "bottom":
-          style.left = triggerRect.left + triggerRect.width / 2 + window.scrollX;
+          return `${x} translateY(-100%)`;
+        }
+        case "bottom": {
+          const x = horizontalAlign();
           style.top = triggerRect.bottom + sideOffset + window.scrollY;
-          return "translateX(-50%)";
+          return x;
+        }
         case "left":
           style.left = triggerRect.left - sideOffset + window.scrollX;
           style.top = triggerRect.top + triggerRect.height / 2 + window.scrollY;
@@ -238,13 +269,17 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
 
     style.transform = `${baseTransform} ${isOpen ? "scale(1)" : "scale(0.95)"}`;
 
-    return style;
-  }, [isOpen, placement, sideOffset, tag, triggerRef]);
+    return { content: style, arrowCross };
+  }, [isOpen, placement, align, sideOffset, tag, triggerRef]);
 
   // * portal + absolute 위치라 레이아웃이 바뀌면 좌표가 틀어진다.
   // * 스크롤/리사이즈 및 콘텐츠 크기 변화(ResizeObserver)에 맞춰 위치를 다시 계산한다.
   useLayoutEffect(() => {
-    const update = () => setStyle(computeStyle());
+    const update = () => {
+      const { content, arrowCross } = computeStyle();
+      setStyle(content);
+      setArrowCross(arrowCross);
+    };
     update();
 
     if (!isOpen) return;
@@ -268,7 +303,7 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
 
   return createPortal(
     <div ref={contentRef} id="tooltip-content" role="tooltip" className={className} style={style}>
-      {arrow && <span style={getArrowStyle(placement)} />}
+      {arrow && <span style={getArrowStyle(placement, arrowCross)} />}
       {tag != null && (
         <span
           style={{
@@ -281,6 +316,7 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
             borderRadius: "999px",
             border: "0.3rem solid rgba(108, 156, 250, 0.4)",
             backgroundColor: DESIGN_TOKEN_COLOR.blue600,
+            backgroundClip: "padding-box",
             color: "#FFFFFF",
             fontSize: "1rem",
             fontWeight: 600,

--- a/apps/web/src/component/common/Tooltip/index.tsx
+++ b/apps/web/src/component/common/Tooltip/index.tsx
@@ -65,6 +65,25 @@ interface TooltipContentProps {
   arrow?: boolean;
 }
 
+// localStorage는 프라이빗 모드/쿠키 차단 정책에서 접근 자체가 throw할 수 있어 안전하게 감싼다.
+const safeGetSeen = (storageKey?: string): boolean => {
+  if (!storageKey || typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(storageKey) === "true";
+  } catch {
+    return false;
+  }
+};
+
+const safeSetSeen = (storageKey?: string) => {
+  if (!storageKey || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey, "true");
+  } catch {
+    // 저장 실패 시 무시한다 (안내 툴팁이 다음에 다시 떠도 무방).
+  }
+};
+
 const TooltipContext = createContext<TooltipContextType | null>(null);
 
 const useTooltip = () => {
@@ -86,7 +105,7 @@ const Tooltip = ({
   storageKey,
 }: TooltipProps) => {
   // storageKey가 있으면 "이미 본 적 있는지"를 localStorage에서 읽어 자동 노출 여부를 결정한다.
-  const hasSeen = storageKey != null && typeof window !== "undefined" && window.localStorage.getItem(storageKey) === "true";
+  const hasSeen = safeGetSeen(storageKey);
   const [isOpen, setIsOpen] = useState(defaultOpen && !hasSeen);
   const triggerRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -123,8 +142,8 @@ const Tooltip = ({
 
   // defaultOpen 안내 툴팁이 최초로 노출되면 기록하여 이후에는 자동으로 뜨지 않게 한다.
   useEffect(() => {
-    if (defaultOpen && storageKey && typeof window !== "undefined" && !hasSeen) {
-      window.localStorage.setItem(storageKey, "true");
+    if (defaultOpen && !hasSeen) {
+      safeSetSeen(storageKey);
     }
   }, [defaultOpen, storageKey, hasSeen]);
 

--- a/apps/web/src/component/common/Tooltip/index.tsx
+++ b/apps/web/src/component/common/Tooltip/index.tsx
@@ -11,6 +11,7 @@ import {
   isValidElement,
   cloneElement,
   useEffect,
+  useLayoutEffect,
   ReactElement,
 } from "react";
 import { createPortal } from "react-dom";
@@ -32,6 +33,8 @@ interface TooltipProps {
   placement?: TooltipPlacement;
   delay?: number;
   disabled?: boolean;
+  /** 마운트 시 기본으로 열어둔다 (안내/announcement 용도) */
+  defaultOpen?: boolean;
 }
 
 interface TooltipTriggerProps {
@@ -43,6 +46,10 @@ interface TooltipContentProps {
   children: ReactNode;
   className?: string;
   sideOffset?: number;
+  /** 본문 앞에 붙는 칩(예: "NEW"). 문자열/노드 모두 가능 */
+  tag?: ReactNode;
+  /** placement 방향을 가리키는 꼬리(화살표) 노출 여부 */
+  arrow?: boolean;
 }
 
 const TooltipContext = createContext<TooltipContextType | null>(null);
@@ -55,8 +62,8 @@ const useTooltip = () => {
   return context;
 };
 
-const Tooltip = ({ children, placement = "top", delay = 200, disabled = false }: TooltipProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+const Tooltip = ({ children, placement = "top", delay = 200, disabled = false, defaultOpen = false }: TooltipProps) => {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
   const triggerRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef<number | null>(null);
@@ -141,23 +148,47 @@ const TooltipTrigger = ({ children, asChild = true }: TooltipTriggerProps) => {
   );
 };
 
-const TooltipContent = ({ children, className = "", sideOffset = 16 }: TooltipContentProps) => {
-  const { isOpen, contentRef, triggerRef, placement } = useTooltip();
+const getArrowStyle = (placement: TooltipPlacement): CSSProperties => {
+  const base: CSSProperties = {
+    position: "absolute",
+    width: "0.8rem",
+    height: "0.8rem",
+    backgroundColor: DESIGN_TOKEN_COLOR.gray900,
+    borderRadius: "0.1rem",
+  };
 
-  if (!triggerRef.current) {
-    return null;
+  switch (placement) {
+    case "top":
+      return { ...base, bottom: "-0.3rem", left: "50%", transform: "translateX(-50%) rotate(45deg)" };
+    case "bottom":
+      return { ...base, top: "-0.3rem", left: "50%", transform: "translateX(-50%) rotate(45deg)" };
+    case "left":
+      return { ...base, right: "-0.3rem", top: "50%", transform: "translateY(-50%) rotate(45deg)" };
+    case "right":
+    default:
+      return { ...base, left: "-0.3rem", top: "50%", transform: "translateY(-50%) rotate(45deg)" };
   }
+};
 
-  const getTooltipStyle = (): CSSProperties => {
-    if (!triggerRef.current) return {};
+const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow = false }: TooltipContentProps) => {
+  const { isOpen, contentRef, triggerRef, placement = "top" } = useTooltip();
+  const [style, setStyle] = useState<CSSProperties>({
+    position: "absolute",
+    top: 0,
+    left: 0,
+    opacity: 0,
+    visibility: "hidden",
+    pointerEvents: "none",
+  });
 
-    const triggerRect = triggerRef.current.getBoundingClientRect();
+  const computeStyle = useCallback((): CSSProperties => {
+    const trigger = triggerRef.current;
     const style: CSSProperties = {
       position: "absolute",
       zIndex: 9999,
       backgroundColor: DESIGN_TOKEN_COLOR.gray900,
       color: "#FFFFFF",
-      padding: "0.8rem 1.2rem",
+      padding: "1rem 1.4rem",
       borderRadius: "0.8rem",
       whiteSpace: "nowrap",
       border: "none",
@@ -169,6 +200,19 @@ const TooltipContent = ({ children, className = "", sideOffset = 16 }: TooltipCo
       transformOrigin: "center",
     };
 
+    if (tag != null) {
+      style.display = "inline-flex";
+      style.alignItems = "center";
+      style.gap = "1rem";
+    }
+
+    if (!trigger) {
+      style.opacity = 0;
+      style.visibility = "hidden";
+      return style;
+    }
+
+    const triggerRect = trigger.getBoundingClientRect();
     const baseTransform = (() => {
       switch (placement) {
         case "top":
@@ -192,15 +236,62 @@ const TooltipContent = ({ children, className = "", sideOffset = 16 }: TooltipCo
       }
     })();
 
-    const scaleTransform = isOpen ? "scale(1)" : "scale(0.95)";
-    style.transform = `${baseTransform} ${scaleTransform}`;
+    style.transform = `${baseTransform} ${isOpen ? "scale(1)" : "scale(0.95)"}`;
 
     return style;
-  };
+  }, [isOpen, placement, sideOffset, tag, triggerRef]);
+
+  // * portal + absolute 위치라 레이아웃이 바뀌면 좌표가 틀어진다.
+  // * 스크롤/리사이즈 및 콘텐츠 크기 변화(ResizeObserver)에 맞춰 위치를 다시 계산한다.
+  useLayoutEffect(() => {
+    const update = () => setStyle(computeStyle());
+    update();
+
+    if (!isOpen) return;
+
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(update);
+      if (triggerRef.current) resizeObserver.observe(triggerRef.current);
+      resizeObserver.observe(document.body);
+    }
+
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+      resizeObserver?.disconnect();
+    };
+  }, [isOpen, computeStyle, triggerRef]);
 
   return createPortal(
-    <div ref={contentRef} id="tooltip-content" role="tooltip" className={className} style={getTooltipStyle()}>
-      {children}
+    <div ref={contentRef} id="tooltip-content" role="tooltip" className={className} style={style}>
+      {arrow && <span style={getArrowStyle(placement)} />}
+      {tag != null && (
+        <span
+          style={{
+            position: "relative",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+            padding: "0.3rem 0.6rem",
+            borderRadius: "999px",
+            border: "0.3rem solid rgba(108, 156, 250, 0.4)",
+            backgroundColor: DESIGN_TOKEN_COLOR.blue600,
+            color: "#FFFFFF",
+            fontSize: "1rem",
+            fontWeight: 600,
+            lineHeight: "normal",
+            letterSpacing: "-0.01rem",
+          }}
+        >
+          {tag}
+        </span>
+      )}
+      <span style={{ position: "relative", fontSize: "1.2rem", fontWeight: 600, lineHeight: 1.4 }}>{children}</span>
     </div>,
     document.body,
   );

--- a/apps/web/src/component/common/Tooltip/index.tsx
+++ b/apps/web/src/component/common/Tooltip/index.tsx
@@ -24,21 +24,30 @@ interface TooltipContextType {
   contentRef: RefObject<HTMLDivElement>;
   placement?: TooltipPlacement;
   align?: TooltipAlign;
+  theme?: TooltipTheme;
   delay?: number;
 }
 
 type TooltipPlacement = "top" | "bottom" | "left" | "right";
 /** top/bottom placement에서 교차축(가로) 정렬. start면 트리거 왼쪽 모서리에 맞춰 오른쪽으로 펼쳐진다. */
 type TooltipAlign = "center" | "start" | "end";
+/** dark: 회색(gray900) 배경 + 파란 NEW 칩 / blue: 파란(blue600) 배경 + 흰색 NEW 칩 */
+type TooltipTheme = "dark" | "blue";
 
 interface TooltipProps {
   children: ReactNode;
   placement?: TooltipPlacement;
   align?: TooltipAlign;
+  theme?: TooltipTheme;
   delay?: number;
   disabled?: boolean;
   /** 마운트 시 기본으로 열어둔다 (안내/announcement 용도) */
   defaultOpen?: boolean;
+  /**
+   * defaultOpen 안내 툴팁을 "한 번만" 노출하기 위한 localStorage 키.
+   * 지정하면 최초 1회 표시 후 기록되어 이후에는 자동으로 열리지 않는다.
+   */
+  storageKey?: string;
 }
 
 interface TooltipTriggerProps {
@@ -66,8 +75,19 @@ const useTooltip = () => {
   return context;
 };
 
-const Tooltip = ({ children, placement = "top", align = "center", delay = 200, disabled = false, defaultOpen = false }: TooltipProps) => {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
+const Tooltip = ({
+  children,
+  placement = "top",
+  align = "center",
+  theme = "dark",
+  delay = 200,
+  disabled = false,
+  defaultOpen = false,
+  storageKey,
+}: TooltipProps) => {
+  // storageKey가 있으면 "이미 본 적 있는지"를 localStorage에서 읽어 자동 노출 여부를 결정한다.
+  const hasSeen = storageKey != null && typeof window !== "undefined" && window.localStorage.getItem(storageKey) === "true";
+  const [isOpen, setIsOpen] = useState(defaultOpen && !hasSeen);
   const triggerRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const timeoutRef = useRef<number | null>(null);
@@ -97,8 +117,16 @@ const Tooltip = ({ children, placement = "top", align = "center", delay = 200, d
     contentRef,
     placement,
     align,
+    theme,
     delay,
   };
+
+  // defaultOpen 안내 툴팁이 최초로 노출되면 기록하여 이후에는 자동으로 뜨지 않게 한다.
+  useEffect(() => {
+    if (defaultOpen && storageKey && typeof window !== "undefined" && !hasSeen) {
+      window.localStorage.setItem(storageKey, "true");
+    }
+  }, [defaultOpen, storageKey, hasSeen]);
 
   useEffect(() => {
     return () => {
@@ -154,12 +182,12 @@ const TooltipTrigger = ({ children, asChild = true }: TooltipTriggerProps) => {
 };
 
 // crossOffsetPx: top/bottom일 때 화살표를 콘텐츠 왼쪽 모서리 기준 몇 px 지점에 둘지. null이면 가운데(50%).
-const getArrowStyle = (placement: TooltipPlacement, crossOffsetPx: number | null = null): CSSProperties => {
+const getArrowStyle = (placement: TooltipPlacement, crossOffsetPx: number | null = null, theme: TooltipTheme = "dark"): CSSProperties => {
   const base: CSSProperties = {
     position: "absolute",
     width: "0.8rem",
     height: "0.8rem",
-    backgroundColor: DESIGN_TOKEN_COLOR.gray900,
+    backgroundColor: theme === "blue" ? DESIGN_TOKEN_COLOR.blue600 : DESIGN_TOKEN_COLOR.gray900,
     borderRadius: "0.1rem",
   };
 
@@ -179,7 +207,7 @@ const getArrowStyle = (placement: TooltipPlacement, crossOffsetPx: number | null
 };
 
 const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow = false }: TooltipContentProps) => {
-  const { isOpen, contentRef, triggerRef, placement = "top", align = "center" } = useTooltip();
+  const { isOpen, contentRef, triggerRef, placement = "top", align = "center", theme = "dark" } = useTooltip();
   const [style, setStyle] = useState<CSSProperties>({
     position: "absolute",
     top: 0,
@@ -196,7 +224,7 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
     const style: CSSProperties = {
       position: "absolute",
       zIndex: 9999,
-      backgroundColor: DESIGN_TOKEN_COLOR.gray900,
+      backgroundColor: theme === "blue" ? DESIGN_TOKEN_COLOR.blue600 : DESIGN_TOKEN_COLOR.gray900,
       color: "#FFFFFF",
       padding: "1rem 1.4rem",
       borderRadius: "0.8rem",
@@ -270,7 +298,7 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
     style.transform = `${baseTransform} ${isOpen ? "scale(1)" : "scale(0.95)"}`;
 
     return { content: style, arrowCross };
-  }, [isOpen, placement, align, sideOffset, tag, triggerRef]);
+  }, [isOpen, placement, align, theme, sideOffset, tag, triggerRef]);
 
   // * portal + absolute 위치라 레이아웃이 바뀌면 좌표가 틀어진다.
   // * 스크롤/리사이즈 및 콘텐츠 크기 변화(ResizeObserver)에 맞춰 위치를 다시 계산한다.
@@ -303,7 +331,7 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
 
   return createPortal(
     <div ref={contentRef} id="tooltip-content" role="tooltip" className={className} style={style}>
-      {arrow && <span style={getArrowStyle(placement, arrowCross)} />}
+      {arrow && <span style={getArrowStyle(placement, arrowCross, theme)} />}
       {tag != null && (
         <span
           style={{
@@ -314,10 +342,10 @@ const TooltipContent = ({ children, className = "", sideOffset = 16, tag, arrow 
             flexShrink: 0,
             padding: "0.3rem 0.6rem",
             borderRadius: "999px",
-            border: "0.3rem solid rgba(108, 156, 250, 0.4)",
-            backgroundColor: DESIGN_TOKEN_COLOR.blue600,
+            border: theme === "blue" ? "0.3rem solid rgba(255, 255, 255, 0.2)" : "0.3rem solid rgba(108, 156, 250, 0.4)",
+            backgroundColor: theme === "blue" ? "#FFFFFF" : DESIGN_TOKEN_COLOR.blue600,
             backgroundClip: "padding-box",
-            color: "#FFFFFF",
+            color: theme === "blue" ? DESIGN_TOKEN_COLOR.blue600 : "#FFFFFF",
             fontSize: "1rem",
             fontWeight: 600,
             lineHeight: "normal",

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
@@ -9,6 +9,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApiOptionsGetRetrospects } from "@/hooks/api/retrospect/useApiOptionsGetRetrospects";
 import { Retrospect } from "@/types/retrospect";
 import { useApiPostActionItem } from "@/hooks/api/actionItem/useApiPostActionItem";
+import { useApiPostPersonalActionItem } from "@/hooks/api/actionItem/useApiPostPersonalActionItem";
 import { ExtendedActionItemType } from "@/types/actionItem";
 import { useToast } from "@/hooks/useToast";
 import { trackEvent } from "@/lib/google-analytics";
@@ -18,10 +19,13 @@ type ActionItemAddSectionProps = {
   spaceId: number;
   retrospectId: number;
   onClose: () => void;
+  variant?: "team" | "personal";
 };
 
-export default function ActionItemAddSection({ spaceId, retrospectId, onClose }: ActionItemAddSectionProps) {
+export default function ActionItemAddSection({ spaceId, retrospectId, onClose, variant = "team" }: ActionItemAddSectionProps) {
   const queryClient = useQueryClient();
+  const isPersonal = variant === "personal";
+  const actionItemQueryKey = isPersonal ? ["getPersonalActionItemListBySpace", spaceId] : ["getTeamActionItemList", spaceId];
 
   const { toast } = useToast();
   const { data: retrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));
@@ -34,7 +38,9 @@ export default function ActionItemAddSection({ spaceId, retrospectId, onClose }:
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const [isClosing, setIsClosing] = useState<boolean>(false);
 
-  const { mutate: createActionItem, isPending: isPendingCreateActionItem } = useApiPostActionItem();
+  const { mutate: createTeamActionItem, isPending: isPendingCreateTeamActionItem } = useApiPostActionItem();
+  const { mutate: createPersonalActionItem, isPending: isPendingCreatePersonalActionItem } = useApiPostPersonalActionItem();
+  const isPendingCreateActionItem = isPendingCreateTeamActionItem || isPendingCreatePersonalActionItem;
 
   const handleRetrospectSelect = (option: Retrospect) => {
     setSelectedRetrospect(option);
@@ -73,48 +79,49 @@ export default function ActionItemAddSection({ spaceId, retrospectId, onClose }:
   };
 
   const handleComplete = () => {
-    if (selectedRetrospect) {
-      createActionItem(
-        {
-          retrospectId: selectedRetrospect.retrospectId,
-          content,
-        },
-        {
-          onSuccess: async (response) => {
-            const previousData: { spaceId: number; spaceName: string; teamActionItemList: ExtendedActionItemType[] } | undefined =
-              await queryClient.getQueryData(["getTeamActionItemList", spaceId]);
+    if (!selectedRetrospect) return;
 
-            if (previousData) {
-              const newActionItem = {
-                actionItemId: response.data.actionItemId,
-                content: content,
+    const onSuccess = async (response: { data: { actionItemId: number } }) => {
+      const listField = isPersonal ? "personalActionItemList" : "teamActionItemList";
+      const previousData: { spaceId: number; spaceName: string; [key: string]: unknown } | undefined =
+        await queryClient.getQueryData(actionItemQueryKey);
+
+      const previousList = previousData?.[listField] as ExtendedActionItemType[] | undefined;
+
+      if (previousData && previousList) {
+        const newActionItem = {
+          actionItemId: response.data.actionItemId,
+          content: content,
+        };
+
+        const updatedData = {
+          ...previousData,
+          [listField]: previousList.map((retrospect) => {
+            if (retrospect.retrospectId === selectedRetrospect.retrospectId) {
+              return {
+                ...retrospect,
+                actionItemList: [...retrospect.actionItemList, newActionItem],
               };
-
-              const updatedData = {
-                ...previousData,
-                teamActionItemList: previousData.teamActionItemList.map((retrospect) => {
-                  if (retrospect.retrospectId === selectedRetrospect.retrospectId) {
-                    return {
-                      ...retrospect,
-                      actionItemList: [...retrospect.actionItemList, newActionItem],
-                    };
-                  }
-                  return retrospect;
-                }),
-              };
-
-              queryClient.setQueryData(["getTeamActionItemList", spaceId], updatedData);
-
-              toast.success("실행목표 추가가 완료되었어요!");
-            } else {
-              queryClient.invalidateQueries({ queryKey: ["getTeamActionItemList", spaceId] });
             }
+            return retrospect;
+          }),
+        };
 
-            trackEvent(GA_EVENTS.ACTION_ITEM.ADD_DONE);
-            onClose();
-          },
-        },
-      );
+        queryClient.setQueryData(actionItemQueryKey, updatedData);
+
+        toast.success("실행목표 추가가 완료되었어요!");
+      } else {
+        queryClient.invalidateQueries({ queryKey: actionItemQueryKey });
+      }
+
+      trackEvent(GA_EVENTS.ACTION_ITEM.ADD_DONE);
+      onClose();
+    };
+
+    if (isPersonal) {
+      createPersonalActionItem({ spaceId, retrospectId: selectedRetrospect.retrospectId, content }, { onSuccess });
+    } else {
+      createTeamActionItem({ retrospectId: selectedRetrospect.retrospectId, content }, { onSuccess });
     }
   };
 

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
@@ -180,31 +180,37 @@ export default function ActionItemCard({ spaceId, retrospectId, title, deadline,
           `}
         >
           {todoList.length === 0 ? (
-            <button
-              css={css`
-                display: flex;
-                align-items: center;
-                gap: 0.8rem;
-              `}
-              onClick={handleAddActionItem}
-            >
-              <div
+            canManage ? (
+              <button
                 css={css`
-                  width: 1.2rem;
-                  height: 1.2rem;
-                  background-color: ${DESIGN_TOKEN_COLOR.gray100};
                   display: flex;
                   align-items: center;
-                  justify-content: center;
-                  border-radius: 0.4rem;
+                  gap: 0.8rem;
                 `}
+                onClick={handleAddActionItem}
               >
-                <Icon icon="ic_plus" size={0.8} color={DESIGN_TOKEN_COLOR.gray500} />
-              </div>
+                <div
+                  css={css`
+                    width: 1.2rem;
+                    height: 1.2rem;
+                    background-color: ${DESIGN_TOKEN_COLOR.gray100};
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    border-radius: 0.4rem;
+                  `}
+                >
+                  <Icon icon="ic_plus" size={0.8} color={DESIGN_TOKEN_COLOR.gray500} />
+                </div>
+                <Typography variant="body14Medium" color="gray500">
+                  실행목표 추가하기
+                </Typography>
+              </button>
+            ) : (
               <Typography variant="body14Medium" color="gray500">
-                실행목표 추가하기
+                등록된 실행목표가 없어요
               </Typography>
-            </button>
+            )
           ) : (
             todoList.map((todo) => (
               <div

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemCard.tsx
@@ -10,32 +10,38 @@ import { currentSpaceState } from "@/store/space/spaceAtom";
 import { isSpaceLeader } from "@/utils/userUtil";
 import { trackEvent } from "@/lib/google-analytics";
 import { GA_EVENTS } from "@/lib/google-analytics/events";
+import { formatDateToString } from "@/utils/formatDate";
 
 type ActionItemCardProps = {
   spaceId: number;
   retrospectId: number;
   title: string;
+  deadline?: string;
   todoList: {
     actionItemId: number;
     content: string;
   }[];
   status: "PROCEEDING" | "DONE" | string;
+  variant?: "team" | "personal";
 };
 
 const STATUS_CONFIG = {
   PROCEEDING: {
     backgroundColor: DESIGN_TOKEN_COLOR.blue100,
     textColor: "blue600" as const,
-    label: "진행 중",
+    borderColor: "transparent",
+    label: "실행 중",
   },
   DONE: {
-    backgroundColor: DESIGN_TOKEN_COLOR.green100,
-    textColor: "green700" as const,
+    backgroundColor: "rgba(33, 35, 41, 0.1)",
+    textColor: "gray900" as const,
+    borderColor: DESIGN_TOKEN_COLOR.gray500,
     label: "완료",
   },
   DEFAULT: {
     backgroundColor: DESIGN_TOKEN_COLOR.gray100,
     textColor: "gray600" as const,
+    borderColor: "transparent",
     label: "미정",
   },
 };
@@ -46,19 +52,21 @@ const getStatusConfig = (status: string) => {
   return STATUS_CONFIG.DEFAULT;
 };
 
-export default function ActionItemCard({ spaceId, retrospectId, title, todoList, status }: ActionItemCardProps) {
+export default function ActionItemCard({ spaceId, retrospectId, title, deadline, todoList, status, variant = "team" }: ActionItemCardProps) {
   const currentSpace = useAtomValue(currentSpaceState);
   const { open: openDesktopModal, close } = useDesktopBasicModal();
 
   const { leader } = currentSpace || {};
   const isLeader = isSpaceLeader(leader?.id);
+  // * 개인 실행목표는 본인 항목이므로 리더 여부와 무관하게 본인이 관리할 수 있다.
+  const canManage = variant === "personal" ? true : isLeader;
 
   const statusStyle = getStatusConfig(status);
 
   const handleAddActionItem = () => {
     openDesktopModal({
       title: "실행목표 추가",
-      contents: <ActionItemAddSection spaceId={spaceId} retrospectId={retrospectId} onClose={close} />,
+      contents: <ActionItemAddSection spaceId={spaceId} retrospectId={retrospectId} onClose={close} variant={variant} />,
       onClose: close,
       options: {
         enableFooter: false,
@@ -96,6 +104,7 @@ export default function ActionItemCard({ spaceId, retrospectId, title, todoList,
             height: 2.2rem;
             padding: 0.3rem 0.6rem;
             background-color: ${statusStyle.backgroundColor};
+            border: 1px solid ${statusStyle.borderColor};
             border-radius: 0.4rem;
           `}
         >
@@ -103,7 +112,7 @@ export default function ActionItemCard({ spaceId, retrospectId, title, todoList,
             {statusStyle.label}
           </Typography>
         </div>
-        {isLeader && (
+        {canManage && (
           <div
             css={css`
               display: flex;
@@ -127,7 +136,7 @@ export default function ActionItemCard({ spaceId, retrospectId, title, todoList,
                 `}
               />
             </button>
-            <ActionItemManageToggleMenu spaceId={spaceId} retrospectId={retrospectId} todoList={todoList} />
+            <ActionItemManageToggleMenu spaceId={spaceId} retrospectId={retrospectId} todoList={todoList} variant={variant} />
           </div>
         )}
       </div>
@@ -136,6 +145,19 @@ export default function ActionItemCard({ spaceId, retrospectId, title, todoList,
       <Typography variant="body15Bold" color="gray900">
         {title}
       </Typography>
+
+      {/* ---------- 날짜 ---------- */}
+      {deadline && (
+        <Typography
+          variant="body14Medium"
+          color="gray500"
+          css={css`
+            margin-top: 0.4rem;
+          `}
+        >
+          {formatDateToString(new Date(deadline), ".")}
+        </Typography>
+      )}
 
       {/* ---------- 할 일 목록 ----------*/}
       <div

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemManageToggleMenu.tsx
@@ -20,6 +20,7 @@ type ActionItemManageToggleMenuProps = {
   }[];
   iconSize?: number;
   iconColor?: keyof typeof DESIGN_TOKEN_COLOR;
+  variant?: "team" | "personal";
 };
 
 export default function ActionItemManageToggleMenu({
@@ -28,6 +29,7 @@ export default function ActionItemManageToggleMenu({
   todoList,
   iconSize = 2,
   iconColor = "gray500",
+  variant = "team",
 }: ActionItemManageToggleMenuProps) {
   const { isShowMenu, showMenu, hideMenu } = useToggleMenu();
   const { open: openDesktopModal, close } = useDesktopBasicModal();
@@ -56,6 +58,7 @@ export default function ActionItemManageToggleMenu({
             content: item.content,
           }))}
           onClose={close}
+          variant={variant}
         />
       ),
       onClose: close,

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItems.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItems.tsx
@@ -10,11 +10,11 @@ import ActionItemsList from "./ActionItemsList";
 import ActionItemsTooltip from "./ActionItemsTooltip";
 
 interface ActionItemsProps {
-  currentTab: "진행 중" | "지난";
+  currentTab: "팀" | "개인";
 }
 
 export default function ActionItems() {
-  const [currentTab, setCurrentTab] = useState<ActionItemsProps["currentTab"]>("진행 중");
+  const [currentTab, setCurrentTab] = useState<ActionItemsProps["currentTab"]>("팀");
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
   const handleCurrentTabClick = (tab: ActionItemsProps["currentTab"]) => {

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
@@ -7,11 +7,13 @@ import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { css } from "@emotion/react";
 import { usePatchActionItemList } from "@/hooks/api/actionItem/usePatchActionItemList";
+import { usePatchPersonalActionItemList } from "@/hooks/api/actionItem/usePatchPersonalActionItemList";
 import { Button, ButtonProvider } from "@/component/common/button";
 import { useQueryClient } from "@tanstack/react-query";
 import { ExtendedActionItemType } from "@/types/actionItem";
 import { useModal } from "@/hooks/useModal";
 import { useDeleteActionItemList } from "@/hooks/api/actionItem/useDeleteActionItemList";
+import { useDeletePersonalActionItemList } from "@/hooks/api/actionItem/useDeletePersonalActionItemList";
 import { useToast } from "@/hooks/useToast";
 import { trackEvent } from "@/lib/google-analytics";
 import { GA_EVENTS } from "@/lib/google-analytics/events";
@@ -27,12 +29,16 @@ type ActionItemsEditSectionProps = {
   retrospectId: number;
   todoList: ActionItem[];
   onClose: () => void;
+  variant?: "team" | "personal";
 };
 
 const INIT_TEMP_ID = -1;
 
-export default function ActionItemsEditSection({ spaceId, retrospectId, todoList, onClose }: ActionItemsEditSectionProps) {
+export default function ActionItemsEditSection({ spaceId, retrospectId, todoList, onClose, variant = "team" }: ActionItemsEditSectionProps) {
   const queryClient = useQueryClient();
+  const isPersonal = variant === "personal";
+  const actionItemQueryKey = isPersonal ? ["getPersonalActionItemListBySpace", spaceId] : ["getTeamActionItemList", spaceId];
+  const listField = isPersonal ? "personalActionItemList" : "teamActionItemList";
 
   const { toast } = useToast();
   const { open, close: closeModal } = useModal();
@@ -40,8 +46,12 @@ export default function ActionItemsEditSection({ spaceId, retrospectId, todoList
   const [actionItems, setActionItems] = useState<ActionItem[]>(todoList);
   const [nextTempId, setNextTempId] = useState(INIT_TEMP_ID);
 
-  const { mutate: patchActionItem, isPending: isPendingPatchActionItem } = usePatchActionItemList();
-  const { mutate: deleteActionItem } = useDeleteActionItemList();
+  const { mutate: patchTeamActionItem, isPending: isPendingPatchTeamActionItem } = usePatchActionItemList();
+  const { mutate: patchPersonalActionItem, isPending: isPendingPatchPersonalActionItem } = usePatchPersonalActionItemList();
+  const { mutate: deleteTeamActionItem } = useDeleteActionItemList();
+  const { mutate: deletePersonalActionItem } = useDeletePersonalActionItemList();
+
+  const isPendingPatchActionItem = isPendingPatchTeamActionItem || isPendingPatchPersonalActionItem;
 
   /**
    * 리스트의 아이템 순서 변경
@@ -82,19 +92,22 @@ export default function ActionItemsEditSection({ spaceId, retrospectId, todoList
       contents: "정말 삭제하시겠어요?",
       onClose: closeModal,
       onConfirm: () => {
+        const deleteActionItem = isPersonal ? deletePersonalActionItem : deleteTeamActionItem;
         deleteActionItem(
           { actionItemId: Number(id) },
           {
             onSuccess: async () => {
               setActionItems(actionItems.filter((item) => item.actionItemId !== id));
 
-              const previousData: { spaceId: string; spaceName: string; teamActionItemList: ExtendedActionItemType[] } | undefined =
-                await queryClient.getQueryData(["getTeamActionItemList", spaceId]);
+              const previousData: { spaceId: string; spaceName: string; [key: string]: unknown } | undefined =
+                await queryClient.getQueryData(actionItemQueryKey);
 
-              if (previousData) {
+              const previousList = previousData?.[listField] as ExtendedActionItemType[] | undefined;
+
+              if (previousData && previousList) {
                 const updatedData = {
                   ...previousData,
-                  teamActionItemList: previousData.teamActionItemList.map((retrospect) => {
+                  [listField]: previousList.map((retrospect) => {
                     if (retrospect.retrospectId === retrospectId) {
                       return {
                         ...retrospect,
@@ -105,7 +118,7 @@ export default function ActionItemsEditSection({ spaceId, retrospectId, todoList
                   }),
                 };
 
-                queryClient.setQueryData(["getTeamActionItemList", spaceId], updatedData);
+                queryClient.setQueryData(actionItemQueryKey, updatedData);
               }
 
               toast.success("실행목표 삭제가 완료되었어요!");
@@ -163,19 +176,15 @@ export default function ActionItemsEditSection({ spaceId, retrospectId, todoList
         });
 
       await new Promise((resolve, reject) => {
-        patchActionItem(
-          {
-            retrospectId,
-            actionItems: requestItems,
-          },
-          {
-            onSuccess: resolve,
-            onError: reject,
-          },
-        );
+        const callbacks = { onSuccess: resolve, onError: reject };
+        if (isPersonal) {
+          patchPersonalActionItem({ spaceId, retrospectId, actionItems: requestItems }, callbacks);
+        } else {
+          patchTeamActionItem({ retrospectId, actionItems: requestItems }, callbacks);
+        }
       });
 
-      await queryClient.invalidateQueries({ queryKey: ["getTeamActionItemList", spaceId] });
+      await queryClient.invalidateQueries({ queryKey: actionItemQueryKey });
       toast.success("실행목표 편집이 완료되었어요!");
       trackEvent(GA_EVENTS.ACTION_ITEM.EDIT_DONE);
       onClose();

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { css } from "@emotion/react";
 import { Typography } from "@/component/common/typography";
 import { Icon } from "@/component/common/Icon";
+import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { useApiOptionsGetTeamActionItemList } from "@/hooks/api/actionItem/useApiOptionsGetTeamActionItemList";
 import { useApiOptionsGetPersonalActionItemListBySpace } from "@/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace";
@@ -25,15 +26,17 @@ export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
   const spaceId = Number(params.spaceId);
   const isTeam = currentTab === "팀";
 
-  const { data: teamData } = useQuery({
+  const { data: teamData, isLoading: isTeamLoading } = useQuery({
     ...useApiOptionsGetTeamActionItemList(spaceId),
     enabled: !!spaceId && isTeam,
   });
-  const { data: personalData } = useQuery({
+  const { data: personalData, isLoading: isPersonalLoading } = useQuery({
     ...useApiOptionsGetPersonalActionItemListBySpace(spaceId),
     enabled: !!spaceId && !isTeam,
   });
 
+  // * 현재 탭의 쿼리만 로딩으로 본다. (비활성 쿼리는 isLoading=false)
+  const isLoading = isTeam ? isTeamLoading : isPersonalLoading;
   const rawActionItems = isTeam ? teamData?.teamActionItemList : personalData?.personalActionItemList;
   const currentActionItems = rawActionItems ? sortByStatus(rawActionItems) : undefined;
 
@@ -46,7 +49,17 @@ export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
         flex-direction: column;
       `}
     >
-      {currentActionItems?.length === 0 ? (
+      {isLoading ? (
+        <div
+          css={css`
+            position: relative;
+            flex: 1;
+            min-height: 22.8rem;
+          `}
+        >
+          <LoadingSpinner />
+        </div>
+      ) : currentActionItems?.length === 0 ? (
         <div
           css={css`
             display: flex;

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsList.tsx
@@ -6,23 +6,36 @@ import { Typography } from "@/component/common/typography";
 import { Icon } from "@/component/common/Icon";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { useApiOptionsGetTeamActionItemList } from "@/hooks/api/actionItem/useApiOptionsGetTeamActionItemList";
+import { useApiOptionsGetPersonalActionItemListBySpace } from "@/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace";
+import { ExtendedActionItemType } from "@/types/actionItem";
 
 import ActionItemCard from "./ActionItemCard";
 
 type ActionItemsListProps = {
-  currentTab: "진행 중" | "지난";
+  currentTab: "팀" | "개인";
 };
+
+// * 진행 중(PROCEEDING) → 지난(DONE) 순으로 정렬한다. (status가 같으면 API 반환 순서 유지)
+const STATUS_ORDER: Record<string, number> = { PROCEEDING: 0, DONE: 1 };
+const sortByStatus = (list: ExtendedActionItemType[]) =>
+  [...list].sort((a, b) => (STATUS_ORDER[a.status] ?? 99) - (STATUS_ORDER[b.status] ?? 99));
 
 export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
   const params = useParams();
   const spaceId = Number(params.spaceId);
+  const isTeam = currentTab === "팀";
 
-  // * 팀 실행목표 리스트 조회
-  const { data } = useQuery(useApiOptionsGetTeamActionItemList(spaceId));
+  const { data: teamData } = useQuery({
+    ...useApiOptionsGetTeamActionItemList(spaceId),
+    enabled: !!spaceId && isTeam,
+  });
+  const { data: personalData } = useQuery({
+    ...useApiOptionsGetPersonalActionItemListBySpace(spaceId),
+    enabled: !!spaceId && !isTeam,
+  });
 
-  const inProgressActionItems = data?.teamActionItemList.filter((goal) => goal.status === "PROCEEDING");
-  const doneActionItems = data?.teamActionItemList.filter((goal) => goal.status === "DONE");
-  const currentActionItems = currentTab === "진행 중" ? inProgressActionItems : doneActionItems;
+  const rawActionItems = isTeam ? teamData?.teamActionItemList : personalData?.personalActionItemList;
+  const currentActionItems = rawActionItems ? sortByStatus(rawActionItems) : undefined;
 
   return (
     <section
@@ -47,7 +60,7 @@ export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
         >
           <Icon icon="ic_folder" size={4.8} color={DESIGN_TOKEN_COLOR.gray500} />
           <Typography variant="body15Medium" color="gray500">
-            완료된 회고가 없어요
+            아직 실행목표가 없어요
           </Typography>
         </div>
       ) : (
@@ -64,8 +77,10 @@ export default function ActionItemsList({ currentTab }: ActionItemsListProps) {
                 spaceId={spaceId}
                 retrospectId={goal.retrospectId}
                 title={goal.retrospectTitle}
+                deadline={goal.deadline}
                 todoList={goal.actionItemList}
                 status={goal.status}
+                variant={isTeam ? "team" : "personal"}
               />
               {index < currentActionItems.length - 1 && (
                 <div

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsTab.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsTab.tsx
@@ -45,7 +45,7 @@ export default function ActionItemsTab({ currentTab, handleCurrentTabClick }: Ac
               }
             `}
           >
-            <Typography variant="subtitle14SemiBold" color={tab === currentTab ? "gray900" : "gray500"}>
+            <Typography variant="subtitle14Bold" color={tab === currentTab ? "gray900" : "gray500"}>
               {tab}
             </Typography>
           </button>

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsTab.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsTab.tsx
@@ -1,13 +1,14 @@
 import { css } from "@emotion/react";
 import { Typography } from "@/component/common/typography";
+import Tooltip from "@/component/common/Tooltip";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 
 type ActionItemsTabProps = {
-  currentTab: "진행 중" | "지난";
-  handleCurrentTabClick: (tab: "진행 중" | "지난") => void;
+  currentTab: "팀" | "개인";
+  handleCurrentTabClick: (tab: "팀" | "개인") => void;
 };
 
-const ACTION_ITEMS_TAB_NAMES = ["진행 중", "지난"] as const;
+const ACTION_ITEMS_TAB_NAMES = ["팀", "개인"] as const;
 
 export default function ActionItemsTab({ currentTab, handleCurrentTabClick }: ActionItemsTabProps) {
   return (
@@ -18,36 +19,52 @@ export default function ActionItemsTab({ currentTab, handleCurrentTabClick }: Ac
         margin-bottom: 2.4rem;
       `}
     >
-      {ACTION_ITEMS_TAB_NAMES.map((tab) => (
-        <button
-          key={tab}
-          onClick={() => handleCurrentTabClick(tab)}
-          css={css`
-            position: relative;
-            background: none;
-            border: none;
-            padding: 0.8rem 0rem;
-            cursor: pointer;
+      {ACTION_ITEMS_TAB_NAMES.map((tab) => {
+        const tabButton = (
+          <button
+            key={tab}
+            onClick={() => handleCurrentTabClick(tab)}
+            css={css`
+              position: relative;
+              background: none;
+              border: none;
+              padding: 0.8rem 0rem;
+              cursor: pointer;
 
-            &::after {
-              content: "";
-              position: absolute;
-              bottom: 0;
-              left: 0;
-              right: 0;
-              height: 2px;
-              background-color: ${DESIGN_TOKEN_COLOR.gray900};
-              transform: scaleX(${tab === currentTab ? 1 : 0});
-              transition: transform 0.3s ease-in-out;
-              transform-origin: center;
-            }
-          `}
-        >
-          <Typography variant="subtitle14SemiBold" color={tab === currentTab ? "gray900" : "gray500"}>
-            {tab}
-          </Typography>
-        </button>
-      ))}
+              &::after {
+                content: "";
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                height: 2px;
+                background-color: ${DESIGN_TOKEN_COLOR.gray900};
+                transform: scaleX(${tab === currentTab ? 1 : 0});
+                transition: transform 0.3s ease-in-out;
+                transform-origin: center;
+              }
+            `}
+          >
+            <Typography variant="subtitle14SemiBold" color={tab === currentTab ? "gray900" : "gray500"}>
+              {tab}
+            </Typography>
+          </button>
+        );
+
+        // * 개인 탭은 호버 시 NEW 안내 툴팁을 노출한다.
+        if (tab === "개인") {
+          return (
+            <Tooltip key={tab} placement="bottom" align="start">
+              <Tooltip.Trigger>{tabButton}</Tooltip.Trigger>
+              <Tooltip.Content tag="NEW" arrow>
+                팀 회고 속 나의 목표를 관리해보세요.
+              </Tooltip.Content>
+            </Tooltip>
+          );
+        }
+
+        return tabButton;
+      })}
     </div>
   );
 }

--- a/apps/web/src/component/space/view/ActionItemListView.tsx
+++ b/apps/web/src/component/space/view/ActionItemListView.tsx
@@ -36,6 +36,8 @@ type ActionItemProps = {
   actionItemContent: string;
 };
 
+const MAX_VISIBLE_ACTION_ITEMS = 3;
+
 export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, leaderId, restrospectArr = [] }: ActionItemListViewProps) {
   const isCompleteRetrospect = restrospectArr.reduce((acc: SelectBoxType["data"], cur) => {
     if (cur.retrospectStatus === "DONE")
@@ -242,12 +244,12 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
               gap: 0.8rem;
             `}
           >
-            {currentActionList.slice(0, 3).map((actionItem, idx) => (
+            {currentActionList.slice(0, MAX_VISIBLE_ACTION_ITEMS).map((actionItem, idx) => (
               <ActionItem key={idx} actionItemContent={actionItem.content} />
             ))}
             {isTeam &&
               isLeader &&
-              Array.from({ length: 3 - currentActionList.length }).map((_, index) => (
+              Array.from({ length: MAX_VISIBLE_ACTION_ITEMS - currentActionList.length }).map((_, index) => (
                 <div key={`plus-${index}`} onClick={handleOpenBottomSheet}>
                   <PlusActionItem />
                 </div>

--- a/apps/web/src/component/space/view/ActionItemListView.tsx
+++ b/apps/web/src/component/space/view/ActionItemListView.tsx
@@ -58,12 +58,14 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
   const isTeam = currentTab === "팀";
 
   // * 개인 실행목표(최근 회고 기준)는 개인 탭일 때만 조회한다.
-  const { data: personalData } = useQuery({
+  const { data: personalData, isLoading: isPersonalLoading } = useQuery({
     ...useApiOptionsGetRecentPersonalActionList(spaceId),
     enabled: !!spaceId && !isTeam,
   });
   const personalActionList = personalData?.personalActionItemList ?? [];
   const currentActionList = isTeam ? teamActionList : personalActionList;
+  // * 개인 탭은 비동기 조회라 응답 전 빈 상태가 먼저 노출되는 깜빡임을 막기 위해 로딩 분기를 둔다.
+  const isLoadingCurrentTab = !isTeam && isPersonalLoading;
 
   const { value: actionItemValue, handleInputChange } = useInput();
   const { mutate } = useCreateActionItem();
@@ -210,17 +212,27 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
 
       <Spacing size={1.0} />
 
-      {currentActionList.length === 0 && (
+      {isLoadingCurrentTab ? (
         <>
           <Icon icon="icon_file_open" size="5.2rem" />
           <Spacing size={1.6} />
-          <Typography variant="body14Medium" color="gray600">
-            {isTeam ? (isPossibleMake ? "완료된 회고가 없어요" : "실행목표를 설정해보세요") : "아직 실행목표가 없어요"}
+          <Typography variant="body14Medium" color="gray500">
+            불러오는 중...
           </Typography>
         </>
+      ) : (
+        currentActionList.length === 0 && (
+          <>
+            <Icon icon="icon_file_open" size="5.2rem" />
+            <Spacing size={1.6} />
+            <Typography variant="body14Medium" color="gray600">
+              {isTeam ? (isPossibleMake ? "완료된 회고가 없어요" : "실행목표를 설정해보세요") : "아직 실행목표가 없어요"}
+            </Typography>
+          </>
+        )
       )}
 
-      {currentActionList.length !== 0 && (
+      {!isLoadingCurrentTab && currentActionList.length !== 0 && (
         <>
           <div
             css={css`

--- a/apps/web/src/component/space/view/ActionItemListView.tsx
+++ b/apps/web/src/component/space/view/ActionItemListView.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Cookies from "js-cookie";
-import { COOKIE_KEYS } from "@/config/storage-keys";
+import { COOKIE_KEYS, LOCAL_STORAGE_KEYS } from "@/config/storage-keys";
 import { useState, Fragment } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -12,8 +12,10 @@ import { TextArea } from "@/component/common/input";
 import { SelectBox } from "@/component/common/SelectBox";
 import { SelectBoxType } from "@/component/common/SelectBox/SelectBox.tsx";
 import { Spacing } from "@/component/common/Spacing";
+import Tooltip from "@/component/common/Tooltip";
 import { Typography } from "@/component/common/typography";
 import { useCreateActionItem } from "@/hooks/api/actionItem/useCreateActionItem";
+import { useApiOptionsGetRecentPersonalActionList } from "@/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { useInput } from "@/hooks/useInput";
 import { useToast } from "@/hooks/useToast";
@@ -51,6 +53,17 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
   const [retrospect, setRetrospect] = useState("");
   const [retrospectId, setRetrospectId] = useState<number | undefined>(-1);
   const isLeader = Number(memberId) === leaderId;
+
+  const [currentTab, setCurrentTab] = useState<"팀" | "개인">("팀");
+  const isTeam = currentTab === "팀";
+
+  // * 개인 실행목표(최근 회고 기준)는 개인 탭일 때만 조회한다.
+  const { data: personalData } = useQuery({
+    ...useApiOptionsGetRecentPersonalActionList(spaceId),
+    enabled: !!spaceId && !isTeam,
+  });
+  const personalActionList = personalData?.personalActionItemList ?? [];
+  const currentActionList = isTeam ? teamActionList : personalActionList;
 
   const { value: actionItemValue, handleInputChange } = useInput();
   const { mutate } = useCreateActionItem();
@@ -104,7 +117,7 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
     <div
       css={css`
         width: 100%;
-        height: 16.9rem;
+        min-height: 16.9rem;
         background-color: ${DESIGN_TOKEN_COLOR.gray00};
         border: 1px solid rgba(33, 37, 41, 0.08);
         border-radius: 1.2rem;
@@ -121,7 +134,7 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
           justify-content: space-between;
         `}
       >
-        <Typography variant="body14Medium">실행 목표</Typography>
+        <Typography variant="subtitle14Bold">실행 목표</Typography>
         {/* You must have a completed retrospective to view more. */}
         {!isPossibleMake && (
           <Typography
@@ -137,19 +150,77 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
         )}
       </div>
 
+      {/* ---------- 팀/개인 탭 ---------- */}
+      <div
+        css={css`
+          width: 100%;
+          display: flex;
+          align-items: flex-end;
+          gap: 0.4rem;
+        `}
+      >
+        {(["팀", "개인"] as const).map((tab) => {
+          const isActive = tab === currentTab;
+          const tabItem = (
+            <button
+              key={tab}
+              onClick={() => setCurrentTab(tab)}
+              css={css`
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: flex-end;
+                gap: 0.6rem;
+                width: 5rem;
+                height: 4rem;
+                padding: 0 0.4rem;
+                background: none;
+                border: none;
+                cursor: pointer;
+              `}
+            >
+              <Typography variant="subtitle14Bold" color={isActive ? "gray900" : "gray500"}>
+                {tab}
+              </Typography>
+              <div
+                css={css`
+                  width: 100%;
+                  height: 2px;
+                  background-color: ${isActive ? DESIGN_TOKEN_COLOR.gray900 : "transparent"};
+                `}
+              />
+            </button>
+          );
+
+          // * 개인 탭에는 NEW 안내 툴팁(파란 테마)을 기본 노출한다.
+          if (tab === "개인") {
+            return (
+              <Tooltip key={tab} placement="bottom" align="start" theme="blue" defaultOpen storageKey={LOCAL_STORAGE_KEYS.actionItemGoalTooltipSeen}>
+                <Tooltip.Trigger>{tabItem}</Tooltip.Trigger>
+                <Tooltip.Content tag="NEW" arrow>
+                  팀 회고 속 나의 목표를 관리해보세요.
+                </Tooltip.Content>
+              </Tooltip>
+            );
+          }
+
+          return tabItem;
+        })}
+      </div>
+
       <Spacing size={1.0} />
 
-      {teamActionList && teamActionList.length === 0 && (
+      {currentActionList.length === 0 && (
         <>
           <Icon icon="icon_file_open" size="5.2rem" />
           <Spacing size={1.6} />
           <Typography variant="body14Medium" color="gray600">
-            {isPossibleMake ? "완료된 회고가 없어요" : "실행목표를 설정해보세요"}
+            {isTeam ? (isPossibleMake ? "완료된 회고가 없어요" : "실행목표를 설정해보세요") : "아직 실행목표가 없어요"}
           </Typography>
         </>
       )}
 
-      {teamActionList && teamActionList.length !== 0 && (
+      {currentActionList.length !== 0 && (
         <>
           <div
             css={css`
@@ -159,11 +230,12 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
               gap: 0.8rem;
             `}
           >
-            {teamActionList.slice(0, 3).map((actionItem, idx) => (
+            {currentActionList.slice(0, 3).map((actionItem, idx) => (
               <ActionItem key={idx} actionItemContent={actionItem.content} />
             ))}
-            {isLeader &&
-              Array.from({ length: 3 - teamActionList.length }).map((_, index) => (
+            {isTeam &&
+              isLeader &&
+              Array.from({ length: 3 - currentActionList.length }).map((_, index) => (
                 <div key={`plus-${index}`} onClick={handleOpenBottomSheet}>
                   <PlusActionItem />
                 </div>

--- a/apps/web/src/component/space/view/ActionItemListView.tsx
+++ b/apps/web/src/component/space/view/ActionItemListView.tsx
@@ -68,7 +68,7 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
   const isLoadingCurrentTab = !isTeam && isPersonalLoading;
 
   const { value: actionItemValue, handleInputChange } = useInput();
-  const { mutate } = useCreateActionItem();
+  const { mutate: createActionItemMutate } = useCreateActionItem();
   const { toast } = useToast();
   const { openBottomSheet, closeBottomSheet } = useBottomSheet();
 
@@ -93,7 +93,7 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
       return;
     }
 
-    mutate(
+    createActionItemMutate(
       { retrospectId, content: actionItemValue },
       {
         onSuccess: async () => {

--- a/apps/web/src/config/storage-keys.ts
+++ b/apps/web/src/config/storage-keys.ts
@@ -26,4 +26,6 @@ export const AUTH_COOKIE_OPTIONS = {
 export const LOCAL_STORAGE_KEYS = {
   utmParamsKey: "UTM_PARAMS",
   recentSocialLoginType: "RECENT_SOCIAL_LOGIN_TYPE",
+  /** 실행목표 팀/개인 NEW 안내 툴팁을 본 적 있는지 (한 번만 노출) */
+  actionItemGoalTooltipSeen: "ACTION_ITEM_GOAL_TOOLTIP_SEEN",
 } as const;

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
@@ -3,15 +3,18 @@ import { UseQueryOptions } from "@tanstack/react-query";
 import { api } from "@/api";
 import { PersonalActionItemListBySpaceType } from "@/types/actionItem";
 
-const getPersonalActionItemListBySpace = async (spaceId: number | undefined) => {
+const getPersonalActionItemListBySpace = async (spaceId: number) => {
   const response = await api.get<PersonalActionItemListBySpaceType>(`/api/action-item/personal/space/${spaceId}`);
   return response.data;
 };
 
 export const useApiOptionsGetPersonalActionItemListBySpace = (
   spaceId?: number,
-): UseQueryOptions<PersonalActionItemListBySpaceType, Error, PersonalActionItemListBySpaceType, [string, number]> => ({
-  queryKey: ["getPersonalActionItemListBySpace", spaceId!],
-  queryFn: () => getPersonalActionItemListBySpace(spaceId),
-  enabled: !!spaceId,
+): UseQueryOptions<PersonalActionItemListBySpaceType, Error, PersonalActionItemListBySpaceType, [string, number | undefined]> => ({
+  queryKey: ["getPersonalActionItemListBySpace", spaceId],
+  queryFn: () => {
+    if (spaceId == null) throw new Error("spaceId is required");
+    return getPersonalActionItemListBySpace(spaceId);
+  },
+  enabled: spaceId != null,
 });

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
@@ -1,0 +1,17 @@
+import { UseQueryOptions } from "@tanstack/react-query";
+
+import { api } from "@/api";
+import { PersonalActionItemListBySpaceType } from "@/types/actionItem";
+
+const getPersonalActionItemListBySpace = async (spaceId: number | undefined) => {
+  const response = await api.get<PersonalActionItemListBySpaceType>(`/api/action-item/personal/space/${spaceId}`);
+  return response.data;
+};
+
+export const useApiOptionsGetPersonalActionItemListBySpace = (
+  spaceId?: number,
+): UseQueryOptions<PersonalActionItemListBySpaceType, Error, PersonalActionItemListBySpaceType, [string, number]> => ({
+  queryKey: ["getPersonalActionItemListBySpace", spaceId!],
+  queryFn: () => getPersonalActionItemListBySpace(spaceId),
+  enabled: !!spaceId,
+});

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
@@ -1,4 +1,4 @@
-import { UseQueryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
 import { PersonalActionItemListBySpaceType } from "@/types/actionItem";
@@ -8,13 +8,12 @@ const getPersonalActionItemListBySpace = async (spaceId: number) => {
   return response.data;
 };
 
-export const useApiOptionsGetPersonalActionItemListBySpace = (
-  spaceId?: number,
-): UseQueryOptions<PersonalActionItemListBySpaceType, Error, PersonalActionItemListBySpaceType, [string, number | undefined]> => ({
-  queryKey: ["getPersonalActionItemListBySpace", spaceId],
-  queryFn: () => {
-    if (spaceId == null) throw new Error("spaceId is required");
-    return getPersonalActionItemListBySpace(spaceId);
-  },
-  enabled: spaceId != null,
-});
+export const useApiOptionsGetPersonalActionItemListBySpace = (spaceId?: number) =>
+  queryOptions({
+    queryKey: ["getPersonalActionItemListBySpace", spaceId] as const,
+    queryFn: () => {
+      if (spaceId == null) throw new Error("spaceId is required");
+      return getPersonalActionItemListBySpace(spaceId);
+    },
+    enabled: spaceId != null,
+  });

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
@@ -1,0 +1,30 @@
+import { UseQueryOptions } from "@tanstack/react-query";
+
+import { api } from "@/api";
+
+export type RecentPersonalActionItem = {
+  actionItemId: number;
+  content: string;
+  retrospectId: number;
+  retrospectTitle: string;
+  createdAt: string;
+};
+
+type RecentPersonalActionItemList = {
+  spaceId: number;
+  spaceName: string;
+  personalActionItemList: RecentPersonalActionItem[];
+};
+
+const getRecentPersonalActionItemList = async (spaceId: number | undefined) => {
+  const response = await api.get<RecentPersonalActionItemList>(`/api/action-item/personal/space/${spaceId}/recent`);
+  return response.data;
+};
+
+export const useApiOptionsGetRecentPersonalActionList = (
+  spaceId?: number,
+): UseQueryOptions<RecentPersonalActionItemList, Error, RecentPersonalActionItemList, [string, number]> => ({
+  queryKey: ["getRecentPersonalActionItemList", spaceId!],
+  queryFn: () => getRecentPersonalActionItemList(spaceId),
+  enabled: !!spaceId,
+});

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
@@ -16,15 +16,18 @@ type RecentPersonalActionItemList = {
   personalActionItemList: RecentPersonalActionItem[];
 };
 
-const getRecentPersonalActionItemList = async (spaceId: number | undefined) => {
+const getRecentPersonalActionItemList = async (spaceId: number) => {
   const response = await api.get<RecentPersonalActionItemList>(`/api/action-item/personal/space/${spaceId}/recent`);
   return response.data;
 };
 
 export const useApiOptionsGetRecentPersonalActionList = (
   spaceId?: number,
-): UseQueryOptions<RecentPersonalActionItemList, Error, RecentPersonalActionItemList, [string, number]> => ({
-  queryKey: ["getRecentPersonalActionItemList", spaceId!],
-  queryFn: () => getRecentPersonalActionItemList(spaceId),
-  enabled: !!spaceId,
+): UseQueryOptions<RecentPersonalActionItemList, Error, RecentPersonalActionItemList, [string, number | undefined]> => ({
+  queryKey: ["getRecentPersonalActionItemList", spaceId],
+  queryFn: () => {
+    if (spaceId == null) throw new Error("spaceId is required");
+    return getRecentPersonalActionItemList(spaceId);
+  },
+  enabled: spaceId != null,
 });

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
@@ -1,4 +1,4 @@
-import { UseQueryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
 
@@ -21,13 +21,12 @@ const getRecentPersonalActionItemList = async (spaceId: number) => {
   return response.data;
 };
 
-export const useApiOptionsGetRecentPersonalActionList = (
-  spaceId?: number,
-): UseQueryOptions<RecentPersonalActionItemList, Error, RecentPersonalActionItemList, [string, number | undefined]> => ({
-  queryKey: ["getRecentPersonalActionItemList", spaceId],
-  queryFn: () => {
-    if (spaceId == null) throw new Error("spaceId is required");
-    return getRecentPersonalActionItemList(spaceId);
-  },
-  enabled: spaceId != null,
-});
+export const useApiOptionsGetRecentPersonalActionList = (spaceId?: number) =>
+  queryOptions({
+    queryKey: ["getRecentPersonalActionItemList", spaceId] as const,
+    queryFn: () => {
+      if (spaceId == null) throw new Error("spaceId is required");
+      return getRecentPersonalActionItemList(spaceId);
+    },
+    enabled: spaceId != null,
+  });

--- a/apps/web/src/hooks/api/actionItem/useApiPostPersonalActionItem.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiPostPersonalActionItem.ts
@@ -1,0 +1,20 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { api } from "@/api";
+
+type PostPersonalActionItemProps = {
+  spaceId: number;
+  retrospectId: number;
+  content: string;
+};
+
+const postPersonalActionItem = async ({ spaceId, retrospectId, content }: PostPersonalActionItemProps) => {
+  const data = await api.post(`/api/action-item/personal/space/${spaceId}/retrospect/${retrospectId}`, { content });
+  return data;
+};
+
+export const useApiPostPersonalActionItem = () => {
+  return useMutation({
+    mutationFn: postPersonalActionItem,
+  });
+};

--- a/apps/web/src/hooks/api/actionItem/useDeletePersonalActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useDeletePersonalActionItemList.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { api } from "@/api";
+
+export const useDeletePersonalActionItemList = () => {
+  const deletePersonalActionItemList = ({ actionItemId }: { actionItemId: number }) => {
+    const res = api.delete(`/api/action-item/personal/${actionItemId}`);
+    return res;
+  };
+
+  return useMutation({
+    mutationFn: ({ actionItemId }: { actionItemId: number }) => deletePersonalActionItemList({ actionItemId }),
+  });
+};

--- a/apps/web/src/hooks/api/actionItem/useGetPersonalActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useGetPersonalActionItemList.ts
@@ -1,0 +1,27 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+
+import { api } from "@/api";
+import { PersonalActionItemListType } from "@/types/actionItem";
+
+/**
+ * 내 모든 스페이스의 "개인" 실행목표 조회
+ * GET /api/action-item/personal/member
+ *
+ * 팀 실행목표(useGetActionItemList, /api/action-item/member)와 동일한 응답 구조를 가진다.
+ */
+export const useGetPersonalActionItemList = <TData = PersonalActionItemListType>({
+  options,
+}: {
+  options?: Omit<UseQueryOptions<PersonalActionItemListType, Error, TData>, "queryKey" | "queryFn">;
+}) => {
+  const getPersonalActionItemList = () => {
+    const res = api.get<PersonalActionItemListType>("/api/action-item/personal/member").then((res) => res.data);
+    return res;
+  };
+
+  return useQuery<PersonalActionItemListType, Error, TData>({
+    queryFn: () => getPersonalActionItemList(),
+    queryKey: ["personalActionItemList"],
+    ...options,
+  });
+};

--- a/apps/web/src/hooks/api/actionItem/usePatchPersonalActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/usePatchPersonalActionItemList.ts
@@ -1,0 +1,32 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { api } from "@/api";
+
+/**
+ * spaceId/retrospectId에 해당하는 "개인" 실행목표 리스트를 수정하는 API
+ *
+ * @param spaceId 스페이스 ID
+ * @param retrospectId 회고 ID (새로 추가한 실행목표인 경우, id 없이 보냅니다.)
+ * @param actionItems 실행목표 리스트
+ */
+export type PatchPersonalActionItemListProps = {
+  spaceId: number;
+  retrospectId: number;
+  actionItems: {
+    id?: number;
+    content: string;
+  }[];
+};
+
+export const usePatchPersonalActionItemList = () => {
+  const patchPersonalActionItemList = ({ spaceId, retrospectId, actionItems }: PatchPersonalActionItemListProps) => {
+    const res = api.patch(`/api/action-item/personal/space/${spaceId}/retrospect/${retrospectId}/update`, {
+      actionItems,
+    });
+    return res;
+  };
+
+  return useMutation({
+    mutationFn: patchPersonalActionItemList,
+  });
+};

--- a/apps/web/src/swiper.d.ts
+++ b/apps/web/src/swiper.d.ts
@@ -1,0 +1,6 @@
+// Swiper 11 maps "swiper/css" subpaths directly to .css files in its exports map.
+// Under moduleResolution: "bundler", TS can't find type declarations for these
+// side-effect imports, so declare them as ambient modules.
+declare module "swiper/css";
+declare module "swiper/css/navigation";
+declare module "swiper/css/pagination";

--- a/apps/web/src/types/actionItem/index.ts
+++ b/apps/web/src/types/actionItem/index.ts
@@ -22,6 +22,12 @@ export type TeamActionItemType = {
   teamActionItemList: ExtendedActionItemType[];
 };
 
+export type PersonalActionItemListBySpaceType = {
+  spaceId: number;
+  spaceName: string;
+  personalActionItemList: ExtendedActionItemType[];
+};
+
 export type PersonalActionItemType = {
   retrospectId: number;
   retrospectTitle: string;


### PR DESCRIPTION
> ### 실행목표 개선
---

### 🏄🏼‍♂️‍ Summary (요약)

- 실행목표를 팀 / 개인 탭으로 구분해 조회·관리하는 기능을 데스크톱·모바일 전반에 추가했습니다.
- 개인 실행목표 전용 API(조회/추가/수정/삭제)를 연동하고, NEW 안내 툴팁을 도입했습니다.

### 🫨 Describe your Change (변경사항)

- 팀/개인 탭 추가
     - 메인페이지(ActionItemsWrapper), 데스크톱 스페이스(ActionItems/ActionItemsTab/ActionItemsList), 모바일 스페이스 카드(ActionItemListView), 모바일 실행목표 더보기(ActionItemMorePage)에 팀/개인 탭 적용
     - 한 탭 안에서 진행 중 → 지난 순으로 모든 실행목표를 표기 (카드별 상태 라벨 노출) 
     - 탭 디자인 Figma 반영: 모바일 탭 가로 폭 50px 고정(터치영역), font-weight 600, 카드 라벨/날짜 등

- 개인 실행목표 API 연동
     - 신규 커스텀훅 추가: 조회(...GetPersonalActionItemListBySpace, ...GetRecentPersonalActionList), 추가(useApiPostPersonalActionItem), 수정(usePatchPersonalActionItemList), 삭제(useDeletePersonalActionItemList)
     - 데스크톱 스페이스 및 모바일 더보기에서 개인 탭 본인 추가/수정/삭제 지원 (개인 전용 엔드포인트 + 개인 캐시 갱신)

- 공용 Tooltip 개선
     - align(start/center/end), theme(dark/blue), storageKey 옵션 추가
     - NEW 칩 디자인(알약형 + 반투명 링) 및 화살표 정렬 보정 
     - storageKey 기반으로 안내 툴팁을 최초 1회만 노출 (localStorage)

### 🧐 Issue number and link (참고)

- close #888 

### 📚 Reference (참조)

- n/a
