### PR TITLE
회고 생성/템플릿 변경 후 데이터 갱신 로직 개선

### DIFF
--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -61,8 +61,13 @@ export function RetrospectCreate() {
       },
       {
         onSuccess: async () => {
+          // 사용자가 템플릿을 변경하거나, 회고를 생성할 때 변경된 정보가 있으면 스페이스 정보를 다시 가져옵니다.
           await queryClient.invalidateQueries({
-            queryKey: ["getSpaceInfo", String(spaceIdNumber)],
+            queryKey: ["getSpaceInfo", spaceIdNumber],
+          });
+          // 사용자가 회고를 추가했다면, 회고 리스트 조회를 다시 리패치합니다.
+          await queryClient.invalidateQueries({
+            queryKey: ["getRetrospects", spaceIdNumber],
           });
           navigate(PATHS.spaceDetail(String(spaceIdNumber)));
           closeFunnelModal();


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 생성 또는 템플릿 변경 성공 시 스페이스 정보 쿼리를 무효화하여 최신 데이터를 반영합니다.
- 회고 생성 성공 시 회고 목록 쿼리를 무효화하여 즉시 갱신된 목록을 표시합니다.

### 🫨 Describe your Change (변경사항)

- RetrospectCreate 컴포넌트의 onSuccess 핸들러에 getRetrospects 쿼리 무효화 로직을 추가했습니다.
- getSpaceInfo 쿼리 무효화 시 queryKey의 spaceIdNumber 인자 타입을 통일했습니다.
- 사용자 경험 개선을 위해 회고 생성 후 관련 데이터가 즉시 업데이트되도록 처리했습니다.

### 🧐 Issue number and link (참고)

closes: #911

### 📚 Reference (참조)

-