### PR TITLE
스페이스 목록 온보딩 툴팁 공용 컴포넌트 전환 및 동적 위치 조정

### DIFF
--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from "../../context/NavigationContext";
 
 import { useApiGetSpaceList } from "@/hooks/api/space/useApiGetSpaceList";
 import { PROJECT_CATEGORY_MAP } from "../../constants";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
 import AddSpacePage from "@/app/desktop/space/add/AddSpacePage";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
@@ -30,10 +30,14 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
   const currentCategory = PROJECT_CATEGORY_MAP[currentTab];
 
   const observerRef = useRef<HTMLDivElement>(null);
+  const addButtonSectionRef = useRef<HTMLElement>(null);
+  const [tooltipTop, setTooltipTop] = useState<number | null>(null);
 
   const { data: spaceData, hasNextPage, isPending, isFetchingNextPage, fetchNextPage } = useApiGetSpaceList(currentCategory);
 
   const spaces = spaceData?.pages.flatMap((page) => page.data) ?? [];
+
+  const showTooltip = spaces.length === 0;
 
   const { open: openDesktopModal } = useDesktopBasicModal();
   const { resetAll: resetRetrospectInfo } = useRetrospectCreateReset();
@@ -86,6 +90,34 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
     postSpacesImpression();
   }, []);
 
+  // 온보딩 툴팁을 "스페이스 추가" 버튼 바로 아래에 위치시킨다.
+  // 버튼은 Portal 밖에 있어 overflow에 가려지므로, 버튼 위치를 측정해 fixed 좌표로 전달한다.
+  useEffect(() => {
+    if (!showTooltip) return;
+
+    const section = addButtonSectionRef.current;
+    if (!section) return;
+
+    // 접힌 상태에서는 갭을 좁히고, 펼친 상태에서는 넓힌다.
+    const TOOLTIP_GAP = isCollapsed ? 4 : 14;
+    const updatePosition = () => {
+      const rect = section.getBoundingClientRect();
+      setTooltipTop(rect.bottom + TOOLTIP_GAP);
+    };
+
+    updatePosition();
+
+    // ResizeObserver로 접기/펼치기 애니메이션 중 버튼 위치 변화를 추적한다.
+    const resizeObserver = new ResizeObserver(updatePosition);
+    resizeObserver.observe(section);
+    window.addEventListener("resize", updatePosition);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [showTooltip, isCollapsed, isPending]);
+
   if (isPending && !isFetchingNextPage) {
     return <LoadingSpinner />;
   }
@@ -108,6 +140,7 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
       ))}
 
       <section
