### PR TITLE
회고 생성 폼 상태 관리 개선

### DIFF
--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -52,7 +52,7 @@ import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { encryptId } from "@/utils/space/cryptoKey";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
 import { useAtom, useAtomValue } from "jotai";
-import { CREATE_RETROSPECT_INIT_ATOM, DEFAULT_QUESTIONS } from "@/store/retrospect/retrospectCreate";
+import { CREATE_RETROSPECT_INIT_ATOM, DEFAULT_QUESTIONS, retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 import { CREATE_SPACE_INIT_ATOM } from "@/store/space/spaceAtom";
 import { useRetrospectCreateReset } from "@/hooks/store/useRetrospectCreateReset";
 import { useSpaceCreateReset } from "@/hooks/store/useSpaceCreateReset";
@@ -1199,6 +1199,7 @@ function CreateRetrospectQuestionFunnel() {
 function CreateRetrospectDeadlineFunnel() {
   const { questions, selectedRecommendTemplate, setSpaceId, deadLine, setDeadLine, title, description, selectedCategory, setFlow } =
     useContext(PhaseContext);
+  const { isNewForm, hasChangedOriginal } = useAtomValue(retrospectCreateAtom);
   const { selectedValue, isChecked, onChange } = useRadioButton();
   const { toast } = useToast();
   const { mutateAsync: postSpace } = useApiPostSpace();
@@ -1231,8 +1232,8 @@ function CreateRetrospectDeadlineFunnel() {
         introduction: "",
         questions: [...DEFAULT_QUESTIONS, ...questions],
         deadline: deadLine,
-        isNewForm: false,
-        hasChangedOriginal: false,
+        isNewForm,
+        hasChangedOriginal,
         curFormId: selectedRecommendTemplate!.id,
       } as RetrospectCreateReq;
       const res = await postRetrospect(


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 생성 마감 기한 퍼널에서 폼의 신규 여부 및 원본 변경 여부 상태를 전역 Jotai atom에서 가져오도록 변경했습니다.
- 이를 통해 폼 상태 관리가 더욱 유연하고 중앙화되었습니다.

### 🫨 Describe your Change (변경사항)

- `retrospectCreateAtom`을 `AddSpacePage.tsx`에 임포트했습니다.
- `CreateRetrospectDeadlineFunnel` 컴포넌트에서 `retrospectCreateAtom`을 사용하여 `isNewForm`과 `hasChangedOriginal` 값을 가져오도록 추가했습니다.
- 기존에 하드코딩된 `isNewForm` 및 `hasChangedOriginal` 값을 동적으로 가져온 값으로 대체했습니다.

### 🧐 Issue number and link (참고)

closes: #910

### 📚 Reference (참조)

-