### PR TITLE
모바일 홈 목표 탭 '팀/개인' 목표 조회 기능 구현

### DIFF
--- a/apps/web/src/app/mobile/home/GoalViewPage.tsx
+++ b/apps/web/src/app/mobile/home/GoalViewPage.tsx
@@ -15,19 +15,35 @@ import { useGetActionItemList } from "@/hooks/api/actionItem/useGetActionItemLis
 import { useTabs } from "@/hooks/useTabs.ts";
 import { DefaultLayout } from "@/layout/DefaultLayout.tsx";
 import { formatOnlyDate } from "@/utils/date";
+import { useGetPersonalActionItemList } from "@/hooks/api/actionItem/useGetPersonalActionItemList";
 
 export function GoalViewPage() {
-  const { tabs, curTab, selectTab } = useTabs(["실행중", "지난"] as const);
+  const { tabs, curTab, selectTab } = useTabs(["팀", "개인"] as const);
   const memberId = Cookies.get(COOKIE_KEYS.memberId);
-  const { data, isLoading } = useGetActionItemList({ memberId: Number(memberId) });
-  const filteredItems = data?.actionItems?.filter(
-    (item) => (curTab === tabs[0] && item.status === status[0]) || (curTab === tabs[1] && item.status === status[1]),
-  );
-  const hasNonEmptyActionItems = filteredItems?.some((item) => item.actionItemList && item.actionItemList.length > 0);
+
+  const isTeamTab = curTab === "팀";
+  const isPersonalTab = curTab === "개인";
+
+  // 개인 목표
+  const { data: personalGoal, isLoading: isLoadingPersonalGoal } = useGetPersonalActionItemList({
+    options: { enabled: !!memberId && isPersonalTab, select: (data) => data.actionItems },
+  });
+  // 팀 목표
+  const { data: teamGoal, isLoading: isLoadingTeamGoal } = useGetActionItemList({
+    memberId: Number(memberId),
+    options: { enabled: !!memberId && isTeamTab, select: (data) => data.actionItems },
+  });
+
+  const filteredItem = (() => {
+    if (isPersonalTab) return { data: personalGoal ?? [], loading: isLoadingPersonalGoal };
+    return { data: teamGoal ?? [], loading: isLoadingTeamGoal };
+  })();
+
+  const hasNonEmptyActionItems = filteredItem?.data?.length > 0;
 
   return (
     <Fragment>
-      {isLoading && <LoadingModal />}
+      {filteredItem.loading && <LoadingModal />}
       <DefaultLayout
         theme="gray"
         height="6.4rem"
@@ -51,7 +67,7 @@ export function GoalViewPage() {
           `}
         >
           {hasNonEmptyActionItems
-            ? filteredItems?.map((item) =>
+            ? filteredItem?.data?.map((item) =>
                 item.actionItemList.length ? (
                   <ActionItemBox
                     key={item.retrospectId}
@@ -66,7 +82,7 @@ export function GoalViewPage() {
                   />
                 ) : null,
               )
-            : !isLoading && <NotActionItemBoxData />}
+            : !filteredItem?.loading && <NotActionItemBoxData />}
         </div>
       </DefaultLayout>
     </Fragment>

--- a/apps/web/src/hooks/api/actionItem/useGetPersonalActionItemList.ts
+++ b/apps/web/src/hooks/api/actionItem/useGetPersonalActionItemList.ts
@@ -14,7 +14,7 @@ export const useGetPersonalActionItemList = <TData = PersonalActionItemListType>
   options,
 }: {
   options?: Omit<UseQueryOptions<PersonalActionItemListType, Error, TData>, "queryKey" | "queryFn">;
-}) => {
+} = {}) => {
   const getPersonalActionItemList = () => {
     const res = api.get<PersonalActionItemListType>("/api/action-item/personal/member").then((res) => res.data);
     return res;


### PR DESCRIPTION
### 🏄🏼‍♂️‍ Summary (요약)

- 모바일 홈 화면에 '팀' 및 '개인' 목표 탭을 추가하여 목표 유형별 조회를 지원합니다.
- 선택된 탭에 따라 팀 또는 개인 목표 데이터를 동적으로 불러오도록 로직을 개선했습니다.
- 목표 데이터 유무 및 로딩 상태에 따른 UI 처리를 업데이트했습니다.

### 🫨 Describe your Change (변경사항)

- GoalViewPage.tsx의 탭 구성을 '실행중', '지난'에서 '팀', '개인'으로 변경했습니다.
- useGetPersonalActionItemList 훅을 도입하여 개인 목표 데이터를 관리합니다.
- 팀/개인 탭 활성화 여부에 따라 해당 목표 데이터를 조건부로 fetch하도록 수정했습니다.
- 목표 데이터 렌더링 로직을 현재 탭에 맞춰 동적으로 처리하도록 변경했습니다.
- useGetPersonalActionItemList 훅의 options 파라미터에 기본값을 추가하여 사용성을 높였습니다.

### 🧐 Issue number and link (참고)

closes: #965

### 📚 Reference (참조)

-