### PR TITLE
회고 반응 기능 개선 및 옵티미스틱 업데이트 로직 중앙화

### DIFF
--- a/apps/web/src/component/retrospect/analysis/Reaction.tsx
+++ b/apps/web/src/component/retrospect/analysis/Reaction.tsx
@@ -38,6 +38,38 @@ const EMPTY_REACTIONS: RetrospectReaction[] = [];
 const getPendingReactionKey = (answerId: number, memberId: number, emojiCode: RetrospectReactionCode) =>
   `${answerId}:${memberId}:${emojiCode}`;
 
+const getReactionGroups = (reactions: RetrospectReaction[]) => {
+  const groups: ReactionGroup[] = [];
+
+  for (const code of Object.keys(RETROSPECT_REACTIONS) as RetrospectReactionCode[]) {
+    const codeReactions: RetrospectReaction[] = [];
+
+    for (const reaction of reactions) {
+      if (reaction.emojiCode === code) {
+        codeReactions.push(reaction);
+      }
+    }
+
+    if (codeReactions.length > 0) {
+      groups.push({ code, reactions: codeReactions });
+    }
+  }
+
+  return groups;
+};
+
+const getSelectedReactionCodes = (reactions: RetrospectReaction[], memberId: number) => {
+  const codes = new Set<RetrospectReactionCode>();
+
+  for (const reaction of reactions) {
+    if (reaction.memberId === memberId) {
+      codes.add(reaction.emojiCode);
+    }
+  }
+
+  return codes;
+};
+
 const REACTION_COLORS = {
   blue: DESIGN_TOKEN_COLOR.blue600,
   purple: DESIGN_TOKEN_COLOR.purple600,
@@ -71,14 +103,8 @@ export default function ReactionBlock({
 
   const answerReactions =
     data?.answerReactions.find((item) => item.answerId === answerId)?.reactions ?? EMPTY_REACTIONS;
-  const reactionGroups = (Object.keys(RETROSPECT_REACTIONS) as RetrospectReactionCode[])
-    .map((code) => ({ code, reactions: answerReactions.filter((reaction) => reaction.emojiCode === code) }))
-    .filter((group) => group.reactions.length > 0);
-  const selectedReactionCodes = new Set(
-    answerReactions
-      .filter((reaction) => reaction.memberId === currentUser.memberId)
-      .map((reaction) => reaction.emojiCode),
-  );
+  const reactionGroups = getReactionGroups(answerReactions);
+  const selectedReactionCodes = getSelectedReactionCodes(answerReactions, currentUser.memberId);
   const visibleGroups = reactionGroups.slice(0, MAX_VISIBLE_REACTIONS);
   const hiddenGroups = reactionGroups.slice(MAX_VISIBLE_REACTIONS);
   const shouldShowEmptyTooltip =
@@ -105,7 +131,7 @@ export default function ReactionBlock({
       },
     };
 
-    const pendingCreate = postReaction.mutateAsync(mutationParams);
+    const pendingCreate = postReaction.optimisticMutateAsync(mutationParams);
     pendingCreateRef.current.set(pendingReactionKey, pendingCreate);
     void pendingCreate
       .finally(() => {
@@ -122,7 +148,7 @@ export default function ReactionBlock({
   };
 
   const handleDelete = (reaction: RetrospectReaction) => {
-    deleteReaction.mutate({
+    deleteReaction.optimisticMutate({
       spaceId,
       retrospectId,
       retrospectReactionId: reaction.retrospectReactionId,
@@ -170,10 +196,10 @@ export default function ReactionBlock({
         <button
           type="button"
           css={chipStyle(false)}
-          onMouseEnter={isMobile ? undefined : (event) => openStatus(event, hiddenGroups)}
+          onMouseEnter={isMobile ? undefined : (event) => openStatus(event, reactionGroups)}
           onMouseLeave={isMobile ? undefined : scheduleClose}
-          onClick={(event) => openStatus(event, hiddenGroups)}
-          aria-label={`반응 ${hiddenGroups.length}개 더 보기`}
+          onClick={(event) => openStatus(event, reactionGroups)}
+          aria-label="전체 반응 보기"
         >
           +{hiddenGroups.length}
         </button>

--- a/apps/web/src/hooks/api/retrospect/reaction/useDeleteRetrospectReaction.ts
+++ b/apps/web/src/hooks/api/retrospect/reaction/useDeleteRetrospectReaction.ts
@@ -7,7 +7,10 @@ import {
   rollbackRetrospectReactionCache,
 } from "@/hooks/api/retrospect/reaction/reactionCache";
 import { retrospectReactionQueryKeys } from "@/hooks/api/retrospect/reaction/queryKeys";
-import { RetrospectReactionCode, RetrospectReactionResponse } from "@/types/retrospectReaction";
+import {
+  RetrospectReactionCode,
+  RetrospectReactionResponse,
+} from "@/types/retrospectReaction";
 
 type DeleteRetrospectReactionParams = {
   spaceId: number;
@@ -17,10 +20,6 @@ type DeleteRetrospectReactionParams = {
   memberId?: number;
   emojiCode?: RetrospectReactionCode;
   pendingCreate?: Promise<void> | null;
-};
-
-type DeleteRetrospectReactionMutationParams = DeleteRetrospectReactionParams & {
-  previousReactions?: RetrospectReactionResponse;
 };
 
 export const useDeleteRetrospectReaction = () => {
@@ -35,7 +34,7 @@ export const useDeleteRetrospectReaction = () => {
       memberId,
       emojiCode,
       pendingCreate,
-    }: DeleteRetrospectReactionMutationParams) => {
+    }: DeleteRetrospectReactionParams) => {
       let reactionId = retrospectReactionId;
 
       if (reactionId < 0) {
@@ -62,30 +61,50 @@ export const useDeleteRetrospectReaction = () => {
       if (reactionId < 0) return;
       await api.delete(`/space/${spaceId}/retrospect/${retrospectId}/reaction/${reactionId}`);
     },
-    onError: (_, { spaceId, retrospectId, previousReactions }) => {
-      rollbackRetrospectReactionCache(queryClient, { spaceId, retrospectId }, previousReactions);
-    },
     onSettled: (_, __, { spaceId, retrospectId }) => {
       void invalidateRetrospectReactionCache(queryClient, { spaceId, retrospectId });
     },
   });
 
-  const applyOptimisticDelete = (params: DeleteRetrospectReactionParams): DeleteRetrospectReactionMutationParams => {
+  const applyOptimisticDelete = (params: DeleteRetrospectReactionParams) => {
     const { spaceId, retrospectId, retrospectReactionId } = params;
-    const { previousReactions } = removeRetrospectReactionCache(
+    return removeRetrospectReactionCache(
       queryClient,
       { spaceId, retrospectId },
       retrospectReactionId,
     );
+  };
 
-    return { ...params, previousReactions };
+  const optimisticMutate = (params: DeleteRetrospectReactionParams, options?: Parameters<typeof mutation.mutate>[1]) => {
+    const { previousReactions } = applyOptimisticDelete(params);
+
+    mutation.mutate(params, {
+      ...options,
+      onError: (error, variables, context) => {
+        rollbackRetrospectReactionCache(queryClient, params, previousReactions);
+        options?.onError?.(error, variables, context);
+      },
+    });
+  };
+
+  const optimisticMutateAsync = async (
+    params: DeleteRetrospectReactionParams,
+    options?: Parameters<typeof mutation.mutateAsync>[1],
+  ) => {
+    const { previousReactions } = applyOptimisticDelete(params);
+
+    return mutation.mutateAsync(params, {
+      ...options,
+      onError: (error, variables, context) => {
+        rollbackRetrospectReactionCache(queryClient, params, previousReactions);
+        options?.onError?.(error, variables, context);
+      },
+    });
   };
 
   return {
     ...mutation,
-    mutate: (params: DeleteRetrospectReactionParams, options?: Parameters<typeof mutation.mutate>[1]) =>
-      mutation.mutate(applyOptimisticDelete(params), options),
-    mutateAsync: (params: DeleteRetrospectReactionParams, options?: Parameters<typeof mutation.mutateAsync>[1]) =>
-      mutation.mutateAsync(applyOptimisticDelete(params), options),
+    optimisticMutate,
+    optimisticMutateAsync,
   };
 };

--- a/apps/web/src/hooks/api/retrospect/reaction/usePostRetrospectReaction.ts
+++ b/apps/web/src/hooks/api/retrospect/reaction/usePostRetrospectReaction.ts
@@ -7,11 +7,7 @@ import {
   invalidateRetrospectReactionCache,
   rollbackRetrospectReactionCache,
 } from "@/hooks/api/retrospect/reaction/reactionCache";
-import {
-  RetrospectReactionCode,
-  RetrospectReactionMember,
-  RetrospectReactionResponse,
-} from "@/types/retrospectReaction";
+import { RetrospectReactionCode, RetrospectReactionMember } from "@/types/retrospectReaction";
 
 type PostRetrospectReactionParams = {
   spaceId: number;
@@ -21,42 +17,58 @@ type PostRetrospectReactionParams = {
   member: RetrospectReactionMember;
 };
 
-type PostRetrospectReactionMutationParams = PostRetrospectReactionParams & {
-  previousReactions?: RetrospectReactionResponse;
-};
-
 export const usePostRetrospectReaction = () => {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async ({ spaceId, retrospectId, answerId, emojiCode }: PostRetrospectReactionMutationParams) => {
+    mutationFn: async ({ spaceId, retrospectId, answerId, emojiCode }: PostRetrospectReactionParams) => {
       await api.post(`/space/${spaceId}/retrospect/${retrospectId}/reaction`, { answerId, emojiCode });
-    },
-    onError: (_, { spaceId, retrospectId, previousReactions }) => {
-      rollbackRetrospectReactionCache(queryClient, { spaceId, retrospectId }, previousReactions);
     },
     onSettled: (_, __, { spaceId, retrospectId }) => {
       void invalidateRetrospectReactionCache(queryClient, { spaceId, retrospectId });
     },
   });
 
-  const applyOptimisticPost = (params: PostRetrospectReactionParams): PostRetrospectReactionMutationParams => {
+  const applyOptimisticPost = (params: PostRetrospectReactionParams) => {
     const { spaceId, retrospectId, answerId, emojiCode, member } = params;
     const optimisticReaction = createOptimisticReaction(emojiCode, member);
-    const { previousReactions } = addRetrospectReactionCache(
+    return addRetrospectReactionCache(
       queryClient,
       { spaceId, retrospectId },
       { answerId, reaction: optimisticReaction },
     );
+  };
 
-    return { ...params, previousReactions };
+  const optimisticMutate = (params: PostRetrospectReactionParams, options?: Parameters<typeof mutation.mutate>[1]) => {
+    const { previousReactions } = applyOptimisticPost(params);
+
+    mutation.mutate(params, {
+      ...options,
+      onError: (error, variables, context) => {
+        rollbackRetrospectReactionCache(queryClient, params, previousReactions);
+        options?.onError?.(error, variables, context);
+      },
+    });
+  };
+
+  const optimisticMutateAsync = async (
+    params: PostRetrospectReactionParams,
+    options?: Parameters<typeof mutation.mutateAsync>[1],
+  ) => {
+    const { previousReactions } = applyOptimisticPost(params);
+
+    return mutation.mutateAsync(params, {
+      ...options,
+      onError: (error, variables, context) => {
+        rollbackRetrospectReactionCache(queryClient, params, previousReactions);
+        options?.onError?.(error, variables, context);
+      },
+    });
   };
 
   return {
     ...mutation,
-    mutate: (params: PostRetrospectReactionParams, options?: Parameters<typeof mutation.mutate>[1]) =>
-      mutation.mutate(applyOptimisticPost(params), options),
-    mutateAsync: (params: PostRetrospectReactionParams, options?: Parameters<typeof mutation.mutateAsync>[1]) =>
-      mutation.mutateAsync(applyOptimisticPost(params), options),
+    optimisticMutate,
+    optimisticMutateAsync,
   };
 };

--- a/apps/web/src/hooks/useClickOutside.ts
+++ b/apps/web/src/hooks/useClickOutside.ts
@@ -1,20 +1,26 @@
-import { RefObject, useEffect } from "react";
+import { RefObject, useEffect, useRef } from "react";
 
 export default function useClickOutside(ref: RefObject<HTMLElement>, handler: (event: MouseEvent | TouchEvent) => void) {
-  useEffect(() => {
+  const handlerRef = useRef(handler);
+
+  useEffect(function syncClickOutsideHandler() {
+    handlerRef.current = handler;
+  }, [handler]);
+
+  useEffect(function subscribeClickOutside() {
     const listener = (event: MouseEvent | TouchEvent) => {
       if (!ref.current || ref.current.contains(event.target as Node)) {
         return;
       }
-      handler(event);
+      handlerRef.current(event);
     };
 
     document.addEventListener("mousedown", listener);
     document.addEventListener("touchstart", listener);
 
-    return () => {
+    return function unsubscribeClickOutside() {
       document.removeEventListener("mousedown", listener);
       document.removeEventListener("touchstart", listener);
     };
-  }, [ref, handler]);
+  }, [ref]);
 }


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 회고 반응 생성/삭제 시 옵티미스틱 업데이트 로직을 중앙화하여 코드 중복을 줄이고 에러 처리 일관성을 높였습니다.
- `ReactionBlock` 컴포넌트의 반응 그룹화 및 선택 로직을 헬퍼 함수로 분리하여 가독성을 향상시켰습니다.
- `useClickOutside` 훅의 이벤트 리스너 등록 로직을 최적화하여 불필요한 재등록을 방지했습니다.

### 🫨 Describe your Change (변경사항)

- `usePostRetrospectReaction` 및 `useDeleteRetrospectReaction` 훅에 `optimisticMutate` 및 `optimisticMutateAsync` 메서드를 추가했습니다.
- 옵티미스틱 업데이트 실패 시 캐시 롤백 로직을 각 `optimisticMutate` 메서드의 `onError` 콜백으로 이동했습니다.
- `ReactionBlock` 컴포넌트에서 `getReactionGroups` 및 `getSelectedReactionCodes` 유틸리티 함수를 도입하여 로직을 분리했습니다.
- `ReactionBlock`의 "전체 반응 보기" 버튼이 모든 반응 그룹을 표시하도록 변경하고, `aria-label`을 업데이트했습니다.
- `useClickOutside` 훅에서 `handler` 함수를 `useRef`로 관리하여 `useEffect` 의존성 문제를 해결하고 성능을 개선했습니다.

### 🧐 Issue number and link (참고)

closes: #942

### 📚 Reference (참조)

-