### PR TITLE
fix: 커스텀 템플릿 전환 시 타이틀 사라지는 이슈

### DIFF
--- a/apps/web/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
+++ b/apps/web/src/component/retrospectCreate/customTemplate/ConfirmEditTemplate.tsx
@@ -24,15 +24,15 @@ type QuestionsListProps = {
 };
 
 export function ConfirmEditTemplate({ goNext, goPrev }: QuestionsListProps) {
-  const { tag: originalTag } = useContext(TemplateContext);
+  const { title: originalTitle, tag: originalTag } = useContext(TemplateContext);
   const [retroCreateData, setRetroCreateData] = useAtom(retrospectCreateAtom);
   const tag = useMemo(() => {
     if (retroCreateData.hasChangedOriginal) {
-      return originalTag;
+      return "CUSTOM";
     }
-    return "커스텀";
+    return originalTag;
   }, [retroCreateData.hasChangedOriginal, originalTag]);
-  const { value: title, handleInputChange: handleTitleChange } = useInput(retroCreateData.formName);
+  const { value: title, handleInputChange: handleTitleChange } = useInput(retroCreateData.formName || originalTitle || "커스텀 템플릿");
   const titleInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
   const { track } = useMixpanel();

--- a/apps/web/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
+++ b/apps/web/src/component/retrospectCreate/customTemplate/EditQuestions.tsx
@@ -75,6 +75,7 @@ export function EditQuestions({ goNext, goPrev }: EditQuestionsProps) {
       isNewForm: isEdited,
       hasChangedOriginal: !isDefaultExtended,
       questions: newQuestions,
+      formName: !isDefaultExtended ? "커스텀 템플릿" : prev.formName,
     }));
   };
 


### PR DESCRIPTION
> ### 커스텀 템플릿 전환 시 타이틀 사라지는 이슈 수정
---

### 🏄🏼‍♂️‍ Summary (요약)

 - 앱(Mobile/WebView) 회고 생성 플로우에서 질문을 수정해 커스텀 템플릿으로 전환할 때
  타이틀이 사라지는 버그를 수정했습니다. Desktop 구현과 태그/타이틀 처리 로직이 어긋나 있던
  것이 원인이었습니다.

### 🫨 Describe your Change (변경사항)

 - EditQuestions.tsx: 질문 수정 완료 시 formName이 갱신되지 않던 문제를 수정 (원본과
  달라지면 "커스텀 템플릿"으로 설정)
  - ConfirmEditTemplate.tsx: 타이틀 폴백 체인 추가, 태그 표시 조건을 Desktop과 동일하게
  정렬
