### PR TITLE
React Query queryKeys 리팩토링 및 관리 개선

### DIFF
--- a/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
+++ b/apps/web/src/app/desktop/component/retrospectCreate/index.tsx
@@ -1,3 +1,5 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { createContext, useCallback, useEffect } from "react";
 import { ProgressBar } from "@/component/common/ProgressBar";
 import { css } from "@emotion/react";
@@ -63,11 +65,11 @@ export function RetrospectCreate() {
         onSuccess: async () => {
           // 사용자가 템플릿을 변경하거나, 회고를 생성할 때 변경된 정보가 있으면 스페이스 정보를 다시 가져옵니다.
           await queryClient.invalidateQueries({
-            queryKey: ["getSpaceInfo", spaceIdNumber],
+            queryKey: spaceQueryKeys.info(spaceIdNumber),
           });
           // 사용자가 회고를 추가했다면, 회고 리스트 조회를 다시 리패치합니다.
           await queryClient.invalidateQueries({
-            queryKey: ["getRetrospects", spaceIdNumber],
+            queryKey: retrospectQueryKeys.list(spaceIdNumber),
           });
           navigate(PATHS.spaceDetail(String(spaceIdNumber)));
           closeFunnelModal();

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -1,3 +1,8 @@
+<<<<<<< Updated upstream
+=======
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
+import { Z_INDEX } from "@/style/zIndex";
+>>>>>>> Stashed changes
 import "swiper/css";
 import "swiper/css/pagination";
 import "swiper/css/navigation";
@@ -1243,7 +1248,7 @@ function CreateRetrospectDeadlineFunnel() {
             toast.success("스페이스와 회고가 생성되었어요!");
             // 스페이스 생성이 완료되면 스페이스 목록을 리패치
             queryClient.invalidateQueries({
-              queryKey: ["spaces"],
+              queryKey: spaceQueryKeys.lists,
             });
             setFlow("COMPLETE", 0);
           },

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -1,8 +1,3 @@
-<<<<<<< Updated upstream
-=======
-import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
-import { Z_INDEX } from "@/style/zIndex";
->>>>>>> Stashed changes
 import "swiper/css";
 import "swiper/css/pagination";
 import "swiper/css/navigation";
@@ -84,6 +79,7 @@ import { splitTemplateIntroduction } from "@/utils/retrospect/splitTemplateIntro
 import { useGetSimpleTemplateInfo } from "@/hooks/api/template/useGetSimpleTemplateInfo";
 import { useApiPostTemplateChoiceListView } from "@/hooks/api/backoffice/useApiPostTemplateChoiceListView";
 import { resolveFormTag } from "@/utils/template/resolveFormTag";
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 
 type flowType = "INFO" | "RECOMMEND" | "RECOMMEND_PROGRESS" | "CREATE" | "COMPLETE";
 type templateType = { id: number; title: string; imageUrl: string; templateName: string };

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
@@ -1,3 +1,8 @@
+<<<<<<< Updated upstream
+=======
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
+import { Z_INDEX } from "@/style/zIndex";
+>>>>>>> Stashed changes
 import { Button, ButtonProvider } from "@/component/common/button";
 import { TextArea } from "@/component/common/input";
 import { Icon } from "@/component/common/Icon";
@@ -25,7 +30,7 @@ type ActionItemAddSectionProps = {
 export default function ActionItemAddSection({ spaceId, retrospectId, onClose, variant = "team" }: ActionItemAddSectionProps) {
   const queryClient = useQueryClient();
   const isPersonal = variant === "personal";
-  const actionItemQueryKey = isPersonal ? ["getPersonalActionItemListBySpace", spaceId] : ["getTeamActionItemList", spaceId];
+  const actionItemQueryKey = isPersonal ? actionItemQueryKeys.personalBySpace(spaceId) : actionItemQueryKeys.team(spaceId);
 
   const { toast } = useToast();
   const { data: retrospects } = useQuery(useApiOptionsGetRetrospects(spaceId));

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemAddSection.tsx
@@ -1,8 +1,4 @@
-<<<<<<< Updated upstream
-=======
 import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
-import { Z_INDEX } from "@/style/zIndex";
->>>>>>> Stashed changes
 import { Button, ButtonProvider } from "@/component/common/button";
 import { TextArea } from "@/component/common/input";
 import { Icon } from "@/component/common/Icon";

--- a/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
+++ b/apps/web/src/component/retrospect/space/actionItems/ActionItemsEditSection.tsx
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { useState } from "react";
 import { DragDropContext, Draggable, Droppable, DropResult } from "@hello-pangea/dnd";
 
@@ -37,7 +38,7 @@ const INIT_TEMP_ID = -1;
 export default function ActionItemsEditSection({ spaceId, retrospectId, todoList, onClose, variant = "team" }: ActionItemsEditSectionProps) {
   const queryClient = useQueryClient();
   const isPersonal = variant === "personal";
-  const actionItemQueryKey = isPersonal ? ["getPersonalActionItemListBySpace", spaceId] : ["getTeamActionItemList", spaceId];
+  const actionItemQueryKey = isPersonal ? actionItemQueryKeys.personalBySpace(spaceId) : actionItemQueryKeys.team(spaceId);
   const listField = isPersonal ? "personalActionItemList" : "teamActionItemList";
 
   const { toast } = useToast();

--- a/apps/web/src/component/retrospect/space/members/MemberManagement.tsx
+++ b/apps/web/src/component/retrospect/space/members/MemberManagement.tsx
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import React, { useState, useRef, useEffect } from "react";
 import { css } from "@emotion/react";
 import Cookies from "js-cookie";
@@ -91,9 +92,9 @@ export default function MemberManagement({ spaceId }: { spaceId: number }) {
         {
           onSuccess: () => {
             // 스페이스 정보를 리패치
-            queryClient.invalidateQueries({ queryKey: ["spaces"] });
+            queryClient.invalidateQueries({ queryKey: spaceQueryKeys.lists });
             // 멤버 정보를 리패치 (혹여나 탈퇴하는 경우를 고려)
-            queryClient.invalidateQueries({ queryKey: ["getMembers", spaceId] });
+            queryClient.invalidateQueries({ queryKey: spaceQueryKeys.members(spaceId) });
             setCurrentView("main");
             close();
           },

--- a/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
+++ b/apps/web/src/component/retrospect/template/card/TemplateCardManageToggleMenu.tsx
@@ -1,3 +1,4 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
 import { DesktopDateTimeInput } from "@/app/desktop/component/retrospectCreate/DesktopDateTimeInput";
 import { ButtonProvider } from "@/component/common/button";
 import { Icon } from "@/component/common/Icon";
@@ -225,7 +226,7 @@ export function ModifyRetrospect(props: {
       if (location.pathname === "/") {
         // 홈 화면에서 만약 수정을 할 경우에 모든 회고 목록을 invalidate 상태로 변경해줘요.
         await queryClient.invalidateQueries({
-          queryKey: ["getAllRetrospects"],
+          queryKey: retrospectQueryKeys.all,
         });
       }
     }

--- a/apps/web/src/component/space/view/ActionItemListView.tsx
+++ b/apps/web/src/component/space/view/ActionItemListView.tsx
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { css } from "@emotion/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Cookies from "js-cookie";
@@ -106,7 +107,7 @@ export function ActionItemListView({ isPossibleMake, teamActionList, spaceId, le
 
           if (spaceId) {
             await queryClient.invalidateQueries({
-              queryKey: ["getTeamActionItemList", spaceId.toString()],
+              queryKey: actionItemQueryKeys.team(spaceId),
             });
           }
         },

--- a/apps/web/src/hooks/api/actionItem/queryKeys.ts
+++ b/apps/web/src/hooks/api/actionItem/queryKeys.ts
@@ -1,0 +1,11 @@
+type QueryId = number | null | undefined;
+
+export const actionItemQueryKeys = {
+  personal: ["personalActionItemList"] as const,
+  member: (memberId: QueryId) => ["actionItemList", "member", memberId] as const,
+  space: (spaceId: QueryId) => ["actionItemList", "space", spaceId] as const,
+  team: (spaceId: QueryId) => ["getTeamActionItemList", spaceId] as const,
+  recentTeam: (spaceId: QueryId) => ["getRecentTeamActionItemList", spaceId] as const,
+  recentPersonal: (spaceId: QueryId) => ["getRecentPersonalActionItemList", spaceId] as const,
+  personalBySpace: (spaceId: QueryId) => ["getPersonalActionItemListBySpace", spaceId] as const,
+};

--- a/apps/web/src/hooks/api/actionItem/useAPiOptionsRecentTeamActionList.ts
+++ b/apps/web/src/hooks/api/actionItem/useAPiOptionsRecentTeamActionList.ts
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { UseQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -14,8 +15,8 @@ const getRecentTeamActionItemList = async (spaceId: number | undefined) => {
 
 export const useAPiOptionsRecentTeamActionList = (
   spaceId?: number,
-): UseQueryOptions<RecentActionItemList, Error, RecentActionItemList, [string, number]> => ({
-  queryKey: ["getTeamActionItemList", spaceId!],
+): UseQueryOptions<RecentActionItemList, Error, RecentActionItemList, ReturnType<typeof actionItemQueryKeys.recentTeam>> => ({
+  queryKey: actionItemQueryKeys.recentTeam(spaceId),
   queryFn: () => getRecentTeamActionItemList(spaceId),
   select(data) {
     return data;

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetPersonalActionItemListBySpace.ts
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -10,7 +11,7 @@ const getPersonalActionItemListBySpace = async (spaceId: number) => {
 
 export const useApiOptionsGetPersonalActionItemListBySpace = (spaceId?: number) =>
   queryOptions({
-    queryKey: ["getPersonalActionItemListBySpace", spaceId] as const,
+    queryKey: actionItemQueryKeys.personalBySpace(spaceId),
     queryFn: () => {
       if (spaceId == null) throw new Error("spaceId is required");
       return getPersonalActionItemListBySpace(spaceId);

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetRecentPersonalActionList.ts
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -23,7 +24,7 @@ const getRecentPersonalActionItemList = async (spaceId: number) => {
 
 export const useApiOptionsGetRecentPersonalActionList = (spaceId?: number) =>
   queryOptions({
-    queryKey: ["getRecentPersonalActionItemList", spaceId] as const,
+    queryKey: actionItemQueryKeys.recentPersonal(spaceId),
     queryFn: () => {
       if (spaceId == null) throw new Error("spaceId is required");
       return getRecentPersonalActionItemList(spaceId);

--- a/apps/web/src/hooks/api/actionItem/useApiOptionsGetTeamActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useApiOptionsGetTeamActionItemList.ts
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { UseQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -10,8 +11,8 @@ const getTeamActionItemList = async (spaceId: number | undefined) => {
 
 export const useApiOptionsGetTeamActionItemList = (
   spaceId?: number,
-): UseQueryOptions<TeamActionItemType, Error, TeamActionItemType, [string, number]> => ({
-  queryKey: ["getTeamActionItemList", spaceId!],
+): UseQueryOptions<TeamActionItemType, Error, TeamActionItemType, ReturnType<typeof actionItemQueryKeys.team>> => ({
+  queryKey: actionItemQueryKeys.team(spaceId),
   queryFn: () => getTeamActionItemList(spaceId),
   select(data) {
     return data;

--- a/apps/web/src/hooks/api/actionItem/useGetActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useGetActionItemList.ts
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -17,7 +18,7 @@ export const useGetActionItemList = <TData = PersonalActionItemListType>({
 
   return useQuery<PersonalActionItemListType, Error, TData>({
     queryFn: () => getActionItemList(),
-    queryKey: [memberId],
+    queryKey: actionItemQueryKeys.member(memberId),
     ...options,
   });
 };

--- a/apps/web/src/hooks/api/actionItem/useGetPersonalActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useGetPersonalActionItemList.ts
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -21,7 +22,7 @@ export const useGetPersonalActionItemList = <TData = PersonalActionItemListType>
 
   return useQuery<PersonalActionItemListType, Error, TData>({
     queryFn: () => getPersonalActionItemList(),
-    queryKey: ["personalActionItemList"],
+    queryKey: actionItemQueryKeys.personal,
     ...options,
   });
 };

--- a/apps/web/src/hooks/api/actionItem/useGetSpaceActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useGetSpaceActionItemList.ts
@@ -1,3 +1,4 @@
+import { actionItemQueryKeys } from "@/hooks/api/actionItem/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -25,6 +26,6 @@ export const useGetSpaceActionItemList = ({ spaceId }: { spaceId: number }) => {
 
   return useQuery({
     queryFn: () => getActionItemList(),
-    queryKey: [spaceId],
+    queryKey: actionItemQueryKeys.space(spaceId),
   });
 };

--- a/apps/web/src/hooks/api/analysis/queryKeys.ts
+++ b/apps/web/src/hooks/api/analysis/queryKeys.ts
@@ -1,0 +1,7 @@
+type QueryId = number | null | undefined;
+
+export const analysisQueryKeys = {
+  member: ["myAnalysis"] as const,
+  result: (spaceId: QueryId, retrospectId: QueryId) => ["analysis", spaceId, retrospectId] as const,
+  answers: (spaceId: QueryId, retrospectId: QueryId) => ["analysisAnswers", spaceId, retrospectId] as const,
+};

--- a/apps/web/src/hooks/api/analysis/useApiGetAnalysis.ts
+++ b/apps/web/src/hooks/api/analysis/useApiGetAnalysis.ts
@@ -1,3 +1,4 @@
+import { analysisQueryKeys } from "@/hooks/api/analysis/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -50,7 +51,7 @@ export const useApiGetAnalysis = ({ spaceId, retrospectId }: { spaceId: number; 
 
   return useQuery({
     queryFn: () => getAnalysis(),
-    queryKey: [spaceId, retrospectId],
+    queryKey: analysisQueryKeys.result(spaceId, retrospectId),
     retry: 1,
   });
 };

--- a/apps/web/src/hooks/api/analysis/useApiGetMemberAnalysis.ts
+++ b/apps/web/src/hooks/api/analysis/useApiGetMemberAnalysis.ts
@@ -1,3 +1,4 @@
+import { analysisQueryKeys } from "@/hooks/api/analysis/queryKeys";
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -22,7 +23,7 @@ export const useApiGetMemberAnalysis = ({ options }: UseApiGetMemberAnalysisProp
 
   return useQuery<AnalysisType>({
     queryFn: () => getAnalysis(),
-    queryKey: ["myAnalysis"],
+    queryKey: analysisQueryKeys.member,
     ...options,
   });
 };

--- a/apps/web/src/hooks/api/auth/queryKeys.ts
+++ b/apps/web/src/hooks/api/auth/queryKeys.ts
@@ -1,0 +1,3 @@
+export const authQueryKeys = {
+  user: ["getUser"] as const,
+};

--- a/apps/web/src/hooks/api/auth/useApiGetUser.ts
+++ b/apps/web/src/hooks/api/auth/useApiGetUser.ts
@@ -1,3 +1,4 @@
+import { authQueryKeys } from "@/hooks/api/auth/queryKeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -10,7 +11,7 @@ export const useApiGetUser = () => {
   };
 
   return useSuspenseQuery({
-    queryKey: ["getUser"],
+    queryKey: authQueryKeys.user,
     queryFn: () => getUser(),
   });
 };

--- a/apps/web/src/hooks/api/retrospect/analysis/useGetAnalysisAnswer.ts
+++ b/apps/web/src/hooks/api/retrospect/analysis/useGetAnalysisAnswer.ts
@@ -1,3 +1,4 @@
+import { analysisQueryKeys } from "@/hooks/api/analysis/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -72,7 +73,7 @@ export const useGetAnalysisAnswer = ({ spaceId, retrospectId }: getAnalysisAnswe
   };
   return useQuery({
     queryFn: () => getAnalysisAnswer(),
-    queryKey: [spaceId, retrospectId, "analysis"],
+    queryKey: analysisQueryKeys.answers(spaceId, retrospectId),
     retry: 1,
     enabled: !!spaceId && !!retrospectId,
   });

--- a/apps/web/src/hooks/api/retrospect/close/useApiCloseRetrospect.ts
+++ b/apps/web/src/hooks/api/retrospect/close/useApiCloseRetrospect.ts
@@ -1,3 +1,4 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
 import { useMutation } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -18,7 +19,7 @@ export const useApiCloseRetrospect = () => {
     onSuccess: async (_, variable) => {
       toast.success("회고 마감이 완료되었어요");
       await queryClient.invalidateQueries({
-        queryKey: ["getRetrospects", variable.spaceId],
+        queryKey: retrospectQueryKeys.list(variable.spaceId),
       });
     },
     onError: () => {

--- a/apps/web/src/hooks/api/retrospect/create/usePostRetrospectCreate.ts
+++ b/apps/web/src/hooks/api/retrospect/create/usePostRetrospectCreate.ts
@@ -1,3 +1,4 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
 import { useMutation } from "@tanstack/react-query";
 import { useResetAtom } from "jotai/utils";
 import { useNavigate } from "react-router-dom";
@@ -37,7 +38,7 @@ export const usePostRetrospectCreate = (spaceId?: number) => {
 
       resetRetroCreateData();
       queryClient.invalidateQueries({
-        queryKey: ["getRetrospects", String(spaceId)],
+        queryKey: retrospectQueryKeys.list(spaceId),
       });
 
       if (isMobile) {

--- a/apps/web/src/hooks/api/retrospect/edit/usePatchRetrospect.ts
+++ b/apps/web/src/hooks/api/retrospect/edit/usePatchRetrospect.ts
@@ -1,3 +1,4 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -24,8 +25,7 @@ export const usePatchRetrospect = () => {
     onSuccess: async (_, variable) => {
       toast.success("회고 정보가 수정되었어요!");
       await queryClient.invalidateQueries({
-        // TODO: queryKey 타입 재정의 필요
-        queryKey: ["getRetrospects", variable.spaceId],
+        queryKey: retrospectQueryKeys.list(variable.spaceId),
       });
     },
     onError: () => {

--- a/apps/web/src/hooks/api/retrospect/queryKeys.ts
+++ b/apps/web/src/hooks/api/retrospect/queryKeys.ts
@@ -1,0 +1,9 @@
+import type { RecommendTemplateType } from "@/types/retrospectCreate/recommend";
+
+type QueryId = number | null | undefined;
+
+export const retrospectQueryKeys = {
+  all: ["getAllRetrospects"] as const,
+  list: (spaceId: QueryId) => ["getRetrospects", spaceId] as const,
+  recommendation: (recommendValue: RecommendTemplateType) => ["recommendTemplate", recommendValue] as const,
+};

--- a/apps/web/src/hooks/api/retrospect/recommend/useApiRecommendTemplate.ts
+++ b/apps/web/src/hooks/api/retrospect/recommend/useApiRecommendTemplate.ts
@@ -1,3 +1,4 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -24,7 +25,7 @@ export const useApiRecommendTemplate = (recommendValue: RecommendTemplateType) =
   };
 
   return useQuery({
-    queryKey: ["recommendTemplate", recommendValue],
+    queryKey: retrospectQueryKeys.recommendation(recommendValue),
     queryFn: () => recommendTemplate(recommendValue),
     staleTime: Infinity,
   });

--- a/apps/web/src/hooks/api/retrospect/useApiDeleteRetrospect.ts
+++ b/apps/web/src/hooks/api/retrospect/useApiDeleteRetrospect.ts
@@ -1,3 +1,4 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -17,9 +18,9 @@ export const useApiDeleteRetrospect = () => {
     mutationFn: ({ spaceId, retrospectId }: { spaceId: number | undefined; retrospectId: number | undefined }) =>
       retrospectDelete(spaceId, retrospectId),
     onMutate: async (variables) => {
-      await queryClient.cancelQueries({ queryKey: ["getRetrospects", variables.spaceId] });
-      const prevList = queryClient.getQueryData(["getRetrospects", variables.spaceId]);
-      queryClient.setQueryData(["getRetrospects", variables.spaceId], (old: RetrospectResponse) => {
+      await queryClient.cancelQueries({ queryKey: retrospectQueryKeys.list(variables.spaceId) });
+      const prevList = queryClient.getQueryData(retrospectQueryKeys.list(variables.spaceId));
+      queryClient.setQueryData(retrospectQueryKeys.list(variables.spaceId), (old: RetrospectResponse) => {
         return {
           ...old,
           retrospects: old?.retrospects?.filter((item) => item.retrospectId !== variables.retrospectId),
@@ -30,10 +31,10 @@ export const useApiDeleteRetrospect = () => {
     onError: (error, variables, context) => {
       toast.error("회고 삭제 중 오류가 발생했어요, 다시 시도해주세요");
       console.error("mutate error with", error);
-      queryClient.setQueryData(["getRetrospects", variables.spaceId], context?.prevList);
+      queryClient.setQueryData(retrospectQueryKeys.list(variables.spaceId), context?.prevList);
     },
     onSettled: async (_, __, variables) => {
-      await queryClient.invalidateQueries({ queryKey: ["getRetrospects", variables.spaceId] });
+      await queryClient.invalidateQueries({ queryKey: retrospectQueryKeys.list(variables.spaceId) });
     },
     onSuccess: () => {
       toast.success("회고 삭제가 완료되었어요");

--- a/apps/web/src/hooks/api/retrospect/useApiOptionsGetRetrospects.ts
+++ b/apps/web/src/hooks/api/retrospect/useApiOptionsGetRetrospects.ts
@@ -1,3 +1,4 @@
+import { retrospectQueryKeys } from "@/hooks/api/retrospect/queryKeys";
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -19,7 +20,7 @@ const getAllRetrospectsFetch = async () => {
 };
 
 export const useApiOptionsGetRetrospects = (spaceId?: number): UseQueryOptions<RetrospectResponse, Error, RetrospectResponse["retrospects"]> => ({
-  queryKey: ["getRetrospects", spaceId],
+  queryKey: retrospectQueryKeys.list(spaceId),
   queryFn: () => spaceRetrospectFetch(spaceId),
   select(data) {
     return data.retrospects;
@@ -30,7 +31,7 @@ export const useApiOptionsGetRetrospects = (spaceId?: number): UseQueryOptions<R
 // * 모든 회고 리스트 요청 API 훅
 export const useGetAllRetrospects = (options?: Partial<UseQueryOptions<RetrospectResponse, Error, RetrospectResponse["retrospects"]>>) => {
   return useQuery({
-    queryKey: ["getAllRetrospects"],
+    queryKey: retrospectQueryKeys.all,
     queryFn: getAllRetrospectsFetch,
     select: (data) => data.retrospects,
     ...options,

--- a/apps/web/src/hooks/api/space/members/useApiChangeLeader.ts
+++ b/apps/web/src/hooks/api/space/members/useApiChangeLeader.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -18,7 +19,7 @@ export const useChangeLeader = (spaceId: number) => {
     mutationFn: (changeValue: { spaceId: number; memberId: number }) => changeLeader(changeValue),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["getMembers", spaceId],
+        queryKey: spaceQueryKeys.members(spaceId),
       });
       toast.success("대표자가 변경되었습니다.");
     },

--- a/apps/web/src/hooks/api/space/members/useApiGetMembers.ts
+++ b/apps/web/src/hooks/api/space/members/useApiGetMembers.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -16,7 +17,7 @@ export const useApiGetMemers = (spaceId: number) => {
   };
 
   return useQuery({
-    queryKey: ["getMembers", spaceId],
+    queryKey: spaceQueryKeys.members(spaceId),
     queryFn: () => getMembers(spaceId),
   });
 };

--- a/apps/web/src/hooks/api/space/members/useApiKickMembers.ts
+++ b/apps/web/src/hooks/api/space/members/useApiKickMembers.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -16,10 +17,10 @@ export const useApiKickMember = (spaceId: number) => {
     mutationFn: (deleteValue: { spaceId: number; memberId: number }) => apiKickMember(deleteValue),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["getMembers", spaceId],
+        queryKey: spaceQueryKeys.members(spaceId),
       });
       await queryClient.invalidateQueries({
-        queryKey: ["getSpaceInfo", spaceId],
+        queryKey: spaceQueryKeys.info(spaceId),
       });
       toast.success("해당 팀원을 추방시켰습니다.");
     },

--- a/apps/web/src/hooks/api/space/queryKeys.ts
+++ b/apps/web/src/hooks/api/space/queryKeys.ts
@@ -1,0 +1,9 @@
+type QueryId = number | null | undefined;
+
+export const spaceQueryKeys = {
+  lists: ["spaces"] as const,
+  list: (category: string) => [...spaceQueryKeys.lists, category] as const,
+  detail: (spaceId: QueryId) => ["getSpace", spaceId] as const,
+  info: (spaceId: QueryId) => ["getSpaceInfo", spaceId] as const,
+  members: (spaceId: QueryId) => ["getMembers", spaceId] as const,
+};

--- a/apps/web/src/hooks/api/space/useApiGetSpace.ts
+++ b/apps/web/src/hooks/api/space/useApiGetSpace.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -28,7 +29,7 @@ export const useApiGetSpace = (spaceId: number, isPublic: boolean = false, optio
   };
 
   return useQuery({
-    queryKey: ["getSpace", spaceId],
+    queryKey: spaceQueryKeys.detail(spaceId),
     queryFn: () => getSpace(spaceId, isPublic),
     enabled: options?.enabled ?? true,
   });

--- a/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
+++ b/apps/web/src/hooks/api/space/useApiGetSpaceList.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useInfiniteQuery, UseInfiniteQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -37,7 +38,7 @@ export const useApiGetSpaceList = (category: string, options?: UseApiGetSpaceLis
   const { pageSize = DEFAULT_PAGE_SIZE, ...queryOptions } = options || {};
 
   return useInfiniteQuery<SpaceFetchResponse>({
-    queryKey: ["spaces", category],
+    queryKey: spaceQueryKeys.list(category),
     queryFn: ({ pageParam = 0 }) => {
       return spaceFetch(pageParam as number, category, pageSize);
     },

--- a/apps/web/src/hooks/api/space/useApiLeaveSpace.ts
+++ b/apps/web/src/hooks/api/space/useApiLeaveSpace.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
@@ -19,7 +20,7 @@ export const useApiLeaveSpace = () => {
     mutationFn: (spaceId: number) => apiSpaceLeave(spaceId),
     onSuccess: () => {
       navigate(PATHS.home());
-      queryClient.invalidateQueries({ queryKey: ["spaces"] });
+      queryClient.invalidateQueries({ queryKey: spaceQueryKeys.lists });
       toast.success("스페이스를 성공적으로 떠났습니다.");
     },
     onError: (error) => {

--- a/apps/web/src/hooks/api/space/useApiOptionsGetSpaceInfo.ts
+++ b/apps/web/src/hooks/api/space/useApiOptionsGetSpaceInfo.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { UseQueryOptions } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -8,8 +9,8 @@ const spaceInfoFetch = async (spaceId: number | undefined) => {
   return response.data;
 };
 
-export const useApiOptionsGetSpaceInfo = (spaceId?: number): UseQueryOptions<Space, Error, Space, [string, number]> => ({
-  queryKey: ["getSpaceInfo", spaceId!],
+export const useApiOptionsGetSpaceInfo = (spaceId?: number): UseQueryOptions<Space, Error, Space, ReturnType<typeof spaceQueryKeys.info>> => ({
+  queryKey: spaceQueryKeys.info(spaceId),
   queryFn: () => spaceInfoFetch(spaceId),
   enabled: !!spaceId,
 });

--- a/apps/web/src/hooks/api/space/useGetSpace.ts
+++ b/apps/web/src/hooks/api/space/useGetSpace.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -10,7 +11,7 @@ export const useApiGetSpacePrivate = (spaceId: number) => {
   };
 
   return useQuery({
-    queryKey: ["getSpace", spaceId],
+    queryKey: spaceQueryKeys.detail(spaceId),
     queryFn: getSpace,
     refetchOnWindowFocus: false,
   });

--- a/apps/web/src/hooks/api/template/queryKeys.ts
+++ b/apps/web/src/hooks/api/template/queryKeys.ts
@@ -1,0 +1,9 @@
+type QueryId = number | null | undefined;
+
+export const templateQueryKeys = {
+  defaultList: ["getDefaultTemplates"] as const,
+  customList: (spaceId: QueryId) => ["getCustomTemplateList", spaceId] as const,
+  custom: (formId: QueryId) => ["customTemplate", formId] as const,
+  detail: (templateId: QueryId) => ["templateInfo", templateId] as const,
+  simpleDetail: (templateId: QueryId) => ["simpleTemplateInfo", templateId] as const,
+};

--- a/apps/web/src/hooks/api/template/useDeleteCustomTemplate.ts
+++ b/apps/web/src/hooks/api/template/useDeleteCustomTemplate.ts
@@ -1,3 +1,4 @@
+import { templateQueryKeys } from "@/hooks/api/template/queryKeys";
 import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -16,9 +17,9 @@ export const useDeleteCustomTemplate = (spaceId: number) => {
   return useMutation({
     mutationFn: deleteCustomTemplate,
     onMutate: async (newTemplate) => {
-      await queryClient.cancelQueries({ queryKey: ["getCustomTemplateList", spaceId] });
-      const prevList = queryClient.getQueryData(["getCustomTemplateList", spaceId]);
-      queryClient.setQueryData(["getCustomTemplateList", spaceId], (old: InfiniteData<CustomTemplateListRes["customTemplateList"]>) => {
+      await queryClient.cancelQueries({ queryKey: templateQueryKeys.customList(spaceId) });
+      const prevList = queryClient.getQueryData(templateQueryKeys.customList(spaceId));
+      queryClient.setQueryData(templateQueryKeys.customList(spaceId), (old: InfiniteData<CustomTemplateListRes["customTemplateList"]>) => {
         return {
           ...old,
           pages: old.pages.map((page) => ({
@@ -31,14 +32,14 @@ export const useDeleteCustomTemplate = (spaceId: number) => {
     },
     onError: (error, _, context) => {
       console.error("mutate error with", error);
-      queryClient.setQueryData(["getCustomTemplateList", spaceId], context?.prevList);
+      queryClient.setQueryData(templateQueryKeys.customList(spaceId), context?.prevList);
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["getCustomTemplateList", spaceId] });
+      await queryClient.invalidateQueries({ queryKey: templateQueryKeys.customList(spaceId) });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["getCustomTemplateList", spaceId], //FIXME - query key 상수화
+        queryKey: templateQueryKeys.customList(spaceId),
       });
     },
   });

--- a/apps/web/src/hooks/api/template/useGetCustomTemplate.ts
+++ b/apps/web/src/hooks/api/template/useGetCustomTemplate.ts
@@ -1,3 +1,4 @@
+import { templateQueryKeys } from "@/hooks/api/template/queryKeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -10,7 +11,7 @@ export const useGetCustomTemplate = (formId: number) => {
   };
 
   return useSuspenseQuery({
-    queryKey: ["customTemplate", formId],
+    queryKey: templateQueryKeys.custom(formId),
     queryFn: getCustomTemplate,
   });
 };

--- a/apps/web/src/hooks/api/template/useGetCustomTemplateList.ts
+++ b/apps/web/src/hooks/api/template/useGetCustomTemplateList.ts
@@ -1,3 +1,4 @@
+import { templateQueryKeys } from "@/hooks/api/template/queryKeys";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -15,7 +16,7 @@ export const useGetCustomTemplateList = (spaceId: number) => {
   };
 
   return useSuspenseInfiniteQuery<CustomTemplateListRes["customTemplateList"]>({
-    queryKey: ["getCustomTemplateList", spaceId],
+    queryKey: templateQueryKeys.customList(spaceId),
     queryFn: ({ pageParam }) => getCustomTemplateList(pageParam as number).then((res) => res.customTemplateList),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.last ? undefined : lastPage.pageable.pageNumber + 1),

--- a/apps/web/src/hooks/api/template/useGetDefaultTemplateList.ts
+++ b/apps/web/src/hooks/api/template/useGetDefaultTemplateList.ts
@@ -1,3 +1,4 @@
+import { templateQueryKeys } from "@/hooks/api/template/queryKeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -10,7 +11,7 @@ export const useGetDefaultTemplateList = () => {
   };
 
   return useSuspenseQuery({
-    queryKey: ["getDefaultTemplates"],
+    queryKey: templateQueryKeys.defaultList,
     queryFn: getDefaultTemplateList,
   });
 };

--- a/apps/web/src/hooks/api/template/useGetSimpleTemplateInfo.ts
+++ b/apps/web/src/hooks/api/template/useGetSimpleTemplateInfo.ts
@@ -1,3 +1,4 @@
+import { templateQueryKeys } from "@/hooks/api/template/queryKeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -17,7 +18,7 @@ export const useGetSimpleTemplateInfo = (templateId: number) => {
 
   return useSuspenseQuery({
     queryFn: () => getSimpleTemplateInfo(),
-    queryKey: ["simpleTemplateInfo", templateId],
+    queryKey: templateQueryKeys.simpleDetail(templateId),
     refetchOnWindowFocus: false,
   });
 };

--- a/apps/web/src/hooks/api/template/useGetTemplateInfo.ts
+++ b/apps/web/src/hooks/api/template/useGetTemplateInfo.ts
@@ -1,3 +1,4 @@
+import { templateQueryKeys } from "@/hooks/api/template/queryKeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -33,7 +34,7 @@ export const useGetTemplateInfo = ({ templateId }: { templateId: number }) => {
 
   return useSuspenseQuery({
     queryFn: () => getTemplateInfo(),
-    queryKey: ["templateInfo", templateId],
+    queryKey: templateQueryKeys.detail(templateId),
     refetchOnWindowFocus: false,
   });
 };

--- a/apps/web/src/hooks/api/template/usePatchTemplateTitle.ts
+++ b/apps/web/src/hooks/api/template/usePatchTemplateTitle.ts
@@ -1,3 +1,4 @@
+import { templateQueryKeys } from "@/hooks/api/template/queryKeys";
 import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -16,9 +17,9 @@ export const usePatchTemplateTitle = (spaceId: number) => {
   return useMutation({
     mutationFn: patchTemplateTitle,
     onMutate: async (newTemplate) => {
-      await queryClient.cancelQueries({ queryKey: ["getCustomTemplateList", spaceId] });
-      const prevList = queryClient.getQueryData(["getCustomTemplateList", spaceId]);
-      queryClient.setQueryData(["getCustomTemplateList", spaceId], (old: InfiniteData<CustomTemplateListRes["customTemplateList"]>) => {
+      await queryClient.cancelQueries({ queryKey: templateQueryKeys.customList(spaceId) });
+      const prevList = queryClient.getQueryData(templateQueryKeys.customList(spaceId));
+      queryClient.setQueryData(templateQueryKeys.customList(spaceId), (old: InfiniteData<CustomTemplateListRes["customTemplateList"]>) => {
         return {
           ...old,
           pages: old.pages.map((page) => ({
@@ -32,10 +33,10 @@ export const usePatchTemplateTitle = (spaceId: number) => {
     },
     onError: (error, _, context) => {
       console.error("mutate error with", error);
-      queryClient.setQueryData(["getCustomTemplateList", spaceId], context?.prevList);
+      queryClient.setQueryData(templateQueryKeys.customList(spaceId), context?.prevList);
     },
     onSettled: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["getCustomTemplateList", spaceId] });
+      await queryClient.invalidateQueries({ queryKey: templateQueryKeys.customList(spaceId) });
     },
   });
 };

--- a/apps/web/src/hooks/api/template/usePostRecentTemplateId.ts
+++ b/apps/web/src/hooks/api/template/usePostRecentTemplateId.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -16,7 +17,7 @@ export const usePostRecentTemplateId = (spaceId: number) => {
     mutationFn: postRecentTemplateId,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ["getSpaceInfo", String(spaceId)], //FIXME - query key 상수화
+        queryKey: spaceQueryKeys.info(spaceId),
       });
     },
   });

--- a/apps/web/src/hooks/api/write/queryKeys.ts
+++ b/apps/web/src/hooks/api/write/queryKeys.ts
@@ -1,0 +1,8 @@
+type QueryId = number | null | undefined;
+
+export const writeQueryKeys = {
+  questions: (spaceId: QueryId, retrospectId: QueryId) => ["questions", spaceId, retrospectId] as const,
+  temporaryQuestions: (spaceId: QueryId, retrospectId: QueryId) =>
+    ["temporaryQuestion", spaceId, retrospectId] as const,
+  answers: (spaceId: QueryId, retrospectId: QueryId) => ["answers", spaceId, retrospectId] as const,
+};

--- a/apps/web/src/hooks/api/write/useGetAnswers.ts
+++ b/apps/web/src/hooks/api/write/useGetAnswers.ts
@@ -1,3 +1,4 @@
+import { writeQueryKeys } from "@/hooks/api/write/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -36,7 +37,7 @@ export const useGetAnswers = ({ spaceId, retrospectId }: { spaceId: number; retr
   };
 
   return useQuery({
-    queryKey: ["answers", spaceId, retrospectId],
+    queryKey: writeQueryKeys.answers(spaceId, retrospectId),
     queryFn: () => getQuestions(),
     refetchOnWindowFocus: false,
     retry: 1,

--- a/apps/web/src/hooks/api/write/useGetQuestions.ts
+++ b/apps/web/src/hooks/api/write/useGetQuestions.ts
@@ -1,3 +1,4 @@
+import { writeQueryKeys } from "@/hooks/api/write/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -25,7 +26,7 @@ export const useGetQuestions = ({ spaceId, retrospectId }: { spaceId: number; re
   };
 
   return useQuery({
-    queryKey: ["questions", spaceId, retrospectId],
+    queryKey: writeQueryKeys.questions(spaceId, retrospectId),
     queryFn: () => getQuestions(),
   });
 };

--- a/apps/web/src/hooks/api/write/useGetTemporaryQuestions.ts
+++ b/apps/web/src/hooks/api/write/useGetTemporaryQuestions.ts
@@ -1,3 +1,4 @@
+import { writeQueryKeys } from "@/hooks/api/write/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/api";
@@ -20,7 +21,7 @@ export const useGetTemporaryQuestions = ({ spaceId, retrospectId }: { spaceId: n
   };
 
   return useQuery({
-    queryKey: ["temporaryQuestion", spaceId, retrospectId],
+    queryKey: writeQueryKeys.temporaryQuestions(spaceId, retrospectId),
     queryFn: () => getTemporaryQuestions(),
     refetchOnWindowFocus: false,
     retry: 1,

--- a/apps/web/src/hooks/app/space/useModifySpace.ts
+++ b/apps/web/src/hooks/app/space/useModifySpace.ts
@@ -1,3 +1,4 @@
+import { spaceQueryKeys } from "@/hooks/api/space/queryKeys";
 import { api } from "@/api";
 import { useApiEditSpace } from "@/hooks/api/space/edit/useApiEditSpace";
 import { useApiDeleteSpace } from "@/hooks/api/space/useApiDeleteSpace";
@@ -80,12 +81,12 @@ export default function useModifySpace({ id }: ModifySpaceProps) {
         setterCurrentSpace((prev) => ({ ...prev, ...{ name, introduction } }) as Space);
         // 수정이 성공하면 현재 스페이스 정보를 상세 조회하는 쿼리를 리패치
         queryClient.invalidateQueries({
-          queryKey: ["getSpace", id],
+          queryKey: spaceQueryKeys.detail(id),
         });
       }
       // 수정이나 삭제가 성공하면 스페이스 목록과 현재 스페이스 정보를 리패치
       queryClient.invalidateQueries({
-        queryKey: ["spaces"],
+        queryKey: spaceQueryKeys.lists,
       });
     }
   }, [isEditSuccess, isDeleteSuccess]);

--- a/apps/web/src/lib/provider/bridge-provider.tsx
+++ b/apps/web/src/lib/provider/bridge-provider.tsx
@@ -9,6 +9,10 @@ import { createContext } from "@/lib/create-context";
 
 const BRIDGE_PROVIER = "BRIDGE_PROVIER";
 
+const bridgeQueryKeys = {
+  safeAreaHeight: ["app", "height"] as const,
+};
+
 type AppBridgeState = {
   getSafeAreaHeight: () => Promise<number>;
   checkWebview: () => Promise<boolean>;
@@ -35,7 +39,7 @@ const [Provider, useBridge] = createContext<WebViewBridgeContext>(BRIDGE_PROVIER
 const BridgeProvider = ({ children }: PropsWithChildren) => {
   const bridgeRef = useRef(bridge).current;
   const { data: { safeAreaHeight, isWebViewBridgeAvailable } = {} } = useQuery({
-    queryKey: ["app", "height"],
+    queryKey: bridgeQueryKeys.safeAreaHeight,
     queryFn: async () => {
       const safeAreaHeight = await bridge.getSafeAreaHeight();
 


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- React Query queryKey를 중앙 집중식으로 관리하기 위한 queryKeys 객체를 도입했습니다.
- 기존 하드코딩된 queryKey를 새로운 queryKeys 객체로 대체하여 일관성과 타입 안정성을 확보했습니다.

### 🫨 Describe your Change (변경사항)

- Action Item, Analysis, Auth, Retrospect, Space, Template, Write 등 주요 API 모듈에 queryKeys.ts 파일을 추가했습니다.
- 관련 컴포넌트 및 훅에서 사용되는 queryKey를 새로 정의된 queryKeys 객체로 변경했습니다.
- queryKey 정의 시 타입 추론을 개선하고 휴먼 에러 발생 가능성을 줄였습니다.

### 🧐 Issue number and link (참고)

closes: #937

### 📚 Reference (참조)

-