+        ref={addButtonSectionRef}
         css={css`
           position: relative;
           width: 100%;
@@ -115,12 +148,12 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
       >
         <SpaceAddButton onClick={handleOpenSpaceAdd} />
 
-        {spaces.length === 0 && (
+        {showTooltip && tooltipTop !== null && (
           <Portal id="tooltip-root">
             <div
               css={css`
                 position: fixed;
-                top: 31rem;
+                top: ${tooltipTop}px;
                 left: 2rem;
                 transform: ${isCollapsed ? "translateX(-50%)" : "none"};
                 background-color: ${DESIGN_TOKEN_COLOR.gray900};

--- a/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
+++ b/apps/web/src/component/common/LocalNavigationBar/Navigation/space/SpacesList.tsx
@@ -6,16 +6,13 @@ import { useNavigation } from "../../context/NavigationContext";
 
 import { useApiGetSpaceList } from "@/hooks/api/space/useApiGetSpaceList";
 import { PROJECT_CATEGORY_MAP } from "../../constants";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
 import AddSpacePage from "@/app/desktop/space/add/AddSpacePage";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
 import { useRetrospectCreateReset } from "@/hooks/store/useRetrospectCreateReset";
 import { useSpaceCreateReset } from "@/hooks/store/useSpaceCreateReset";
-import { ANIMATION } from "@/style/common/animation";
-import { Typography } from "@/component/common/typography";
-import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
-import { Portal } from "@/component/common/Portal";
+import { Tooltip } from "@/component/common/tip/Tooltip";
 import { useApiPostSpacesImpression } from "@/hooks/api/backoffice/useApiPostSpacesImpression";
 import { trackEvent } from "@/lib/google-analytics";
 import { GA_EVENTS } from "@/lib/google-analytics/events";
@@ -24,20 +21,25 @@ interface SpacesListProps {
   currentTab: "전체" | "개인" | "팀";
 }
 
+// 온보딩 툴팁과 "스페이스 추가" 버튼 사이 세로 간격
+// LNB가 접히면 버튼이 작아져 더 위로 붙인다.
+const TOOLTIP_OFFSET_Y = {
+  collapsed: -6,
+  expanded: 14,
+} as const;
+
 export default function SpacesList({ currentTab }: SpacesListProps) {
   const { isCollapsed } = useNavigation();
 
   const currentCategory = PROJECT_CATEGORY_MAP[currentTab];
 
   const observerRef = useRef<HTMLDivElement>(null);
-  const addButtonSectionRef = useRef<HTMLElement>(null);
-  const [tooltipTop, setTooltipTop] = useState<number | null>(null);
 
   const { data: spaceData, hasNextPage, isPending, isFetchingNextPage, fetchNextPage } = useApiGetSpaceList(currentCategory);
 
   const spaces = spaceData?.pages.flatMap((page) => page.data) ?? [];
 
-  const showTooltip = spaces.length === 0;
+  const isEmptySpace = spaces.length === 0;
 
   const { open: openDesktopModal } = useDesktopBasicModal();
   const { resetAll: resetRetrospectInfo } = useRetrospectCreateReset();
@@ -90,34 +92,6 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
     postSpacesImpression();
   }, []);
 
-  // 온보딩 툴팁을 "스페이스 추가" 버튼 바로 아래에 위치시킨다.
-  // 버튼은 Portal 밖에 있어 overflow에 가려지므로, 버튼 위치를 측정해 fixed 좌표로 전달한다.
-  useEffect(() => {
-    if (!showTooltip) return;
-
-    const section = addButtonSectionRef.current;
-    if (!section) return;
-
-    // 접힌 상태에서는 갭을 좁히고, 펼친 상태에서는 넓힌다.
-    const TOOLTIP_GAP = isCollapsed ? 4 : 14;
-    const updatePosition = () => {
-      const rect = section.getBoundingClientRect();
-      setTooltipTop(rect.bottom + TOOLTIP_GAP);
-    };
-
-    updatePosition();
-
-    // ResizeObserver로 접기/펼치기 애니메이션 중 버튼 위치 변화를 추적한다.
-    const resizeObserver = new ResizeObserver(updatePosition);
-    resizeObserver.observe(section);
-    window.addEventListener("resize", updatePosition);
-
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener("resize", updatePosition);
-    };
-  }, [showTooltip, isCollapsed, isPending]);
-
   if (isPending && !isFetchingNextPage) {
     return <LoadingSpinner />;
   }
@@ -140,54 +114,26 @@ export default function SpacesList({ currentTab }: SpacesListProps) {
       ))}
 
       <section
-        ref={addButtonSectionRef}
         css={css`
-          position: relative;
           width: 100%;
         `}
       >
