### PR TITLE
첫 사용자 온보딩 및 스페이스 추가 툴팁 개선

### DIFF
--- a/apps/web/src/app/desktop/component/home/Onboarding/index.tsx
+++ b/apps/web/src/app/desktop/component/home/Onboarding/index.tsx
@@ -1,7 +1,4 @@
 import { css } from "@emotion/react";
-import { useState, useEffect } from "react";
-import Cookies from "js-cookie";
-import { COOKIE_KEYS } from "@/config/storage-keys";
 import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
@@ -26,63 +23,7 @@ const ONBOARDING_STEPS = [
   },
 ];
 
-const ONBOARDING_STORAGE_KEY = "layer_home_onboarding_closed";
-
-/**
- * 온보딩 닫기 기록 불러오기
- *
- * @returns Record<string, boolean>
- */
-const getOnboardingClosedRecord = (): Record<string, boolean> => {
-  const stored = localStorage.getItem(ONBOARDING_STORAGE_KEY);
-  return stored ? JSON.parse(stored) : {};
-};
-
-/**
- * 특정 사용자가 온보딩을 닫았는지 확인
- *
- * @param memberId
- * @returns boolean
- */
-const hasUserClosedOnboarding = (memberId: string): boolean => {
-  const record = getOnboardingClosedRecord();
-  return record[memberId] === true;
-};
-
-/**
- * 특정 사용자의 온보딩 닫기 기록 저장
- *
- * @param memberId
- */
-const saveOnboardingClosed = (memberId: string): void => {
-  const record = getOnboardingClosedRecord();
-  record[memberId] = true;
-  localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(record));
-};
-
-export default function Onboarding() {
-  const [isVisible, setIsVisible] = useState(false);
-  const memberId = Cookies.get(COOKIE_KEYS.memberId);
-
-  const handleClose = () => {
-    if (!memberId) return;
-
-    saveOnboardingClosed(memberId);
-    setIsVisible(false);
-  };
-
-  useEffect(() => {
-    if (!memberId) {
-      setIsVisible(false);
-      return;
-    }
-
-    const shouldShowOnboarding = !hasUserClosedOnboarding(memberId);
-    setIsVisible(shouldShowOnboarding);
-  }, [memberId]);
-
-  if (!isVisible) return null;
-
+export default function Onboarding({ onClose }: { onClose: () => void }) {
   return (
     <article
       css={css`
@@ -117,7 +58,7 @@ export default function Onboarding() {
         </Typography>
 
         <button
-          onClick={handleClose}
+          onClick={onClose}
           css={css`
             border: none;
             display: flex;

--- a/apps/web/src/app/desktop/component/home/Onboarding/useFirstTimeUser.ts
+++ b/apps/web/src/app/desktop/component/home/Onboarding/useFirstTimeUser.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect } from "react";
+import Cookies from "js-cookie";
+import { COOKIE_KEYS } from "@/config/storage-keys";
+
+// 기존 사용자의 저장 상태를 유지하기 위해 키 값은 변경하지 않는다.
+const FIRST_TIME_USER_STORAGE_KEY = "layer_home_onboarding_closed";
+
+/**
+ * 첫 사용자 졸업(온보딩 닫음) 기록 불러오기
+ *
+ * @returns Record<string, boolean>
+ */
+const getDismissedRecord = (): Record<string, boolean> => {
+  const stored = localStorage.getItem(FIRST_TIME_USER_STORAGE_KEY);
+  return stored ? JSON.parse(stored) : {};
+};
+
+/**
+ * 특정 사용자가 이미 첫 사용자 단계를 지났는지 확인
+ *
+ * @param memberId
+ * @returns boolean
+ */
+const hasUserDismissed = (memberId: string): boolean => {
+  const record = getDismissedRecord();
+  return record[memberId] === true;
+};
+
+/**
+ * 특정 사용자를 첫 사용자 단계 졸업으로 기록
+ *
+ * @param memberId
+ */
+const saveUserDismissed = (memberId: string): void => {
+  const record = getDismissedRecord();
+  record[memberId] = true;
+  localStorage.setItem(FIRST_TIME_USER_STORAGE_KEY, JSON.stringify(record));
+};
+
+/**
+ * 첫 사용자 여부 상태
+ *
+ * 아직 온보딩을 닫지 않은 사용자를 첫 사용자로 본다(`isFirstTimeUser` true).
+ * 이 기준은 온보딩 노출뿐 아니라, 첫 사용자에게 가려야 하는 다른 영역의
+ * 표시 여부를 함께 제어하는 데 사용된다.
+ */
+export function useFirstTimeUser() {
+  const [isFirstTimeUser, setIsFirstTimeUser] = useState(false);
+  const memberId = Cookies.get(COOKIE_KEYS.memberId);
+
+  const dismiss = () => {
+    if (!memberId) return;
+
+    saveUserDismissed(memberId);
+    setIsFirstTimeUser(false);
+  };
+
+  useEffect(() => {
+    if (!memberId) {
+      setIsFirstTimeUser(false);
+      return;
+    }
+
+    setIsFirstTimeUser(!hasUserDismissed(memberId));
+  }, [memberId]);
+
+  return { isFirstTimeUser, dismiss };
+}

--- a/apps/web/src/app/desktop/home/HomePage.tsx
+++ b/apps/web/src/app/desktop/home/HomePage.tsx
@@ -5,8 +5,11 @@ import InProgressRetrospectsWrapper from "@/app/desktop/component/home/InProgres
 import ActionItemsWrapper from "@/app/desktop/component/home/ActionItemsWrapper";
 import AnalyticsWrapper from "../component/home/AnalyticsWrapper";
 import Onboarding from "../component/home/Onboarding";
+import { useFirstTimeUser } from "../component/home/Onboarding/useFirstTimeUser";
 
 export function HomePage() {
+  const { isFirstTimeUser, dismiss: dismissFirstTimeUser } = useFirstTimeUser();
+
   return (
     <section
       css={css`
@@ -21,10 +24,10 @@ export function HomePage() {
       <HomePageHeader />
 
       {/* ---------- 온보딩 ---------- */}
-      <Onboarding />
+      {isFirstTimeUser && <Onboarding onClose={dismissFirstTimeUser} />}
 
-      {/* ---------- 작성중인 회고 ---------- */}
-      <InProgressRetrospectsWrapper />
+      {/* ---------- 작성중인 회고 (첫 사용자에게는 숨김) ---------- */}
+      {!isFirstTimeUser && <InProgressRetrospectsWrapper />}
 
       {/* ---------- 실행목표 ---------- */}
       <ActionItemsWrapper />

--- a/apps/web/src/component/common/tip/Tooltip.tsx
+++ b/apps/web/src/component/common/tip/Tooltip.tsx
@@ -106,6 +106,9 @@ function Content({
 
   const { styles, attributes, update } = usePopper(context.referenceEl, context.popperEl, {
     placement,
+    // 포털(body)로 렌더되는 툴팁이 중첩 스크롤 컨테이너 안의 트리거를 따라갈 때
+    // absolute 전략은 스크롤마다 위치가 출렁인다. fixed(뷰포트 기준)로 두면 매끄럽게 따라온다.
+    strategy: "fixed",
     modifiers: [
       {
         name: "offset",


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 첫 사용자 온보딩 로직을 `useFirstTimeUser` 훅으로 분리하여 재사용성을 높였습니다.
- 홈 화면에서 첫 사용자에게는 온보딩을 노출하고, 진행 중인 회고 목록을 숨겨 집중도를 향상시켰습니다.
- 스페이스 추가 버튼의 툴팁을 공통 `Tooltip` 컴포넌트로 교체하고, LNB 상태에 따른 위치 조정을 개선했습니다.

### 🫨 Describe your Change (변경사항)

- `useFirstTimeUser` 훅 도입: 첫 사용자 여부 및 온보딩 닫기 로직을 캡슐화했습니다.
- 홈 페이지 온보딩 조건부 렌더링: `isFirstTimeUser` 상태에 따라 온보딩을 표시하고, 진행 중인 회고 목록을 숨기도록 변경했습니다.
- 스페이스 추가 버튼 툴팁 개선: 기존 커스텀 툴팁을 공통 `Tooltip` 컴포넌트로 대체하고, LNB 확장/축소 시 툴팁 위치를 동적으로 조정합니다.
- `Tooltip` 컴포넌트 개선: `popper` 전략을 `fixed`로 변경하고, 트리거 요소 크기 변경 시 툴팁 위치를 재계산하도록 `ResizeObserver`를 추가했습니다.
- `recharts` 라이브러리 버전 업데이트: `2.12.7`에서 `2.15.4`로 업데이트하여 React 19 지원을 추가했습니다.

### 🧐 Issue number and link (참고)

closes: #903

### 📚 Reference (참조)

-