### PR TITLE
스페이스 떠나기 모달 문구 및 옵션 개선

### DIFF
--- a/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
+++ b/apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx
@@ -76,12 +76,9 @@ export default function SpaceManageToggleMenu({
    */
   const handleLeaveSpace = () => {
     openAlertModal({
-      title: "스페이스를 떠나시겠어요?",
-      contents: "떠난 스페이스는 다시 돌아올 수 없어요",
+      title: "해당 스페이스를 떠나시겠어요?",
+      contents: "내 리스트에서 스페이스가 사라져요",
       onConfirm: () => leaveSpace(spaceId),
-      options: {
-        buttonText: ["취소", "떠나기"],
-      },
     });
   };
 


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 스페이스 떠나기 확인 모달의 제목과 내용 문구를 수정했습니다.
- 사용자에게 제공되는 안내 메시지를 명확하게 개선했습니다.
- 모달 호출 시 불필요한 옵션 설정을 제거하여 코드를 간소화했습니다.

### 🫨 Describe your Change (변경사항)

- apps/web/src/component/space/edit/SpaceManageToggleMenu.tsx 파일 내 openAlertModal 호출 로직 변경.
- 모달 제목을 "스페이스를 떠나시겠어요?"에서 "해당 스페이스를 떠나시겠어요?"로 수정.
- 모달 내용을 "떠난 스페이스는 다시 돌아올 수 없어요"에서 "내 리스트에서 스페이스가 사라져요"로 변경.
- 모달 버튼 텍스트를 명시적으로 설정하는 options.buttonText 속성 제거.

### 🧐 Issue number and link (참고)

closes: #913

### 📚 Reference (참조)

-