### PR TITLE
ConfirmModal 닫기 핸들러 일관성 개선

### DIFF
--- a/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
@@ -114,7 +114,7 @@ export default function TemplateCardManageToggleMenu({
                   autoClose: false,
                 },
                 onConfirm: handleCloseRetrospect,
-                onClose: close,
+                onClose: closeConfirmModal,
               })
             }
           >
@@ -155,7 +155,7 @@ export default function TemplateCardManageToggleMenu({
                   autoClose: false,
                 },
                 onConfirm: handleRemoveRetrospect,
-                onClose: close,
+                onClose: closeConfirmModal,
               })
             }
           >


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- TemplateCardManageToggleMenu 컴포넌트 내 ConfirmModal의 onClose 핸들러를 closeConfirmModal로 통일했습니다.
- 명확한 함수명 사용으로 코드 가독성을 높였습니다.

### 🫨 Describe your Change (변경사항)

- 회고 종료 확인 모달의 onClose 핸들러를 close에서 closeConfirmModal로 변경했습니다.
- 회고 삭제 확인 모달의 onClose 핸들러를 close에서 closeConfirmModal로 변경했습니다.

### 🧐 Issue number and link (참고)

closes: #898

### 📚 Reference (참조)

-