### PR TITLE
Recharts 업데이트 및 회고 생성 후 데이터 동기화 개선

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,7 @@
     "react-popper": "^2.3.0",
     "react-router-dom": "^6.24.0",
     "react-slick": "^0.30.2",
-    "recharts": "^2.12.7",
+    "recharts": "^2.15.4",
     "slick-carousel": "^1.8.1",
     "swiper": "^11.1.5",
     "vite-plugin-html": "^3.2.2",

--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -61,13 +61,17 @@ export function RetrospectCreate() {
       },
       {
         onSuccess: async () => {
+          // 사용자가 템플릿을 변경하거나, 회고를 생성할 때 변경된 정보가 있으면 스페이스 정보를 다시 가져옵니다.
           await queryClient.invalidateQueries({
-            queryKey: ["getSpaceInfo", String(spaceIdNumber)],
+            queryKey: ["getSpaceInfo", spaceIdNumber],
+          });
+          // 사용자가 회고를 추가했다면, 회고 리스트 조회를 다시 리패치합니다.
+          await queryClient.invalidateQueries({
+            queryKey: ["getRetrospects", spaceIdNumber],
           });
           navigate(PATHS.spaceDetail(String(spaceIdNumber)));
           closeFunnelModal();
           toast.success("회고가 생성되었어요!");
-
           setRetrospectValue((prev) => ({
             ...prev,
             tempTemplateId: null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,8 +301,8 @@ importers:
         specifier: ^0.30.2
         version: 0.30.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       recharts:
-        specifier: ^2.12.7
-        version: 2.12.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^2.15.4
+        version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       slick-carousel:
         specifier: ^1.8.1
         version: 1.8.1(jquery@3.7.1)
@@ -1482,7 +1482,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.29':
     resolution: {integrity: sha512-X810C48Ss+67RdZU39YEO1khNYo1RmjouRV+vVe0QhMoTe8R6OA3t+XYEdwaNbJ5p/DJN7szfHfNmX2glpC7xg==}
@@ -5857,7 +5857,6 @@ packages:
     resolution: {integrity: sha512-Quz3MvAwHxVYNXsOByL7xI5EB2WYOeFswqaHIA3qOK3isRWTxiplBEocmmru6XmxDB2L7jDNYtYA4FyimoAFEw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
-    bundledDependencies: []
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -7307,11 +7306,11 @@ packages:
       react: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0
 
-  react-smooth@4.0.1:
-    resolution: {integrity: sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==}
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
@@ -7393,13 +7392,13 @@ packages:
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
-  recharts@2.12.7:
-    resolution: {integrity: sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==}
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
     deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -17638,7 +17637,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       resize-observer-polyfill: 1.5.1
 
-  react-smooth@4.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-smooth@4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       fast-equals: 5.0.1
       prop-types: 15.8.1
@@ -17750,15 +17749,15 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.1
 
-  recharts@2.12.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  recharts@2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
       lodash: 4.17.21
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-is: 16.13.1
-      react-smooth: 4.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- Recharts 라이브러리를 최신 버전으로 업데이트했습니다.
- 회고 생성 성공 시 스페이스 정보와 회고 목록을 자동으로 새로고침하도록 로직을 개선했습니다.
- React 19 호환성을 위해 일부 라이브러리의 peerDependencies를 업데이트했습니다.

### 🫨 Describe your Change (변경사항)

- apps/web/package.json에서 recharts 버전을 2.12.7에서 2.15.4로 업데이트했습니다.
- 회고 생성 성공 시 getSpaceInfo 쿼리 키의 String() 변환을 제거하여 타입 일관성을 확보했습니다.
- 회고 생성 성공 시 getRetrospects 쿼리를 무효화하여 회고 목록이 즉시 반영되도록 했습니다.
- pnpm-lock.yaml에서 recharts 및 react-smooth 버전을 업데이트하고, React 19 지원을 추가했습니다.

### 🧐 Issue number and link (참고)

closes: #911

### 📚 Reference (참조)

-