### PR TITLE
회고 템플릿 리스트: 리더 권한 로직 개선 및 컨텍스트 분리

### DIFF
--- a/apps/web/src/app/desktop/component/retrospect/template/list/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospect/template/list/index.tsx
@@ -2,7 +2,11 @@ import { useRequiredParams } from "@/hooks/useRequiredParams";
 import { useTabs } from "@/hooks/useTabs";
 import { useToast } from "@/hooks/useToast";
 import { css } from "@emotion/react";
-import { createContext, useEffect, useRef } from "react";
+import { createContext, useEffect } from "react";
+import { useAtomValue } from "jotai";
+import { currentSpaceState } from "@/store/space/spaceAtom";
+import { branchLayoutAtom } from "@/store/auth/authAtom";
+import { isSpaceLeader } from "@/utils/userUtil";
 import { TemplateListTabButton } from "./TemplateListTab/TemplateListTabButton";
 import { CustomTemplateList } from "@/component/retrospect/template/list";
 import { useGetDefaultTemplateList } from "@/hooks/api/template/useGetDefaultTemplateList";
@@ -16,8 +20,6 @@ import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
 import { useSearchParams } from "react-router-dom";
 import { trackEvent } from "@/lib/google-analytics";
 import { GA_EVENTS } from "@/lib/google-analytics/events";
-import { useAtomValue } from "jotai";
-import { branchLayoutAtom } from "@/store/auth/authAtom";
 import { Button } from "@/component/common/button";
 import { useFunnelModal } from "@/hooks/useFunnelModal";
 import { TemplateRecommend } from "../recommend";
@@ -112,7 +114,8 @@ function RecommendBanner({ onClickRecommend }: { onClickRecommend: () => void })
 
 export function TemplateList() {
   const { toast } = useToast();
-  const isLeader = useRef(false);
+  const currentSpace = useAtomValue(currentSpaceState);
+  const isLeader = isSpaceLeader(currentSpace?.leader?.id);
   const params = useRequiredParams<{ spaceId?: string }>();
   const [searchParams] = useSearchParams();
   const spaceId = params.spaceId || searchParams.get("spaceId") || "";
@@ -163,7 +166,7 @@ export function TemplateList() {
           margin-top: 2rem;
         `}
       >
-        <TemplateListPageContext.Provider value={{ spaceId, isLeader: isLeader.current }}>
+        <TemplateListPageContext.Provider value={{ spaceId, isLeader }}>
           {branchLayout === "A" ? <InfoBanner /> : <RecommendBanner onClickRecommend={handleClickRecommend} />}
           <ul
             css={css`

--- a/apps/web/src/component/retrospect/template/list/CustomTemplateListItem.tsx
+++ b/apps/web/src/component/retrospect/template/list/CustomTemplateListItem.tsx
@@ -18,7 +18,8 @@ import { useModal } from "@/hooks/useModal";
 import { useFunnelModal } from "@/hooks/useFunnelModal";
 import CustomTemplateListDetailItem from "@/app/desktop/component/retrospect/template/list/CustomTemplateListDetailItem";
 import { getDeviceType } from "@/utils/deviceUtils";
-import { TemplateListPageContext } from "@/app/mobile/retrospect/template/list/TemplateListPage";
+import { TemplateListPageContext as DesktopTemplateListPageContext } from "@/app/desktop/component/retrospect/template/list";
+import { TemplateListPageContext as MobileTemplateListPageContext } from "@/app/mobile/retrospect/template/list/TemplateListPage";
 
 type CustomTemplateListItem = {
   id: number;
@@ -35,13 +36,16 @@ export function CustomTemplateListItem({ id, title, tag, date }: CustomTemplateL
   const MENU_DELETE = "delete";
   const SHEET_ID = `modifyTemplateSheet_${id}`;
 
-  const { spaceId, readOnly, isLeader } = useContext(TemplateListPageContext);
+  const { isDesktop } = getDeviceType();
+  const desktopContext = useContext(DesktopTemplateListPageContext);
+  const mobileContext = useContext(MobileTemplateListPageContext);
+  const { spaceId, isLeader } = isDesktop ? desktopContext : mobileContext;
+  const readOnly = isDesktop ? true : mobileContext.readOnly;
   const { open } = useModal();
   const { openBottomSheet, closeBottomSheet } = useBottomSheet();
   const { value: templateTitle, handleInputChange: handleChangeTitle } = useInput(title);
   const { mutate: patchTemplateTitle } = usePatchTemplateTitle(+spaceId);
   const { mutate: deleteCustomTemplate } = useDeleteCustomTemplate(+spaceId);
-  const { isDesktop } = getDeviceType();
 
   const handleSubmitTitle = () => {
     patchTemplateTitle({ formId: id, formTitle: templateTitle });


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 데스크톱 회고 템플릿 리스트에서 리더 권한 확인 로직을 Jotai 상태 기반으로 개선했습니다.
- CustomTemplateListItem 컴포넌트에서 데스크톱/모바일 환경에 따른 컨텍스트를 분리하여 사용하도록 수정했습니다.
- readOnly 속성 처리를 데스크톱 환경에 맞게 명확히 했습니다.

### 🫨 Describe your Change (변경사항)

- apps/web/src/app/desktop/component/retrospect/template/list/index.tsx 파일에서 isLeader 상태를 useRef 대신 currentSpaceState와 isSpaceLeader 유틸리티를 사용하여 관리하도록 변경했습니다.
- TemplateListPageContext.Provider에 전달되는 isLeader 값을 개선된 로직으로 반영했습니다.
- apps/web/src/component/retrospect/template/list/CustomTemplateListItem.tsx 파일에서 TemplateListPageContext를 DesktopTemplateListPageContext와 MobileTemplateListPageContext로 분리하여 임포트했습니다.
- CustomTemplateListItem 내부에서 isDesktop 여부에 따라 적절한 컨텍스트를 동적으로 사용하도록 수정했습니다.
- 데스크톱 환경에서 readOnly 값을 true로 명시하고, 모바일 환경에서는 기존 컨텍스트에서 가져오도록 처리했습니다.

### 🧐 Issue number and link (참고)

closes: #899

### 📚 Reference (참조)

-