### PR TITLE
회고 반응 UI 개선 및 정렬 로직 적용

### DIFF
--- a/apps/web/src/component/retrospect/analysis/Reaction.tsx
+++ b/apps/web/src/component/retrospect/analysis/Reaction.tsx
@@ -38,21 +38,34 @@ const EMPTY_REACTIONS: RetrospectReaction[] = [];
 const getPendingReactionKey = (answerId: number, memberId: number, emojiCode: RetrospectReactionCode) =>
   `${answerId}:${memberId}:${emojiCode}`;
 
+const compareRecentReactionFirst = (reactionA: RetrospectReaction, reactionB: RetrospectReaction) => {
+  const reactionAId = reactionA.retrospectReactionId;
+  const reactionBId = reactionB.retrospectReactionId;
+  const isReactionAOptimistic = reactionAId < 0;
+  const isReactionBOptimistic = reactionBId < 0;
+
+  if (isReactionAOptimistic && isReactionBOptimistic) return reactionAId - reactionBId;
+  if (isReactionAOptimistic) return -1;
+  if (isReactionBOptimistic) return 1;
+
+  return reactionBId - reactionAId;
+};
+
 const getReactionGroups = (reactions: RetrospectReaction[]) => {
   const groups: ReactionGroup[] = [];
+  const groupMap = new Map<RetrospectReactionCode, ReactionGroup>();
 
-  for (const code of Object.keys(RETROSPECT_REACTIONS) as RetrospectReactionCode[]) {
-    const codeReactions: RetrospectReaction[] = [];
+  for (const reaction of reactions.toSorted(compareRecentReactionFirst)) {
+    const group = groupMap.get(reaction.emojiCode);
 
-    for (const reaction of reactions) {
-      if (reaction.emojiCode === code) {
-        codeReactions.push(reaction);
-      }
+    if (group) {
+      group.reactions.push(reaction);
+      continue;
     }
 
-    if (codeReactions.length > 0) {
-      groups.push({ code, reactions: codeReactions });
-    }
+    const newGroup = { code: reaction.emojiCode, reactions: [reaction] };
+    groupMap.set(reaction.emojiCode, newGroup);
+    groups.push(newGroup);
   }
 
   return groups;
@@ -68,6 +81,12 @@ const getSelectedReactionCodes = (reactions: RetrospectReaction[], memberId: num
   }
 
   return codes;
+};
+
+const getStatusGroups = (codes: RetrospectReactionCode[], reactionGroups: ReactionGroup[]) => {
+  const codeSet = new Set(codes);
+
+  return reactionGroups.filter((group) => codeSet.has(group.code));
 };
 
 const REACTION_COLORS = {
@@ -107,6 +126,7 @@ export default function ReactionBlock({
   const selectedReactionCodes = getSelectedReactionCodes(answerReactions, currentUser.memberId);
   const visibleGroups = reactionGroups.slice(0, MAX_VISIBLE_REACTIONS);
   const hiddenGroups = reactionGroups.slice(MAX_VISIBLE_REACTIONS);
+  const reactionGroupCodes = reactionGroups.map((group) => group.code);
   const shouldShowEmptyTooltip =
     showEmptyTooltip && isSuccess && !data.answerReactions.some((item) => item.reactions.length > 0);
 
@@ -157,7 +177,9 @@ export default function ReactionBlock({
       emojiCode: reaction.emojiCode,
       pendingCreate: getPendingCreate(reaction),
     });
-    closeOverlay();
+    if (overlay?.type !== "status" || !overlay.keepOpenOnDelete) {
+      closeOverlay();
+    }
   };
 
   const addReactionButton = (
@@ -186,9 +208,9 @@ export default function ReactionBlock({
           key={group.code}
           group={group}
           selected={group.reactions.some((reaction) => reaction.memberId === currentUser.memberId)}
-          onMouseEnter={isMobile ? undefined : (event) => openStatus(event, [group])}
+          onMouseEnter={isMobile ? undefined : (event) => openStatus(event, [group.code])}
           onMouseLeave={isMobile ? undefined : scheduleClose}
-          onClick={(event) => openStatus(event, [group])}
+          onClick={(event) => openStatus(event, [group.code])}
         />
       ))}
 
@@ -196,9 +218,13 @@ export default function ReactionBlock({
         <button
           type="button"
           css={chipStyle(false)}
-          onMouseEnter={isMobile ? undefined : (event) => openStatus(event, reactionGroups)}
+          onMouseEnter={
+            isMobile
+              ? undefined
+              : (event) => openStatus(event, reactionGroupCodes, { keepOpenOnDelete: true })
+          }
           onMouseLeave={isMobile ? undefined : scheduleClose}
-          onClick={(event) => openStatus(event, reactionGroups)}
+          onClick={(event) => openStatus(event, reactionGroupCodes, { keepOpenOnDelete: true })}
           aria-label="전체 반응 보기"
         >
           +{hiddenGroups.length}
@@ -236,6 +262,7 @@ export default function ReactionBlock({
             >
               <ReactionOverlayContent
                 overlay={overlay}
+                reactionGroups={reactionGroups}
                 selectedCodes={selectedReactionCodes}
                 currentMemberId={currentUser.memberId}
                 onSelect={handleCreate}
@@ -258,6 +285,7 @@ export default function ReactionBlock({
           >
             <ReactionOverlayContent
               overlay={overlay}
+              reactionGroups={reactionGroups}
               selectedCodes={selectedReactionCodes}
               currentMemberId={currentUser.memberId}
               onSelect={handleCreate}
@@ -288,12 +316,14 @@ function ReactionChip({
 
 function ReactionOverlayContent({
   overlay,
+  reactionGroups,
   selectedCodes,
   currentMemberId,
   onSelect,
   onDelete,
 }: {
   overlay: Exclude<ReactionOverlayState, null>;
+  reactionGroups: ReactionGroup[];
   selectedCodes: Set<RetrospectReactionCode>;
   currentMemberId: number;
   onSelect: (code: RetrospectReactionCode) => void;
@@ -303,7 +333,13 @@ function ReactionOverlayContent({
     return <ReactionSelector onSelect={onSelect} selectedCodes={selectedCodes} />;
   }
 
-  return <ReactionStatus groups={overlay.groups} currentMemberId={currentMemberId} onDelete={onDelete} />;
+  return (
+    <ReactionStatus
+      groups={getStatusGroups(overlay.codes, reactionGroups)}
+      currentMemberId={currentMemberId}
+      onDelete={onDelete}
+    />
+  );
 }
 
 function ReactionSelector({

--- a/apps/web/src/component/retrospect/analysis/useReactionOverlay.ts
+++ b/apps/web/src/component/retrospect/analysis/useReactionOverlay.ts
@@ -3,7 +3,7 @@ import { usePopper } from "react-popper";
 
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import useClickOutside from "@/hooks/useClickOutside";
-import { RetrospectReaction } from "@/types/retrospectReaction";
+import { RetrospectReaction, RetrospectReactionCode } from "@/types/retrospectReaction";
 
 export type ReactionGroup = {
   code: RetrospectReaction["emojiCode"];
@@ -12,12 +12,16 @@ export type ReactionGroup = {
 
 export type ReactionOverlayState =
   | { type: "selector" }
-  | { type: "status"; groups: ReactionGroup[] }
+  | { type: "status"; codes: RetrospectReactionCode[]; keepOpenOnDelete?: boolean }
   | null;
 
 type UseReactionOverlayParams = {
   answerId: number;
   isMobile: boolean;
+};
+
+type OpenStatusOptions = {
+  keepOpenOnDelete?: boolean;
 };
 
 export const useReactionOverlay = ({ answerId, isMobile }: UseReactionOverlayParams) => {
@@ -88,14 +92,14 @@ export const useReactionOverlay = ({ answerId, isMobile }: UseReactionOverlayPar
     };
   }, []);
 
-  const openStatus = (event: MouseEvent<HTMLElement>, groups: ReactionGroup[]) => {
+  const openStatus = (event: MouseEvent<HTMLElement>, codes: RetrospectReactionCode[], options?: OpenStatusOptions) => {
     clearCloseTimer();
     if (isMobile) {
       openBottomSheet({ id: sheetId });
     } else {
       setReferenceElement(event.currentTarget);
     }
-    setOverlay({ type: "status", groups });
+    setOverlay({ type: "status", codes, keepOpenOnDelete: options?.keepOpenOnDelete });
   };
 
   const openSelector = (event: MouseEvent<HTMLButtonElement>) => {

--- a/apps/web/src/hooks/api/retrospect/reaction/reactionCache.ts
+++ b/apps/web/src/hooks/api/retrospect/reaction/reactionCache.ts
@@ -52,7 +52,7 @@ export const addRetrospectReactionCache = (
     return {
       answerReactions: hasAnswer
         ? answerReactions.map((item) =>
-            item.answerId === answerId ? { ...item, reactions: [...item.reactions, reaction] } : item,
+            item.answerId === answerId ? { ...item, reactions: [reaction, ...item.reactions] } : item,
           )
         : [...answerReactions, { answerId, reactions: [reaction] }],
     };


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 옵티미스틱 반응을 포함한 모든 반응이 최신순으로 정렬되도록 로직을 개선했습니다.
- 반응 오버레이 상태 관리 방식을 개선하여 유연성을 높였습니다.
- '더보기' 반응 오버레이에서 반응 삭제 후에도 오버레이가 유지되도록 기능을 추가했습니다.

### 🫨 Describe your Change (변경사항)

- `compareRecentReactionFirst` 함수를 추가하여 옵티미스틱 반응 및 최신순 정렬 우선순위를 정의했습니다.
- `getReactionGroups` 로직을 최신순 정렬 및 효율적인 그룹화 방식으로 리팩토링했습니다.
- 반응 오버레이의 상태를 `ReactionGroup[]` 대신 `RetrospectReactionCode[]`로 관리하도록 변경하여 유연성을 확보했습니다.
- `addRetrospectReactionCache`에서 새로운 반응을 캐시에 추가할 때 최신순으로 앞에 추가되도록 수정했습니다.
- '더보기' 오버레이에서 반응 삭제 시 오버레이가 닫히지 않도록 `keepOpenOnDelete` 옵션을 추가했습니다.

### 🧐 Issue number and link (참고)

closes: #942

### 📚 Reference (참조)

-