### PR TITLE
회고 생성 플로우 간소화 및 GA 이벤트 트래킹 추가

### DIFF
--- a/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
+++ b/apps/web/src/app/desktop/component/analysis/AnalysisOverview/AnalysisOverviewHeader.tsx
@@ -2,9 +2,7 @@ import { Icon } from "@/component/common/Icon";
 import { Typography } from "@/component/common/typography";
 import SpaceManageToggleMenu from "@/component/space/edit/SpaceManageToggleMenu";
 import { useApiOptionsGetSpaceInfo } from "@/hooks/api/space/useApiOptionsGetSpaceInfo";
-import { useActionModal } from "@/hooks/useActionModal";
 import { useFunnelModal } from "@/hooks/useFunnelModal";
-import { useModal } from "@/hooks/useModal";
 import { retrospectInitialState } from "@/store/retrospect/retrospectInitial";
 import { currentSpaceState } from "@/store/space/spaceAtom";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens";
@@ -13,17 +11,16 @@ import { css } from "@emotion/react";
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue, useSetAtom } from "jotai";
 import { RetrospectCreate } from "../../retrospectCreate";
-import { TemplateChoice } from "../../retrospect/choice";
 import { TemplateList } from "../../retrospect/template/list";
 import MemberManagement from "@/component/retrospect/space/members/MemberManagement";
 import { useState } from "react";
 import ActionItems from "./ActionItems";
 import { useTemporarySave } from "@/hooks/useTemporarySave";
+import { GA_EVENTS } from "@/lib/google-analytics/events";
+import { trackEvent } from "@/lib/google-analytics";
 
 export default function AnalysisOverviewHeader() {
-  const { open } = useModal();
   const { openFunnelModal } = useFunnelModal();
-  const { openActionModal } = useActionModal();
 
   // 실행목표 토글 상태
   const [actionItemToggle, setActionItemToggle] = useState(false);
@@ -51,25 +48,11 @@ export default function AnalysisOverviewHeader() {
         templateId: spaceInfo.formId,
       }));
 
-      open({
-        title: "전에 진행했던 템플릿이 있어요!\n계속 진행하시겠어요?",
-        contents: "",
-        options: {
-          buttonText: ["재설정", "진행하기"],
-        },
-        onConfirm: () => {
-          openFunnelModal({
-            title: "",
-            step: "retrospectCreate",
-            contents: <RetrospectCreate />,
-          });
-        },
-        onClose: () => {
-          openActionModal({
-            title: "",
-            contents: <TemplateChoice />,
-          });
-        },
+      trackEvent(GA_EVENTS.RETROSPECT.ADD);
+      openFunnelModal({
+        title: "",
+        step: "retrospectCreate",
+        contents: <RetrospectCreate />,
       });
     }
   };

