### PR TITLE
회고 생성 시 isNewForm 및 hasChangedOriginal 상태 반영

### DIFF
--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -52,7 +52,7 @@ import { LoadingModal } from "@/component/common/Modal/LoadingModal";
 import { encryptId } from "@/utils/space/cryptoKey";
 import useDesktopBasicModal from "@/hooks/useDesktopBasicModal";
 import { useAtom, useAtomValue } from "jotai";
-import { CREATE_RETROSPECT_INIT_ATOM, DEFAULT_QUESTIONS } from "@/store/retrospect/retrospectCreate";
+import { CREATE_RETROSPECT_INIT_ATOM, DEFAULT_QUESTIONS, retrospectCreateAtom } from "@/store/retrospect/retrospectCreate";
 import { CREATE_SPACE_INIT_ATOM } from "@/store/space/spaceAtom";
 import { useRetrospectCreateReset } from "@/hooks/store/useRetrospectCreateReset";
 import { useSpaceCreateReset } from "@/hooks/store/useSpaceCreateReset";
@@ -1199,6 +1199,7 @@ function CreateRetrospectQuestionFunnel() {
 function CreateRetrospectDeadlineFunnel() {
   const { questions, selectedRecommendTemplate, setSpaceId, deadLine, setDeadLine, title, description, selectedCategory, setFlow } =
     useContext(PhaseContext);
+  const { isNewForm, hasChangedOriginal } = useAtomValue(retrospectCreateAtom);
   const { selectedValue, isChecked, onChange } = useRadioButton();
   const { toast } = useToast();
   const { mutateAsync: postSpace } = useApiPostSpace();
@@ -1231,8 +1232,8 @@ function CreateRetrospectDeadlineFunnel() {
         introduction: "",
         questions: [...DEFAULT_QUESTIONS, ...questions],
         deadline: deadLine,
-        isNewForm: false,
-        hasChangedOriginal: false,
+        isNewForm,
+        hasChangedOriginal,
         curFormId: selectedRecommendTemplate!.id,
       } as RetrospectCreateReq;
       const res = await postRetrospect(


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 생성 시 `isNewForm` 및 `hasChangedOriginal` 상태를 동적으로 반영하도록 수정했습니다.
- `retrospectCreateAtom`에서 해당 상태 값을 가져와 사용합니다.
- 기존의 하드코딩된 `false` 값을 제거했습니다.

### 🫨 Describe your Change (변경사항)

- `retrospectCreateAtom`을 `AddSpacePage.tsx` 파일에 임포트했습니다.
- `CreateRetrospectDeadlineFunnel` 컴포넌트 내에서 `retrospectCreateAtom`으로부터 `isNewForm`과 `hasChangedOriginal` 값을 읽어오도록 변경했습니다.
- 회고 생성 시 전달되는 데이터 객체에서 `isNewForm`과 `hasChangedOriginal` 필드를 `retrospectCreateAtom`에서 가져온 값으로 설정하도록 수정했습니다.

### 🧐 Issue number and link (참고)

closes: #910

### 📚 Reference (참조)

-