### PR TITLE
회고 템플릿 이름 수정 UI 개선

### DIFF
--- a/apps/web/src/app/desktop/component/retrospectCreate/steps/ConfirmDefaultTemplate.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/steps/ConfirmDefaultTemplate.tsx
@@ -117,38 +117,34 @@ export function ConfirmDefaultTemplate() {
             {!retroCreateData.hasChangedOriginal ? (
               <Typography variant={"S1"}>{displayTitle}</Typography>
             ) : (
-              <input
-                type="text"
-                value={customTemplateTitle}
-                onChange={(e) => {
-                  handleTitleChange(e.target.value);
-                }}
-                css={css`
-                  font-size: 2rem;
-                  font-weight: bold;
-                  width: 100%;
-                  margin-right: 1rem;
-                `}
-                onBlur={() => {
-                  if (displayTitle !== retroCreateData.formName) {
-                    toast.success("이름 수정이 완료되었어요!");
-                  }
-                }}
-              />
+              <Tooltip>
+                <Tooltip.Trigger>
+                  <input
+                    type="text"
+                    value={customTemplateTitle}
+                    onChange={(e) => {
+                      handleTitleChange(e.target.value);
+                    }}
+                    css={css`
+                      font-size: 2rem;
+                      font-weight: bold;
+                      width: 100%;
+                      margin-right: 1rem;
+                    `}
+                    onBlur={() => {
+                      if (displayTitle !== retroCreateData.formName) {
+                        toast.success("이름 수정이 완료되었어요!");
+                      }
+                    }}
+                  />
+                </Tooltip.Trigger>
+                <Tooltip.Content message="커스텀된 템플릿의 이름을 수정할 수 있어요!" placement="top-start" offsetX={-15} offsetY={10} hideOnClick />
+              </Tooltip>
             )}
 
             <Tag styles="margin-top: 0.8rem">{displayTag}</Tag>
           </div>
-          {retroCreateData.hasChangedOriginal ? (
-            <Tooltip>
-              <Tooltip.Trigger>
-                <QuestionEditButton />
-              </Tooltip.Trigger>
-              <Tooltip.Content message="커스텀된 템플릿의 이름을 수정할 수 있어요!" placement="top-end" offsetX={-15} offsetY={10} hideOnClick />
-            </Tooltip>
-          ) : (
-            <QuestionEditButton />
-          )}
+          <QuestionEditButton />
         </div>
         <Spacing size={3} />
 


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 커스텀 템플릿 이름 입력 필드에 툴팁을 추가하여 사용자 안내를 강화했습니다.
- QuestionEditButton의 조건부 렌더링 및 툴팁 로직을 제거하여 UI를 간소화했습니다.

### 🫨 Describe your Change (변경사항)

- ConfirmDefaultTemplate 컴포넌트 내 customTemplateTitle 입력 필드를 Tooltip 컴포넌트로 감쌌습니다.
- 새로운 툴팁은 '커스텀된 템플릿의 이름을 수정할 수 있어요!' 메시지를 표시합니다.
- QuestionEditButton을 감싸던 조건부 렌더링 로직(retroCreateData.hasChangedOriginal 사용)을 제거했습니다.
- QuestionEditButton에 연결된 툴팁을 제거했습니다.
- QuestionEditButton은 이제 항상 표시됩니다.

### 🧐 Issue number and link (참고)

closes: #900

### 📚 Reference (참조)

-