--- a/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
+++ b/apps/web/src/app/desktop/space/add/AddSpacePage.tsx
@@ -1374,7 +1374,7 @@ function CompleteCreateSpace() {
     closeModalDesktop();
     resetRetrospectInfo();
     resetSpaceInfo();
-    branchLayout === "A" ? trackEvent(GA_EVENTS.SPACE.ADD_DONE_B_LAYOUT) : trackEvent(GA_EVENTS.SPACE.ADD_DONE_A_LAYOUT);
+    branchLayout === "A" ? trackEvent(GA_EVENTS.SPACE.ADD_DONE_A_LAYOUT) : trackEvent(GA_EVENTS.SPACE.ADD_DONE_B_LAYOUT);
   };
 
   useEffect(() => {

--- a/apps/web/src/app/mobile/write/RetrospectWriteCompletePage.tsx
+++ b/apps/web/src/app/mobile/write/RetrospectWriteCompletePage.tsx
@@ -13,6 +13,8 @@ import { useApiGetSpacePrivate } from "@/hooks/api/space/useGetSpace.ts";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 import { ANIMATION } from "@/style/common/animation.ts";
 import { PATHS } from "@layer/shared";
+import { GA_EVENTS } from "@/lib/google-analytics/events";
+import { trackEvent } from "@/lib/google-analytics";
 
 type UserInfoType = {
   isLogin: boolean;
@@ -54,6 +56,7 @@ export function RetrospectWriteCompletePage() {
   };
 
   useEffect(() => {
+    trackEvent(GA_EVENTS.RETROSPECT.WRITE_SUBMIT_DONE);
     const timer = setTimeout(() => {
       setAnimation(true);
     }, 700);

--- a/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
+++ b/apps/web/src/component/retrospect/space/InProgressRetrospects.tsx
@@ -12,12 +12,11 @@ import RetrospectCard from "@/app/desktop/component/home/RetrospectCard";
 import { LoadingSpinner } from "@/component/space/view/LoadingSpinner";
 import { useSetAtom } from "jotai";
 import { retrospectInitialState } from "@/store/retrospect/retrospectInitial";
-import { useModal } from "@/hooks/useModal";
 import { useFunnelModal } from "@/hooks/useFunnelModal";
-import { useActionModal } from "@/hooks/useActionModal";
 import { RetrospectCreate } from "@/app/desktop/component/retrospectCreate";
-import { TemplateChoice } from "@/app/desktop/component/retrospect/choice";
 import { useApiOptionsGetSpaceInfo } from "@/hooks/api/space/useApiOptionsGetSpaceInfo";
+import { GA_EVENTS } from "@/lib/google-analytics/events";
+import { trackEvent } from "@/lib/google-analytics";
 
 export default function InProgressRetrospects() {
   const { spaceId: rawSpaceId } = useParams();
@@ -29,9 +28,7 @@ export default function InProgressRetrospects() {
   // * 스페이스 정보 조회
   const { data: spaceInfo } = useQuery(useApiOptionsGetSpaceInfo(spaceId));
 
-  const { open } = useModal();
   const { openFunnelModal } = useFunnelModal();
-  const { openActionModal } = useActionModal();
 
   const setRetrospectValue = useSetAtom(retrospectInitialState);
 
@@ -45,25 +42,11 @@ export default function InProgressRetrospects() {
         templateId: spaceInfo.formId,
       }));
 
-      open({
-        title: "전에 진행했던 템플릿이 있어요!\n계속 진행하시겠어요?",
-        contents: "",
-        options: {
-          buttonText: ["재설정", "진행하기"],
-        },
-        onConfirm: () => {
-          openFunnelModal({
-            title: "",
-            step: "retrospectCreate",
-            contents: <RetrospectCreate />,
-          });
-        },
-        onClose: () => {
-          openActionModal({
-            title: "",
-            contents: <TemplateChoice />,
-          });
-        },
+      trackEvent(GA_EVENTS.RETROSPECT.ADD);
+      openFunnelModal({
+        title: "",
+        step: "retrospectCreate",
+        contents: <RetrospectCreate />,
       });
     }
   };

--- a/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
+++ b/apps/web/src/component/retrospect/space/RetrospectSpaceHeader.tsx
@@ -15,6 +15,8 @@ import { useQueries } from "@tanstack/react-query";
 import { useAtomValue, useSetAtom } from "jotai";
 import { TemplateList } from "@/app/desktop/component/retrospect/template/list";
 import { useSearchParams } from "react-router-dom";
+import { GA_EVENTS } from "@/lib/google-analytics/events";
+import { trackEvent } from "@/lib/google-analytics";
 
 export default function RetrospectSpaceHeader() {
   const { openFunnelModal } = useFunnelModal();
@@ -39,6 +41,7 @@ export default function RetrospectSpaceHeader() {
         templateId: spaceInfo.formId,
       }));
 
+      trackEvent(GA_EVENTS.RETROSPECT.ADD);
       openFunnelModal({
         title: "",
         step: "retrospectCreate",

--- a/apps/web/src/component/write/phase/Write.tsx
+++ b/apps/web/src/component/write/phase/Write.tsx
@@ -26,6 +26,8 @@ import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 import { useMixpanel } from "@/lib/provider/mix-pannel-provider";
 import { DESIGN_TOKEN_COLOR } from "@/style/designTokens.ts";
 import { PATHS } from "@layer/shared";
+import { GA_EVENTS } from "@/lib/google-analytics/events";
+import { trackEvent } from "@/lib/google-analytics";
 
 export type Answer = {
   questionId: number;
@@ -129,6 +131,7 @@ export function Write() {
    * NOTE: Tanstack Post User Data
    * */
   const mutatePostData = () => {
+    trackEvent(GA_EVENTS.RETROSPECT.WRITE_SUBMIT_CONFIRM);
     mutate(
       { data: answers, isTemporarySave: false, spaceId: spaceId, retrospectId: retrospectId, method: editMode.current },
       {
@@ -446,7 +449,8 @@ export function Write() {
           {isComplete ? (
             <Button
               colorSchema={"primary"}
-              onClick={() =>
+              onClick={() => {
+                trackEvent(GA_EVENTS.RETROSPECT.WRITE_SUBMIT_OPEN);
                 open({
                   title: "회고를 제출할까요?",
                   contents: "제출하고 난 뒤에는\n더 이상 회고를 수정할 수 없어요",
@@ -454,8 +458,8 @@ export function Write() {
                     buttonText: ["취소", "제출하기"],
                   },
                   onConfirm: mutatePostData,
-                })
-              }
+                });
+              }}
             >
               제출하기
             </Button>


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 생성 시 불필요한 모달 단계를 제거하여 사용자 경험을 개선했습니다.
- 주요 사용자 행동에 대한 Google Analytics 이벤트 트래킹을 추가 및 수정했습니다.
- 스페이스 생성 완료 시 GA 이벤트 트래킹 오류를 수정했습니다.

### 🫨 Describe your Change (변경사항)

- 회고 생성 시 기존 템플릿 진행 여부 및 템플릿 선택 모달(`useModal`, `useActionModal`, `TemplateChoice`)을 제거하고, `RetrospectCreate` 퍼널 모달로 직접 이동하도록 변경했습니다.
- 새 회고 시작 시 `GA_EVENTS.RETROSPECT.ADD` 이벤트를 트래킹하도록 추가했습니다.
- 회고 작성 완료 페이지 및 제출 관련 액션에 대한 GA 이벤트를 추가했습니다.
- 스페이스 생성 완료 시 A/B 레이아웃에 따른 GA 이벤트 트래킹 로직 오류를 수정했습니다.

### 🧐 Issue number and link (참고)

closes: #949

### 📚 Reference (참조)

-