-        <SpaceAddButton onClick={handleOpenSpaceAdd} />
-
-        {showTooltip && tooltipTop !== null && (
-          <Portal id="tooltip-root">
-            <div
-              css={css`
-                position: fixed;
-                top: ${tooltipTop}px;
-                left: 2rem;
-                transform: ${isCollapsed ? "translateX(-50%)" : "none"};
-                background-color: ${DESIGN_TOKEN_COLOR.gray900};
-                padding: 1rem 1.4rem;
-                border-radius: 0.8rem;
-                animation: ${ANIMATION.BOUNCE} 2s ease-in-out infinite;
-                white-space: nowrap;
-                z-index: 1000;
-              `}
-            >
-              <Typography variant="body12Medium" color="gray00">
-                스페이스를 생성해야 회고를 진행할 수 있어요!
-              </Typography>
-              <div
-                css={css`
-                  ::before {
-                    position: absolute;
-                    top: -0.4rem;
-                    left: 2rem;
-                    width: 1.2rem;
-                    height: 1.2rem;
-                    border-radius: 0.2rem;
-                    background: ${DESIGN_TOKEN_COLOR.gray900};
-                    visibility: visible;
-                    content: "";
-                    transform: rotate(45deg);
-                    transition:
-                      opacity 0.2s ease,
-                      visibility 0.2s ease;
-                  }
-                `}
-              />
-            </div>
-          </Portal>
+        {isEmptySpace ? (
+          <Tooltip>
+            <Tooltip.Trigger>
+              <SpaceAddButton onClick={handleOpenSpaceAdd} />
+            </Tooltip.Trigger>
+            <Tooltip.Content
+              message="스페이스를 생성해야 회고를 진행할 수 있어요!"
+              placement="bottom-start"
+              offsetY={isCollapsed ? TOOLTIP_OFFSET_Y.collapsed : TOOLTIP_OFFSET_Y.expanded}
+              arrowOffsetX={2}
+              autoHide={false}
+              hideOnClick={false}
+            />
+          </Tooltip>
+        ) : (
+          <SpaceAddButton onClick={handleOpenSpaceAdd} />
         )}
       </section>
 

--- a/apps/web/src/component/common/tip/Tooltip.tsx
+++ b/apps/web/src/component/common/tip/Tooltip.tsx
@@ -104,7 +104,7 @@ function Content({
     }
   }, [context.hideTooltip, hideOnClick]);
 
-  const { styles, attributes } = usePopper(context.referenceEl, context.popperEl, {
+  const { styles, attributes, update } = usePopper(context.referenceEl, context.popperEl, {
     placement,
     modifiers: [
       {
@@ -116,6 +116,20 @@ function Content({
       ...modifiers,
     ],
   });
+
+  // 트리거 크기가 바뀌면(예: 사이드바 접기/펼치기) 툴팁 위치를 다시 계산한다.
+  // ex LNB가 접혔을 때와 펼쳤을 때, 높이가 다른 경우가 발생함.
+  useEffect(() => {
+    const referenceEl = context.referenceEl;
+    if (!referenceEl || !update || typeof ResizeObserver === "undefined") return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      update();
+    });
+    resizeObserver.observe(referenceEl);
+
+    return () => resizeObserver.disconnect();
+  }, [context.referenceEl, update]);
 
   const getArrowPosition = (placement: ContentProps["placement"]) => {
     const offsetY = -0.4;


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 스페이스 목록의 온보딩 툴팁을 공용 "Tooltip" 컴포넌트로 전환했습니다.
- LNB 상태에 따라 툴팁의 세로 위치가 동적으로 조정되도록 개선했습니다.
- 트리거 요소 크기 변경 시 툴팁 위치가 자동으로 업데이트되도록 기능을 추가했습니다.

### 🫨 Describe your Change (변경사항)

- "SpacesList.tsx"에서 수동 구현된 온보딩 툴팁을 "Tooltip" 공용 컴포넌트로 대체했습니다.
- LNB 접힘/펼침 상태에 따라 '스페이스 추가' 버튼 툴팁의 "offsetY" 값을 다르게 적용하여 위치를 최적화했습니다.
- "Tooltip.tsx"에 "ResizeObserver"를 활용하여 트리거 요소 크기 변경 시 툴팁 위치를 자동으로 재계산하는 로직을 추가했습니다.
- 불필요한 "Portal", "ANIMATION", "Typography", "DESIGN_TOKEN_COLOR" 임포트를 제거했습니다.

### 🧐 Issue number and link (참고)

closes: #902

### 📚 Reference (참조)

-