### PR TITLE
회고 템플릿 확인 문구 통일 및 간소화

### DIFF
--- a/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListConform.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/TemplateListConform.tsx
@@ -71,7 +71,7 @@ export function TemplateListConform() {
         height: 100%;
       `}
     >
-      <Header title={"추천받은 템플릿 질문들로\n회고를 진행할까요?"} />
+      <Header title={"해당 템플릿으로\n회고를 진행할까요?"} />
       <Spacing size={12} />
       <div
         css={css`

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -709,7 +709,7 @@ function ConfirmRetrospectTemplateFunnel() {
   const { data: templateData } = useGetSimpleTemplateInfo(selectedRecommendTemplateId);
   return (
     <Fragment>
-      <Header title={`해당 템플릿으로\n회고를 진행할까요?`} contents="템플릿을 기반으로 질문을 커스텀 할 수 있어요" />
+      <Header title={`해당 템플릿으로\n회고를 진행할까요?`} />
       <Spacing size={9} />
       <div
         css={css`
@@ -1050,7 +1050,7 @@ function RecommendRetrospectTemplateConfirmFunnel() {
         height: 100%;
       `}
     >
-      <Header title={"추천받은 템플릿 질문들로\n회고를 진행할까요?"} contents="템플릿을 기반으로 질문을 커스텀 할 수 있어요" />
+      <Header title={"해당 템플릿으로\n회고를 진행할까요?"} />
       <Spacing size={10} />
       <div
         css={css`
@@ -1119,7 +1119,7 @@ function CreateRetrospectQuestionFunnel() {
         height: 100%;
       `}
     >
-      <Header title={`추천받은 템플릿으로 회고를 진행할까요?`} contents="템플릿을 기반으로 질문을 커스텀할 수 있어요" />
+      <Header title={`해당 템플릿으로\n회고를 진행할까요?`} contents="템플릿을 기반으로 질문을 커스텀 할 수 있어요" />
       <Spacing size={4} />
       <div
         css={css`


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 템플릿 사용 확인 문구를 "해당 템플릿으로 회고를 진행할까요?"로 일관되게 적용했습니다.
- 일부 회고 템플릿 확인 화면에서 보조 문구를 제거하여 사용자 경험을 개선했습니다.

### 🫨 Describe your Change (변경사항)

- TemplateListConform 컴포넌트의 헤더 문구를 수정했습니다.
- AddSpacePage 내 ConfirmRetrospectTemplateFunnel에서 보조 문구를 제거했습니다.
- AddSpacePage 내 RecommendRetrospectTemplateConfirmFunnel의 헤더 문구 및 보조 문구를 수정/제거했습니다.
- AddSpacePage 내 CreateRetrospectQuestionFunnel의 헤더 문구를 통일했습니다.

### 🧐 Issue number and link (참고)

closes: #906

### 📚 Reference (참조)

-